### PR TITLE
Cert cache + refresh logic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -37,11 +37,12 @@ pub async fn build(config: config::Config) -> anyhow::Result<Bound> {
         .expect("admin server starts");
     let admin_address = admin.address();
     admin.spawn(&shutdown, drain_rx.clone());
-    let secrets = identity::SecretManager::new(config.clone());
+
+    let cert_manager = identity::SecretManager::new(config.clone());
     let proxy = proxy::Proxy::new(
         config.clone(),
         workload_manager.workloads(),
-        secrets,
+        cert_manager,
         drain_rx.clone(),
     )
     .await?;

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 use std::fmt;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::time::{sleep, Duration};
 use tracing::instrument;
 
 use super::CaClient;
 use super::Error;
 use crate::tls;
+use tracing::{info, warn};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum Identity {
     Spiffe {
         trust_domain: String,
@@ -46,16 +50,68 @@ impl fmt::Display for Identity {
 #[derive(Clone)]
 pub struct SecretManager {
     client: CaClient,
+    cache: Arc<Mutex<HashMap<Identity, tls::Certs>>>,
 }
 
 impl SecretManager {
     pub fn new(cfg: crate::config::Config) -> SecretManager {
         let client = CaClient::new(cfg.auth);
-        SecretManager { client }
+        let cache: HashMap<Identity, tls::Certs> = Default::default();
+        return SecretManager { client: client, cache: Arc::new(Mutex::new(cache)) };
+    }
+
+    pub async fn refresh_handler(id: Identity, ctx: SecretManager, initial_sleep_time: u64) {
+        info!("refreshing certs for id {} in {:?} seconds", id, initial_sleep_time);
+        sleep(Duration::from_secs(initial_sleep_time)).await;
+        loop {
+            match ctx.client.clone().fetch_certificate(&id.clone()).await {
+                Err(e) => {
+                    // Cert refresh has failed. Drop cert from the cache.
+                    warn!("Failed cert refresh for id {:?}: {:?}", id, e);
+                    { // lock cache
+                        let mut locked_cache = ctx.cache.lock().unwrap();
+                        locked_cache.remove(&id.clone());
+                    } // unlock cache
+                    return;
+                }
+                Ok(fetched_certs) => {
+                    info!("refreshed certs {:?}", fetched_certs);
+                    { // lock cache
+                        let mut locked_cache = ctx.cache.lock().unwrap();
+                        locked_cache.insert(id.clone(), fetched_certs.clone());
+                    } // unlock cache
+                    let sleep_dur = Duration::from_secs(fetched_certs.get_seconds_until_refresh());
+                    info!("refreshing certs for id {} in {:?} seconds", id, sleep_dur);
+                    sleep(sleep_dur).await;
+                }
+            }
+        }
     }
 
     #[instrument(skip_all, fields(%id))]
-    pub async fn fetch_certificate(&self, id: &Identity) -> Result<tls::Certs, Error> {
-        self.client.clone().fetch_certificate(id).await
+    pub async fn fetch_certificate(&mut self, id: &Identity) -> Result<tls::Certs, Error> {
+        // Check cache first
+        { // lock cache
+            let locked_cache = self.cache.lock().unwrap();
+            let cache_certs: std::option::Option<&tls::Certs> = locked_cache.get(id);
+            info!("cache certs for req: {:?}", cache_certs);
+            if cache_certs.is_some() {
+                return Ok(cache_certs.unwrap().clone())
+            }
+        } // unlock cache
+
+        // No cache entry, fetch it and spawn refresh handler
+        let fetched_certs = self.client.clone().fetch_certificate(id).await?;
+        info!("fetched certs {:?}", fetched_certs);
+        { // lock cache
+            let mut locked_cache = self.cache.lock().unwrap();
+            locked_cache.insert(id.clone(), fetched_certs.clone());
+        } // unlock cache
+
+        tokio::spawn(SecretManager::refresh_handler(id.clone(),
+                                                        self.clone(),
+                                                        fetched_certs.get_seconds_until_refresh()));
+
+        Ok(fetched_certs.clone())
     }
 }

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -24,6 +24,7 @@ use tracing::{error, info, warn};
 use crate::config::Config;
 use crate::identity;
 use crate::proxy::inbound::InboundConnect::Hbone;
+use crate::identity::{CertificateProvider};
 use crate::tls::TlsError;
 use crate::workload::WorkloadInformation;
 
@@ -32,7 +33,7 @@ use super::Error;
 pub struct Inbound {
     cfg: Config,
     listener: TcpListener,
-    cert_manager: identity::SecretManager,
+    cert_manager: identity::SecretManager<identity::CaClient>,
     workloads: WorkloadInformation,
 }
 
@@ -40,7 +41,7 @@ impl Inbound {
     pub async fn new(
         cfg: Config,
         workloads: WorkloadInformation,
-        cert_manager: identity::SecretManager,
+        cert_manager: identity::SecretManager<identity::CaClient>,
     ) -> Result<Inbound, Error> {
         let listener: TcpListener = TcpListener::bind(cfg.inbound_addr)
             .await
@@ -204,7 +205,7 @@ pub(super) enum InboundConnect {
 
 #[derive(Clone)]
 struct InboundCertProvider {
-    cert_manager: identity::SecretManager,
+    cert_manager: identity::SecretManager<identity::CaClient>,
     workloads: WorkloadInformation,
 }
 

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -23,8 +23,8 @@ use tracing::{error, info, warn};
 
 use crate::config::Config;
 use crate::identity;
+use crate::identity::CertificateProvider;
 use crate::proxy::inbound::InboundConnect::Hbone;
-use crate::identity::{CertificateProvider};
 use crate::tls::TlsError;
 use crate::workload::WorkloadInformation;
 

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -210,7 +210,7 @@ struct InboundCertProvider {
 
 #[async_trait::async_trait]
 impl crate::tls::CertProvider for InboundCertProvider {
-    async fn fetch_cert(&self, fd: RawFd) -> Result<boring::ssl::SslAcceptor, TlsError> {
+    async fn fetch_cert(&mut self, fd: RawFd) -> Result<boring::ssl::SslAcceptor, TlsError> {
         let orig = crate::socket::orig_dst_addr_fd(fd).map_err(TlsError::DestinationLookup)?;
         let identity = {
             let remote_addr = super::to_canonical_ip(orig);

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -17,10 +17,9 @@ use drain::Watch;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
+use inbound::Inbound;
 use tokio::net::TcpStream;
 use tracing::{error, info};
-
-use inbound::Inbound;
 
 use crate::proxy::inbound_passthrough::InboundPassthrough;
 use crate::proxy::outbound::Outbound;
@@ -44,7 +43,7 @@ impl Proxy {
     pub async fn new(
         cfg: config::Config,
         workloads: WorkloadInformation,
-        cert_manager: identity::SecretManager,
+        cert_manager: identity::SecretManager<identity::CaClient>,
         drain: Watch,
     ) -> Result<Proxy, Error> {
         // We setup all the listeners first so we can capture any errors that should block startup

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -44,15 +44,15 @@ impl Proxy {
     pub async fn new(
         cfg: config::Config,
         workloads: WorkloadInformation,
-        secret_manager: identity::SecretManager,
+        cert_manager: identity::SecretManager,
         drain: Watch,
     ) -> Result<Proxy, Error> {
         // We setup all the listeners first so we can capture any errors that should block startup
         let inbound_passthrough = InboundPassthrough::new(cfg.clone());
-        let inbound = Inbound::new(cfg.clone(), workloads.clone(), secret_manager.clone()).await?;
+        let inbound = Inbound::new(cfg.clone(), workloads.clone(), cert_manager.clone()).await?;
         let outbound = Outbound::new(
             cfg.clone(),
-            secret_manager.clone(),
+            cert_manager.clone(),
             workloads.clone(),
             inbound.address().port(),
             drain,
@@ -60,7 +60,7 @@ impl Proxy {
         .await?;
         let socks5 = Socks5::new(
             cfg.clone(),
-            secret_manager.clone(),
+            cert_manager.clone(),
             inbound.address().port(),
             workloads.clone(),
         )

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::{Instant};
 use std::net::{IpAddr, SocketAddr};
+use std::time::Instant;
 
 use boring::ssl::ConnectConfiguration;
 use drain::Watch;
@@ -84,10 +84,15 @@ impl Outbound {
                         tokio::spawn(async move {
                             let res = oc.proxy(stream).await;
                             match res {
-                                Ok(_) => info!("outbound proxy complete ({}ms)",
-                                                        start_outbound_instant.elapsed().as_millis()),
-                                Err(ref e) => warn!("outbound proxy failed: {} ({}ms)", e,
-                                                        start_outbound_instant.elapsed().as_millis()),
+                                Ok(_) => info!(
+                                    "outbound proxy complete ({}ms)",
+                                    start_outbound_instant.elapsed().as_millis()
+                                ),
+                                Err(ref e) => warn!(
+                                    "outbound proxy failed: {} ({}ms)",
+                                    e,
+                                    start_outbound_instant.elapsed().as_millis()
+                                ),
                             };
                         });
                     }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -21,8 +21,8 @@ use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, error, info, warn};
 
 use crate::config::Config;
-use crate::proxy::inbound::{Inbound, InboundConnect};
 use crate::identity::CertificateProvider;
+use crate::proxy::inbound::{Inbound, InboundConnect};
 use crate::proxy::Error;
 use crate::workload::{Protocol, Workload, WorkloadInformation};
 use crate::{identity, socket};
@@ -176,7 +176,7 @@ impl OutboundConnection {
 
                 let mut request_sender = if self.cfg.tls {
                     let id = &req.source.identity();
-                    let cert = self.cert_manager.fetch_certificate(&id).await?;
+                    let cert = self.cert_manager.fetch_certificate(id).await?;
                     let connector = cert.connector(&req.destination_identity)?.configure()?;
                     let tcp_stream = TcpStream::connect(req.gateway).await?;
                     let tls_stream = connect_tls(connector, tcp_stream).await?;

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -75,7 +75,7 @@ impl Socks5 {
 // sufficient to integrate with common clients:
 // - only unauthenticated requests
 // - only CONNECT, with IPv4 or IPv6
-async fn handle(oc: OutboundConnection, mut stream: TcpStream) -> Result<(), anyhow::Error> {
+async fn handle(mut oc: OutboundConnection, mut stream: TcpStream) -> Result<(), anyhow::Error> {
     // Version(5), Number of auth methods
     let mut version = [0u8; 2];
     stream.read_exact(&mut version).await?;

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -13,7 +13,7 @@ use tracing::{error, info, warn};
 
 pub struct Socks5 {
     cfg: Config,
-    cert_manager: identity::SecretManager,
+    cert_manager: identity::SecretManager<identity::CaClient>,
     workloads: WorkloadInformation,
     hbone_port: u16,
     listener: TcpListener,
@@ -22,7 +22,7 @@ pub struct Socks5 {
 impl Socks5 {
     pub async fn new(
         cfg: Config,
-        cert_manager: identity::SecretManager,
+        cert_manager: identity::SecretManager<identity::CaClient>,
         hbone_port: u16,
         workloads: WorkloadInformation,
     ) -> Result<Socks5, Error> {

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -99,10 +99,6 @@ pub struct Certs {
 }
 
 impl PartialEq for Certs {
-    fn ne(&self, other: &Self) -> bool {
-        !self.eq(other)
-    }
-
     fn eq(&self, other: &Self) -> bool {
         self.cert.to_der().iter().eq(other.cert.to_der().iter())
             && self
@@ -121,7 +117,7 @@ impl Certs {
         if time_until_expired.secs > 0 {
             return false;
         }
-        return true;
+        true
     }
 
     pub fn get_duration_until_refresh(&self) -> Duration {

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -384,16 +384,16 @@ pub mod tests {
     }
 
     // Creates an invalid dummy cert with overridden expire time
-    pub fn generate_test_certs(seconds_until_expiry: u64) -> Certs {
+    pub fn generate_test_certs(seconds_until_expiry: Duration) -> Certs {
         let mut tmp = x509::X509::builder().unwrap();
         let current = Asn1Time::days_from_now(0).unwrap();
         let expire_time: i64 = (SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs()
-            + seconds_until_expiry)
-            .try_into()
-            .unwrap();
+            + seconds_until_expiry.as_secs())
+        .try_into()
+        .unwrap();
         tmp.set_not_before(&current)
             .expect("error setting cert 'not_before'");
         tmp.set_not_after(&Asn1Time::from_unix(expire_time).unwrap())

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -21,6 +21,7 @@ use std::pin::Pin;
 use std::task::Poll;
 use std::time::Duration;
 
+use boring::asn1::{Asn1Time, Asn1TimeRef};
 use boring::ec::{EcGroup, EcKey};
 use boring::hash::MessageDigest;
 use boring::nid::Nid;
@@ -30,7 +31,6 @@ use boring::ssl::{self, SslContextBuilder};
 use boring::stack::Stack;
 use boring::x509::extension::SubjectAlternativeName;
 use boring::x509::{self, GeneralName, X509StoreContext, X509StoreContextRef, X509VerifyResult};
-use boring::asn1::{Asn1Time, Asn1TimeRef};
 use hyper::client::ResponseFuture;
 use hyper::{Request, Uri};
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -113,10 +113,10 @@ impl Certs {
 
         let total_lifetime = start.diff(end).unwrap();
         let total_lifetime_secs = total_lifetime.days * 86400 + total_lifetime.secs;
-        let halflife = total_lifetime_secs/2;
+        let halflife = total_lifetime_secs / 2;
         let elapsed = start.diff(&current).unwrap();
         let elapsed_secs = elapsed.days * 86400 + elapsed.secs; // 86400 secs/day
-        let returnval : i32 = halflife-elapsed_secs;
+        let returnval: i32 = halflife - elapsed_secs;
         if returnval < 0 {
             return Duration::from_secs(0);
         }

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -29,6 +29,7 @@ use boring::ssl::{self, SslContextBuilder};
 use boring::stack::Stack;
 use boring::x509::extension::SubjectAlternativeName;
 use boring::x509::{self, GeneralName, X509StoreContext, X509StoreContextRef, X509VerifyResult};
+use boring::asn1::{Asn1Time, Asn1TimeRef};
 use hyper::client::ResponseFuture;
 use hyper::{Request, Uri};
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -87,13 +88,39 @@ impl CsrOptions {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Certs {
     // the leaf cert
     cert: x509::X509,
     // the remainder of the chain, not including the leaf cert
     chain: Vec<x509::X509>,
     key: pkey::PKey<pkey::Private>,
+}
+
+impl<'a> Certs {
+    pub fn not_before(&'a self) -> &'a Asn1TimeRef {
+        self.cert.not_before()
+    }
+    pub fn not_after(&'a self) -> &'a Asn1TimeRef {
+        self.cert.not_after()
+    }
+
+    pub fn get_seconds_until_refresh(&self) -> u64 {
+        let current = Asn1Time::days_from_now(0).unwrap();
+        let start: &Asn1TimeRef = self.not_before();
+        let end: &Asn1TimeRef = self.not_after();
+
+        let total_lifetime = start.diff(end).unwrap();
+        let total_lifetime_secs = total_lifetime.days * 86400 + total_lifetime.secs;
+        let halflife = total_lifetime_secs/2;
+        let elapsed = start.diff(&current).unwrap();
+        let elapsed_secs = elapsed.days * 86400 + elapsed.secs; // 86400 secs/day
+        let returnval : i32 = halflife-elapsed_secs;
+        if returnval < 0 {
+            return 0 as u64
+        }
+        returnval as u64
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -278,7 +305,7 @@ impl Alpn {
 
 #[async_trait::async_trait]
 pub trait CertProvider: Send + Sync + Clone {
-    async fn fetch_cert(&self, fd: RawFd) -> Result<ssl::SslAcceptor, TlsError>;
+    async fn fetch_cert(&mut self, fd: RawFd) -> Result<ssl::SslAcceptor, TlsError>;
 }
 
 #[derive(Clone)]
@@ -317,7 +344,7 @@ where
 
     fn accept(&self, conn: C) -> Self::AcceptFuture {
         let fd = conn.as_raw_fd();
-        let acceptor = self.acceptor.clone();
+        let mut acceptor = self.acceptor.clone();
         Box::pin(async move {
             let tls = acceptor.fetch_cert(fd).await?;
             tokio_boring::accept(&tls, conn)

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -369,7 +369,6 @@ where
     }
 }
 
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -380,7 +379,12 @@ pub mod tests {
     pub fn test_certs() -> Certs {
         let cert = x509::X509::from_pem(CERT).unwrap();
         let key = pkey::PKey::private_key_from_pem(PKEY).unwrap();
-        Certs { cert, key, chain: unimplemented!() }
+        let chain = vec![cert.clone()];
+        Certs {
+            cert,
+            key,
+            chain: chain,
+        }
     }
 
     // Creates an invalid dummy cert with overridden expire time
@@ -401,7 +405,8 @@ pub mod tests {
 
         let cert = tmp.build();
         let key = pkey::PKey::private_key_from_pem(PKEY).unwrap();
-        Certs { cert, key, chain: unimplemented!() }
+        let chain = vec![cert.clone()];
+        Certs { cert, key, chain }
     }
 
     #[test]

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -19,6 +19,7 @@ use std::net::IpAddr;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::pin::Pin;
 use std::task::Poll;
+use std::time::Duration;
 
 use boring::ec::{EcGroup, EcKey};
 use boring::hash::MessageDigest;
@@ -97,15 +98,15 @@ pub struct Certs {
     key: pkey::PKey<pkey::Private>,
 }
 
-impl<'a> Certs {
-    pub fn not_before(&'a self) -> &'a Asn1TimeRef {
+impl Certs {
+    pub fn not_before(&self) -> &Asn1TimeRef {
         self.cert.not_before()
     }
-    pub fn not_after(&'a self) -> &'a Asn1TimeRef {
+    pub fn not_after(&self) -> &Asn1TimeRef {
         self.cert.not_after()
     }
 
-    pub fn get_seconds_until_refresh(&self) -> u64 {
+    pub fn get_duration_until_refresh(&self) -> Duration {
         let current = Asn1Time::days_from_now(0).unwrap();
         let start: &Asn1TimeRef = self.not_before();
         let end: &Asn1TimeRef = self.not_after();
@@ -117,9 +118,9 @@ impl<'a> Certs {
         let elapsed_secs = elapsed.days * 86400 + elapsed.secs; // 86400 secs/day
         let returnval : i32 = halflife-elapsed_secs;
         if returnval < 0 {
-            return 0 as u64
+            return Duration::from_secs(0);
         }
-        returnval as u64
+        Duration::from_secs(u64::try_from(returnval).unwrap())
     }
 }
 

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -18,7 +18,7 @@ pub use crate::tls::boring::*;
 use ::boring::error::ErrorStack;
 use hyper::http::uri::InvalidUri;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
     #[error("invalid operation: {0}")]
     SslError(#[from] ErrorStack),

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -18,7 +18,7 @@ pub use crate::tls::boring::*;
 use ::boring::error::ErrorStack;
 use hyper::http::uri::InvalidUri;
 
-#[derive(thiserror::Error, Debug, Clone)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("invalid operation: {0}")]
     SslError(#[from] ErrorStack),


### PR DESCRIPTION
Initially used tokio::DelayQueue for refreshing, but after discussing with John changed to independent tasks spawned when we fetch the cert. Eventually will want some protection against sending many CA requests at once. 