### PR TITLE
tls: use real certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out/
 var/
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-stream",
+ "async-trait",
  "boring",
  "bytes",
  "console-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tokio-boring = { version = "2.1.5", features = ['fips'] }
 hyper-boring = { version= "2.1.2", features = ['fips'] }
 anyhow = "1.0.65"
 serde_yaml = "0.9.13"
+async-trait = "0.1.58"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -16,5 +16,9 @@ format:
 	cargo clippy --fix --allow-staged --allow-dirty
 	cargo fmt
 
+gen: format
+
+gen-check: gen check-clean-repo
+
 presubmit: export RUSTFLAGS = -D warnings
 presubmit: build test format gen-check

--- a/examples/localhost.yaml
+++ b/examples/localhost.yaml
@@ -2,5 +2,6 @@
 # This allows local testing by sending requests through the local ztunnel to other servers running on localhost.
 - name: local
   namespace: default
+  service_account: default
   workload_ip: "127.0.0.1"
   protocol: Hbone

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
+use crate::identity;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Config {
     pub tls: bool,
 
@@ -17,6 +19,8 @@ pub struct Config {
 
     /// Filepath to a local xds file for workloads, as YAML.
     pub local_xds_path: Option<String>,
+
+    pub auth: identity::AuthSource,
 }
 
 impl Default for Config {
@@ -36,6 +40,10 @@ impl Default for Config {
 
             local_xds_path: Some(std::env::var("LOCAL_XDS_PATH").unwrap_or_else(|_| "".into()))
                 .filter(|s| !s.is_empty()),
+
+            auth: identity::AuthSource::Token(PathBuf::from(
+                r"./var/run/secrets/tokens/istio-token",
+            )),
         }
     }
 }

--- a/src/identity/auth.rs
+++ b/src/identity/auth.rs
@@ -5,6 +5,7 @@ use tonic::metadata::AsciiMetadataValue;
 use tonic::service::Interceptor;
 use tonic::{Code, Request, Status};
 
+#[derive(Clone, Debug)]
 pub enum AuthSource {
     Token(PathBuf),
 }

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -1,6 +1,7 @@
-use crate::identity::caclient::CaClient;
 use std::fmt;
 
+use super::CaClient;
+use super::Error;
 use crate::tls;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -27,15 +28,18 @@ impl fmt::Display for Identity {
     }
 }
 
