### PR TITLE
Audit clone usages

### DIFF
--- a/src/workload.rs
+++ b/src/workload.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
+use std::convert::Into;
 use std::net::{IpAddr, SocketAddr};
-use std::str::FromStr;
+use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::{fmt, net};
 
@@ -81,68 +82,6 @@ impl Workload {
     }
 }
 
-pub struct WorkloadBuilder {
-    gateway_ip: Option<SocketAddr>,
-    name: String,
-    namespace: String,
-    native_hbone: bool,
-    node: String,
-    protocol: Protocol,
-    service_account: String,
-    waypoint_address: Option<IpAddr>,
-    workload_ip: IpAddr,
-}
-
-impl WorkloadBuilder {
-    pub fn new(
-        name: String,
-        namespace: String,
-        native_hbone: bool,
-        node: String,
-        protocol: Protocol,
-        service_account: String,
-        workload_ip: IpAddr,
-    ) -> WorkloadBuilder {
-        WorkloadBuilder {
-            gateway_ip: None,
-            name,
-            namespace,
-            native_hbone,
-            node,
-            protocol,
-            service_account,
-            waypoint_address: None,
-            workload_ip,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn gateway_ip(mut self, gateway_ip: Option<SocketAddr>) -> WorkloadBuilder {
-        self.gateway_ip = gateway_ip;
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn waypoint_address(mut self, waypoint_address: Option<IpAddr>) -> WorkloadBuilder {
-        self.waypoint_address = waypoint_address;
-        self
-    }
-
-    pub fn build(self) -> Workload {
-        Workload {
-            gateway_ip: self.gateway_ip,
-            name: self.name,
-            namespace: self.namespace,
-            native_hbone: self.native_hbone,
-            node: self.node,
-            protocol: self.protocol,
-            service_account: self.service_account,
-            waypoint_address: self.waypoint_address,
-            workload_ip: self.workload_ip,
-        }
-    }
-}
-
 impl fmt::Display for Workload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -182,39 +121,48 @@ impl fmt::Display for Upstream {
 }
 
 fn byte_to_ip(b: &bytes::Bytes) -> Result<Option<IpAddr>, WorkloadError> {
-    let s = std::str::from_utf8(b).expect("error converting bytes to string");
-    if s.is_empty() {
-        return Ok(None);
-    }
-    match IpAddr::from_str(s) {
-        Ok(ip) => Ok(Some(ip)),
-        Err(_) => Err(WorkloadError::ByteAddressParse(s.len())),
-    }
+    Ok(match b.len() {
+        0 => None,
+        4 => {
+            let v: [u8; 4] = b.deref().try_into().expect("size already proven");
+            Some(IpAddr::from(v))
+        }
+        16 => {
+            let v: [u8; 16] = b.deref().try_into().expect("size already proven");
+            Some(IpAddr::from(v))
+        }
+        n => {
+            println!("invalid ip address length: {n}");
+            return Err(WorkloadError::ByteAddressParse(n));
+        }
+    })
 }
+
+const DEFAULT_SERVICE_ACCOUNT: &str = "default";
 
 impl TryFrom<&XdsWorkload> for Workload {
     type Error = WorkloadError;
     fn try_from(resource: &XdsWorkload) -> Result<Self, Self::Error> {
-        let resource = resource.to_owned();
-        let workload_ip =
-            byte_to_ip(&resource.address)?.ok_or(WorkloadError::ByteAddressParse(0))?;
-        let waypoint_ip = byte_to_ip(&resource.waypoint_address)?;
-        let protocol =
-            Protocol::try_from(xds::istio::workload::Protocol::from_i32(resource.protocol))?;
-        let service_account =
-            Option::from(resource.service_account).unwrap_or_else(|| String::from("default"));
-        let workload = WorkloadBuilder::new(
-            resource.name,
-            resource.namespace,
-            resource.native_hbone,
-            resource.node,
-            protocol,
-            service_account,
-            workload_ip,
-        )
-        .waypoint_address(waypoint_ip)
-        .build();
-        Ok(workload)
+        let resource: XdsWorkload = resource.to_owned();
+        let waypoint = byte_to_ip(&resource.waypoint_address)?;
+        let address = byte_to_ip(&resource.address)?.ok_or(WorkloadError::ByteAddressParse(0))?;
+        Ok(Workload {
+            workload_ip: address,
+            waypoint_address: waypoint,
+            gateway_ip: None,
+
+            protocol: Protocol::try_from(xds::istio::workload::Protocol::from_i32(
+                resource.protocol,
+            ))?,
+
+            name: resource.name,
+            namespace: resource.namespace,
+            service_account: Option::from(resource.service_account)
+                .unwrap_or_else(|| DEFAULT_SERVICE_ACCOUNT.into()),
+            node: resource.node,
+
+            native_hbone: resource.native_hbone,
+        })
     }
 }
 
@@ -425,13 +373,15 @@ pub enum WorkloadError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bytes::Bytes;
+
+    use super::*;
 
     #[test]
     fn byte_to_ipaddr_garbage() {
-        let garbage = "foo";
-        let result = byte_to_ip(&Bytes::from(garbage));
+        let garbage = "not_an_ip";
+        let bytes = Bytes::from(garbage);
+        let result = byte_to_ip(&bytes);
         assert!(result.is_err());
         let actual_error: WorkloadError = result.unwrap_err();
         let expected_error = WorkloadError::ByteAddressParse(garbage.len());
@@ -441,7 +391,8 @@ mod tests {
     #[test]
     fn byte_to_ipaddr_empty() {
         let empty = "";
-        let result = byte_to_ip(&Bytes::from(empty));
+        let bytes = Bytes::from(empty);
+        let result = byte_to_ip(&bytes);
         assert!(result.is_ok());
         let maybe_ip_addr = result.unwrap();
         assert!(maybe_ip_addr.is_none());
@@ -449,8 +400,9 @@ mod tests {
 
     #[test]
     fn byte_to_ipaddr_unspecified() {
-        let unspecified = "0.0.0.0";
-        let result = byte_to_ip(&Bytes::from(unspecified));
+        let unspecified: Vec<u8> = vec![0, 0, 0, 0];
+        let bytes = Bytes::from(unspecified);
+        let result = byte_to_ip(&bytes);
         assert!(result.is_ok());
         let maybe_ip_addr = result.unwrap();
         assert!(maybe_ip_addr.is_some());
@@ -460,65 +412,54 @@ mod tests {
 
     #[test]
     fn byte_to_ipaddr_v4_loopback() {
-        let loopback = "127.0.0.1";
-        let result = byte_to_ip(&Bytes::from(loopback));
+        let loopback: Vec<u8> = vec![127, 0, 0, 1];
+        let bytes = Bytes::from(loopback);
+        let result = byte_to_ip(&bytes);
         assert!(result.is_ok());
         let maybe_loopback_ip = result.unwrap();
         assert!(maybe_loopback_ip.is_some());
-        assert_eq!(maybe_loopback_ip.unwrap().to_string(), loopback);
+        assert_eq!(maybe_loopback_ip.unwrap().to_string(), "127.0.0.1");
     }
 
     #[test]
-    fn byte_to_ipaddr_v4_localhost() {
-        let localhost = "localhost";
-        let result = byte_to_ip(&Bytes::from(localhost));
-        assert!(result.is_err());
-        let actual_error: WorkloadError = result.unwrap_err();
-        let expected_error = WorkloadError::ByteAddressParse(localhost.len());
-        assert_eq!(actual_error, expected_error);
-    }
-
-    #[test]
-    fn byte_to_ipaddr_v4() {
-        let ipv4 = "1.1.1.1";
-        let result = byte_to_ip(&Bytes::from(ipv4));
+    fn byte_to_ipaddr_v4_happy() {
+        let addr_vec: Vec<u8> = Vec::from([1, 1, 1, 1]);
+        let bytes = &Bytes::from(addr_vec);
+        let result = byte_to_ip(bytes);
         assert!(result.is_ok());
         let maybe_ip_addr = result.unwrap();
+        assert!(maybe_ip_addr.is_some());
         let ip_addr = maybe_ip_addr.unwrap();
         assert!(ip_addr.is_ipv4(), "was not ipv4");
         assert!(!ip_addr.is_ipv6(), "was ipv6");
         assert!(!ip_addr.is_unspecified(), "was unspecified");
-        assert_eq!(ip_addr.to_string(), ipv4, "to_string mismatch");
+        assert_eq!(ip_addr.to_string(), "1.1.1.1");
     }
 
     #[test]
-    fn byte_to_ipaddr_v6() {
-        let ipv6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
-        let result = byte_to_ip(&Bytes::from(ipv6));
+    fn byte_to_ipaddr_v6_happy() {
+        let addr: Vec<u8> = Vec::from([
+            32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52,
+        ]);
+        let bytes = &Bytes::from(addr);
+        let result = byte_to_ip(bytes);
         assert!(result.is_ok());
         let maybe_ip_addr = result.unwrap();
         assert!(maybe_ip_addr.is_some());
         let ip_addr = maybe_ip_addr.unwrap();
         assert!(ip_addr.is_ipv6(), "was not ipv6");
         assert!(!ip_addr.is_ipv4(), "was ipv4");
-        assert_eq!(ip_addr.to_string(), "2001:db8:85a3::8a2e:370:7334");
         assert!(!ip_addr.is_unspecified());
+        assert_eq!(ip_addr.to_string(), "2001:db8:85a3::8a2e:370:7334");
     }
 
     #[test]
-    fn byte_to_ipaddr_v6_loopback_short() {
-        let loopback = "::1";
-        let result = byte_to_ip(&Bytes::from(loopback));
-        assert!(result.is_ok());
-        let maybe_loopback_ip = result.unwrap();
-        assert!(maybe_loopback_ip.is_some());
-        assert_eq!(maybe_loopback_ip.unwrap().to_string(), loopback);
-    }
-
-    #[test]
-    fn byte_to_ipaddr_v6_loopback_long() {
-        let loopback = "0:0:0:0:0:0:0:1";
-        let result = byte_to_ip(&Bytes::from(loopback));
+    fn byte_to_ipaddr_v6_loopback() {
+        let addr_vec: Vec<u8> = Vec::from([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]);
+        let bytes = &Bytes::from(addr_vec);
+        let result = byte_to_ip(bytes);
         assert!(result.is_ok());
         let maybe_loopback_ip = result.unwrap();
         assert!(maybe_loopback_ip.is_some());

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -131,14 +131,9 @@ fn byte_to_ip(b: &bytes::Bytes) -> Result<Option<IpAddr>, WorkloadError> {
             let v: [u8; 16] = b.deref().try_into().expect("size already proven");
             Some(IpAddr::from(v))
         }
-        n => {
-            println!("invalid ip address length: {n}");
-            return Err(WorkloadError::ByteAddressParse(n));
-        }
+        n => return Err(WorkloadError::ByteAddressParse(n)),
     })
 }
-
-const DEFAULT_SERVICE_ACCOUNT: &str = "default";
 
 impl TryFrom<&XdsWorkload> for Workload {
     type Error = WorkloadError;
@@ -157,8 +152,14 @@ impl TryFrom<&XdsWorkload> for Workload {
 
             name: resource.name,
             namespace: resource.namespace,
-            service_account: Option::from(resource.service_account)
-                .unwrap_or_else(|| DEFAULT_SERVICE_ACCOUNT.into()),
+            service_account: {
+                let result = resource.service_account;
+                if result.is_empty() {
+                    "default".into()
+                } else {
+                    result
+                }
+            },
             node: resource.node,
 
             native_hbone: resource.native_hbone,

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -455,9 +455,7 @@ mod tests {
 
     #[test]
     fn byte_to_ipaddr_v6_loopback() {
-        let addr_vec: Vec<u8> = Vec::from([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-        ]);
+        let addr_vec: Vec<u8> = Vec::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
         let bytes = &Bytes::from(addr_vec);
         let result = byte_to_ip(bytes);
         assert!(result.is_ok());

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -202,7 +202,7 @@ impl TryFrom<&XdsWorkload> for Workload {
         let protocol =
             Protocol::try_from(xds::istio::workload::Protocol::from_i32(resource.protocol))?;
         let service_account =
-            Option::from(resource.service_account).unwrap_or(String::from("default"));
+            Option::from(resource.service_account).unwrap_or_else(|| String::from("default"));
         let workload = WorkloadBuilder::new(
             resource.name,
             resource.namespace,
@@ -413,7 +413,7 @@ impl WorkloadInformation {
 }
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum WorkloadError {
     #[error("failed to parse address: {0}")]
     AddressParse(#[from] net::AddrParseError),
@@ -502,7 +502,7 @@ mod tests {
         assert!(ip_addr.is_ipv6(), "was not ipv6");
         assert!(!ip_addr.is_ipv4(), "was ipv4");
         assert_eq!(ip_addr.to_string(), "2001:db8:85a3::8a2e:370:7334");
-        assert_ne!(ip_addr.is_unspecified(), true);
+        assert!(!ip_addr.is_unspecified());
     }
 
     #[test]


### PR DESCRIPTION
* Address some of the `clone()` usages #10
* Introduce `WorkloadBuilder` in an effort to clean up how `Workload` is constructed
* Simplify `byte_to_ip` function and added tests