+#[derive(Clone)]
 pub struct SecretManager {
     client: CaClient,
 }
 
 impl SecretManager {
-    pub fn new() -> SecretManager {
-        todo!()
+    pub fn new(cfg: crate::config::Config) -> SecretManager {
+        let client = CaClient::new(cfg.auth);
+        SecretManager { client }
     }
-    pub fn fetch_certificate(_id: Identity) -> tls::Certs {
-        todo!()
+
+    pub async fn fetch_certificate(&self, id: Identity) -> Result<tls::Certs, Error> {
+        self.client.clone().fetch_certificate(id).await
     }
 }

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use tracing::instrument;
 
 use super::CaClient;
 use super::Error;
@@ -39,6 +40,7 @@ impl SecretManager {
         SecretManager { client }
     }
 
+    #[instrument(skip_all, fields(%id))]
     pub async fn fetch_certificate(&self, id: Identity) -> Result<tls::Certs, Error> {
         self.client.clone().fetch_certificate(id).await
     }

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -12,7 +12,9 @@ pub use auth::*;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("failed to create CSR: {0}")]
-    SigningError(#[from] tls::Error),
+    Signing(#[from] tls::Error),
+    #[error("signing gRPC error ({}): {}", .0.code(), .0.message())]
+    SigningRequest(#[from] tonic::Status),
     #[error("failed to process string: {0}")]
-    Utf8Error(#[from] Utf8Error),
+    Utf8(#[from] Utf8Error),
 }

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -51,7 +51,7 @@ impl Inbound {
                 Ok::<_, hyper::Error>(service_fn(Self::serve_connect))
             });
             let boring_acceptor = crate::tls::BoringTlsAcceptor {
-                acceptor: CertProvider {
+                acceptor: InboundCertProvider {
                     workloads: self.workloads.clone(),
                     cert_manager: self.cert_manager.clone(),
                 },
@@ -147,13 +147,13 @@ impl Inbound {
 }
 
 #[derive(Clone)]
-struct CertProvider {
+struct InboundCertProvider {
     cert_manager: identity::SecretManager,
     workloads: Arc<Mutex<WorkloadInformation>>,
 }
 
 #[async_trait::async_trait]
-impl crate::tls::CertProvider for CertProvider {
+impl crate::tls::CertProvider for InboundCertProvider {
     async fn fetch_cert(&self, fd: RawFd) -> Result<boring::ssl::SslAcceptor, TlsError> {
         let orig = crate::socket::orig_dst_addr_fd(fd).map_err(TlsError::DestinationLookup)?;
         let identity = {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -1,4 +1,6 @@
 use std::net::SocketAddr;
+use std::os::unix::io::RawFd;
+use std::sync::{Arc, Mutex};
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
@@ -7,16 +9,25 @@ use tokio_stream::StreamExt;
 use tracing::{error, info, warn};
 
 use crate::config::Config;
+use crate::identity;
+use crate::tls::TlsError;
+use crate::workload::WorkloadInformation;
 
 use super::Error;
 
 pub struct Inbound {
     cfg: Config,
     listener: TcpListener,
+    cert_manager: identity::SecretManager,
+    workloads: Arc<Mutex<WorkloadInformation>>,
 }
 
 impl Inbound {
-    pub async fn new(cfg: Config) -> Result<Inbound, Error> {
+    pub async fn new(
+        cfg: Config,
+        workloads: Arc<Mutex<WorkloadInformation>>,
+        cert_manager: identity::SecretManager,
+    ) -> Result<Inbound, Error> {
         let listener: TcpListener = TcpListener::bind(cfg.inbound_addr)
             .await
             .map_err(Error::Bind)?;
@@ -24,8 +35,14 @@ impl Inbound {
             Err(_e) => info!("running without transparent mode"),
             _ => info!("running with transparent mode"),
         };
-        Ok(Inbound { cfg, listener })
+        Ok(Inbound {
+            cfg,
+            workloads,
+            listener,
+            cert_manager,
+        })
     }
+
     pub(super) async fn run(self) {
         let addr = self.listener.local_addr().unwrap();
         if self.cfg.tls {
@@ -33,9 +50,14 @@ impl Inbound {
             let service = make_service_fn(|_| async {
                 Ok::<_, hyper::Error>(service_fn(Self::serve_connect))
             });
-            let acc = crate::tls::test_certs().acceptor().unwrap();
+            let boring_acceptor = crate::tls::BoringTlsAcceptor {
+                acceptor: CertProvider {
+                    workloads: self.workloads.clone(),
+                    cert_manager: self.cert_manager.clone(),
+                },
+            };
             let incoming = hyper::server::accept::from_stream(
-                tls_listener::builder(crate::tls::BoringTlsAcceptor(acc))
+                tls_listener::builder(boring_acceptor)
                     .listen(
                         hyper::server::conn::AddrIncoming::from_listener(self.listener)
                             .expect("hbone bind"),
@@ -43,10 +65,10 @@ impl Inbound {
                     .filter(|conn| {
                         // Avoid 'By default, if a client fails the TLS handshake, that is treated as an error, and the TlsListener will return an Err'
                         if let Err(err) = conn {
-                            warn!("TLS handshake error: {:?}", err);
+                            warn!("TLS handshake error: {}", err);
                             false
                         } else {
-                            info!("TLS handshake succeeded: {:?}", conn);
+                            info!("TLS handshake succeeded");
                             true
                         }
                     }),
@@ -121,5 +143,31 @@ impl Inbound {
                 Ok(not_found)
             }
         }
+    }
+}
+
+#[derive(Clone)]
+struct CertProvider {
+    cert_manager: identity::SecretManager,
+    workloads: Arc<Mutex<WorkloadInformation>>,
+}
+
+#[async_trait::async_trait]
+impl crate::tls::CertProvider for CertProvider {
+    async fn fetch_cert(&self, fd: RawFd) -> Result<boring::ssl::SslAcceptor, TlsError> {
+        let orig = crate::socket::orig_dst_addr_fd(fd).map_err(TlsError::DestinationLookup)?;
+        let identity = {
+            let remote_addr = super::to_canonical_ip(orig);
+            self.workloads
+                .lock()
+                .unwrap()
+                .find_workload(&remote_addr)
+                .ok_or(TlsError::CertificateLookup(remote_addr))?
+                .identity()
+        };
+        info!("tls: accepting connection to {:?} ({})", orig, identity);
+        let cert = self.cert_manager.fetch_certificate(identity).await?;
+        let acc = cert.acceptor()?;
+        Ok(acc)
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,3 +1,4 @@
+use boring::error::ErrorStack;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
@@ -9,7 +10,7 @@ use inbound::Inbound;
 use crate::proxy::inbound_passthrough::InboundPassthrough;
 use crate::proxy::outbound::Outbound;
 use crate::workload::WorkloadInformation;
-use crate::{config, identity};
+use crate::{config, identity, tls};
 
 mod inbound;
 mod inbound_passthrough;
@@ -29,8 +30,8 @@ impl Proxy {
     ) -> Result<Proxy, Error> {
         // We setup all the listeners first so we can capture any errors that should block startup
         let inbound_passthrough = InboundPassthrough::new(cfg.clone());
-        let inbound = Inbound::new(cfg.clone(), workloads.clone(), secret_manager).await?;
-        let outbound = Outbound::new(cfg.clone(), workloads).await?;
+        let inbound = Inbound::new(cfg.clone(), workloads.clone(), secret_manager.clone()).await?;
+        let outbound = Outbound::new(cfg.clone(), secret_manager, workloads).await?;
         Ok(Proxy {
             inbound,
             inbound_passthrough,
@@ -65,6 +66,15 @@ pub enum Error {
 
     #[error("http failed: {0}")]
     Http(#[from] hyper::Error),
+
+    #[error("tls error: {0}")]
+    Tls(#[from] tls::Error),
+
+    #[error("ssl error: {0}")]
+    Ssl(#[from] ErrorStack),
+
+    #[error("identity error: {0}")]
+    Identity(#[from] identity::Error),
 }
 
 pub async fn copy_hbone(

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -1,3 +1,4 @@
+use boring::ssl::ConnectConfiguration;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
 
@@ -8,10 +9,11 @@ use tracing::{debug, error, info, warn};
 use crate::config::Config;
 use crate::proxy::Error;
 use crate::workload::{Protocol, Workload, WorkloadInformation};
-use crate::{socket, tls};
+use crate::{identity, socket};
 
 pub struct Outbound {
     cfg: Config,
+    cert_manager: identity::SecretManager,
     workloads: Arc<Mutex<WorkloadInformation>>,
     listener: TcpListener,
 }
@@ -19,6 +21,7 @@ pub struct Outbound {
 impl Outbound {
     pub async fn new(
         cfg: Config,
+        cert_manager: identity::SecretManager,
         workloads: Arc<Mutex<WorkloadInformation>>,
     ) -> Result<Outbound, Error> {
         let listener: TcpListener = TcpListener::bind(cfg.outbound_addr)
@@ -31,6 +34,7 @@ impl Outbound {
 
         Ok(Outbound {
             cfg,
+            cert_manager,
             workloads,
             listener,
         })
@@ -48,6 +52,7 @@ impl Outbound {
                     info!("accepted outbound connection from {}", remote);
                     let cfg = self.cfg.clone();
                     let oc = OutboundConnection {
+                        cert_manager: self.cert_manager.clone(),
                         workloads: self.workloads.clone(),
                         cfg,
                     };
@@ -66,6 +71,7 @@ impl Outbound {
 }
 
 struct OutboundConnection {
+    cert_manager: identity::SecretManager,
     workloads: Arc<Mutex<WorkloadInformation>>,
     // TODO: Config may be excessively large, maybe we store a scoped OutboundConfig intended for cloning.
     cfg: Config,
@@ -103,8 +109,11 @@ impl OutboundConnection {
                     .unwrap();
 
                 let mut request_sender = if self.cfg.tls {
+                    let id = req.source.identity();
+                    let cert = self.cert_manager.fetch_certificate(id).await?;
+                    let connector = cert.connector()?.configure()?;
                     let tcp_stream = TcpStream::connect(req.gateway).await?;
-                    let tls_stream = connect_tls(tcp_stream).await?;
+                    let tls_stream = connect_tls(connector, tcp_stream).await?;
                     let (request_sender, connection) = builder
                         .handshake(tls_stream)
                         .await
@@ -184,7 +193,7 @@ impl OutboundConnection {
         };
         let mut req = Request {
             protocol: us.workload.protocol,
-            _source: source_workload.clone(), // TODO drop clone
+            source: source_workload.clone(), // TODO drop clone
             destination: SocketAddr::from((us.workload.workload_ip, us.port)),
             gateway: us
                 .workload
@@ -241,7 +250,7 @@ impl OutboundConnection {
 struct Request {
     protocol: Protocol,
     direction: Direction,
-    _source: Workload,
+    source: Workload,
     destination: SocketAddr,
     gateway: SocketAddr,
     request_type: RequestType,
@@ -263,16 +272,15 @@ enum RequestType {
 }
 
 async fn connect_tls(
+    mut connector: ConnectConfiguration,
     stream: TcpStream,
 ) -> Result<tokio_boring::SslStream<TcpStream>, tokio_boring::HandshakeError<TcpStream>> {
-    let conn = tls::test_certs().connector();
-    let mut cfg = conn.unwrap().configure().unwrap();
-    cfg.set_verify_hostname(false);
-    cfg.set_use_server_name_indication(false);
+    connector.set_verify_hostname(false);
+    connector.set_use_server_name_indication(false);
     let addr = stream.local_addr();
-    cfg.set_verify_callback(boring::ssl::SslVerifyMode::PEER, move |_, x509| {
+    connector.set_verify_callback(boring::ssl::SslVerifyMode::PEER, move |_, x509| {
         info!("TLS callback for {:?}: {:?}", addr, x509.error());
         true
     });
-    tokio_boring::connect(cfg, "", stream).await
+    tokio_boring::connect(connector, "", stream).await
 }

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -242,15 +242,6 @@ where
     }
 }
 
-const CERT: &[u8] = include_bytes!("cert.crt");
-const PKEY: &[u8] = include_bytes!("cert.key");
-
-pub fn test_certs() -> Certs {
-    let cert = x509::X509::from_pem(CERT).unwrap();
-    let key = pkey::PKey::private_key_from_pem(PKEY).unwrap();
-    Certs { cert, key }
-}
-
 #[test]
 fn is_fips_enabled() {
     assert!(boring::fips::enabled());

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -1,5 +1,8 @@
 use core::fmt;
 use std::future::Future;
+use std::io;
+use std::net::IpAddr;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::pin::Pin;
 use std::task::Poll;
 
@@ -17,7 +20,9 @@ use hyper::{Request, Uri};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tonic::body::BoxBody;
 use tower::Service;
-use tracing::info;
+use tracing::{error, info};
+
+use crate::identity;
 
 use super::Error;
 
@@ -77,42 +82,39 @@ pub struct TlsGrpcChannel {
     client: hyper::Client<hyper_boring::HttpsConnector<hyper::client::HttpConnector>, BoxBody>,
 }
 
+/// grpc_connector provides a client TLS channel for gRPC requests.
+pub fn grpc_connector(uri: &'static str) -> Result<TlsGrpcChannel, Error> {
+    let mut conn = ssl::SslConnector::builder(ssl::SslMethod::tls_client())?;
+
+    conn.set_verify(ssl::SslVerifyMode::NONE);
+    conn.set_verify_callback(ssl::SslVerifyMode::NONE, |_, x509| {
+        info!("ssl: {:?}", x509.error());
+        // TODO: this MUST verify before upstreaming
+        true
+    });
+
+    conn.set_alpn_protos(Alpn::H2.encode())?;
+    conn.set_min_proto_version(Some(ssl::SslVersion::TLS1_2))?;
+    conn.set_max_proto_version(Some(ssl::SslVersion::TLS1_3))?;
+    let mut http = hyper::client::HttpConnector::new();
+    http.enforce_http(false);
+    let mut https = hyper_boring::HttpsConnector::with_connector(http, conn)?;
+    https.set_callback(|cc, _| {
+        // TODO: this MUST verify before upstreaming
+        cc.set_verify_hostname(false);
+        Ok(())
+    });
+
+    // Configure hyper's client to be h2 only and build with the
+    // correct https connector.
+    let hyper = hyper::Client::builder().http2_only(true).build(https);
+
+    let uri = Uri::from_static(uri);
+
+    Ok(TlsGrpcChannel { uri, client: hyper })
+}
+
 impl Certs {
-    pub fn grpc_connector(&self, uri: &'static str) -> Result<TlsGrpcChannel, Error> {
-        let mut conn = ssl::SslConnector::builder(ssl::SslMethod::tls_client())?;
-
-        // conn.set_private_key(&self.key)?;
-        // conn.set_certificate(&self.cert)?;
-        // conn.check_private_key()?;
-
-        conn.set_verify(ssl::SslVerifyMode::NONE);
-        conn.set_verify_callback(ssl::SslVerifyMode::NONE, |_, x509| {
-            info!("ssl: {:?}", x509.error());
-            // TODO: this MUST verify before upstreaming
-            true
-        });
-
-        conn.set_alpn_protos(Alpn::H2.encode())?;
-        conn.set_min_proto_version(Some(ssl::SslVersion::TLS1_2))?;
-        conn.set_max_proto_version(Some(ssl::SslVersion::TLS1_3))?;
-        let mut http = hyper::client::HttpConnector::new();
-        http.enforce_http(false);
-        let mut https = hyper_boring::HttpsConnector::with_connector(http, conn)?;
-        https.set_callback(|cc, _| {
-            // TODO: this MUST verify before upstreaming
-            cc.set_verify_hostname(false);
-            Ok(())
-        });
-
-        // Configure hyper's client to be h2 only and build with the
-        // correct https connector.
-        let hyper = hyper::Client::builder().http2_only(true).build(https);
-
-        let uri = Uri::from_static(uri);
-
-        Ok(TlsGrpcChannel { uri, client: hyper })
-    }
-
     pub fn acceptor(&self) -> Result<ssl::SslAcceptor, Error> {
         let _ctx = ssl::SslContext::builder(ssl::SslMethod::tls_server())?;
         // mozilla_intermediate_v5 is the only variant that enables TLSv1.3, so we use that.
@@ -193,20 +195,50 @@ impl Alpn {
     }
 }
 
-#[derive(Clone)]
-pub struct BoringTlsAcceptor(pub ssl::SslAcceptor);
+#[async_trait::async_trait]
+pub trait CertProvider: Send + Sync + Clone {
+    async fn fetch_cert(&self, fd: RawFd) -> Result<ssl::SslAcceptor, TlsError>;
+}
 
-impl<C> tls_listener::AsyncTls<C> for BoringTlsAcceptor
+#[derive(Clone)]
+pub struct BoringTlsAcceptor<F: CertProvider> {
+    /// Acceptor is a function that determines the TLS context to use. As input, the FD of the client
+    /// connection is provided.
+    pub acceptor: F,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum TlsError {
+    #[error("tls handshake error")]
+    Handshake,
+    #[error("certificate lookup error: {0} is not a known destination")]
+    CertificateLookup(IpAddr),
+    #[error("destination lookup error")]
+    DestinationLookup(#[source] io::Error),
+    #[error("signing error: {0}")]
+    SigningError(#[from] identity::Error),
+    #[error("ssl error: {0}")]
+    SslError(#[from] Error),
+}
+
+impl<C, F> tls_listener::AsyncTls<C> for BoringTlsAcceptor<F>
 where
-    C: AsyncRead + AsyncWrite + Unpin + Send + fmt::Debug + 'static,
+    C: AsRawFd + AsyncRead + AsyncWrite + Unpin + Send + fmt::Debug + 'static,
+    F: CertProvider + 'static,
 {
     type Stream = tokio_boring::SslStream<C>;
-    type Error = tokio_boring::HandshakeError<C>;
+    type Error = TlsError;
     type AcceptFuture = Pin<Box<dyn Future<Output = Result<Self::Stream, Self::Error>> + Send>>;
 
     fn accept(&self, conn: C) -> Self::AcceptFuture {
-        let tls = self.0.clone();
-        Box::pin(async move { tokio_boring::accept(&tls, conn).await })
+        let fd = conn.as_raw_fd();
+        let acceptor = self.acceptor.clone();
+        Box::pin(async move {
+            let tls = acceptor.fetch_cert(fd).await?;
+            tokio_boring::accept(&tls, conn)
+                .await
+                .map_err(|_| TlsError::Handshake)
+        })
     }
 }
 

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -149,7 +149,7 @@ impl AdsClient {
         } else {
             "http://localhost:15010"
         };
-        let svc = tls::test_certs().grpc_connector(address).unwrap();
+        let svc = tls::grpc_connector(address).unwrap();
         let mut client = AggregatedDiscoveryServiceClient::new(svc);
         let (discovery_req_tx, mut discovery_req_rx) =
             tokio::sync::mpsc::channel::<DeltaDiscoveryRequest>(100);


### PR DESCRIPTION
This drops the test-certs for real certs.

WARNING: this tanks performance since every connection generates a cert
on the fly. https://github.com/istio/ztunnel/issues/11 will fix this and
Brian is working on this right now.

Note: certs are still not verified since we don't properly get the root
cert, etc.