### PR TITLE
Initial support for on demand xds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1.0.34"
 lazy_static = "1.4.0"
 pprof = { version = "0.10.1", features = ["protobuf", "protobuf-codec"] }
 gperftools = { version = "0.2.0", features = ["heap"], optional = true }
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { version = "1.0.144", features = ["derive", "rc"] }
 serde_json = "1.0.85"
 tryhard = "0.5.0"
 num_cpus = "1.13.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub struct Config {
 
     /// Filepath to a local xds file for workloads, as YAML.
     pub local_xds_path: Option<String>,
+    /// If true, on-demand XDS will be used
+    pub xds_on_demand: bool,
 
     pub auth: identity::AuthSource,
 }
@@ -40,6 +42,7 @@ impl Default for Config {
 
             local_xds_path: Some(std::env::var("LOCAL_XDS_PATH").unwrap_or_else(|_| "".into()))
                 .filter(|s| !s.is_empty()),
+            xds_on_demand: std::env::var("XDS_ON_DEMAND").unwrap_or_else(|_| "".into()) == "on",
 
             auth: identity::AuthSource::Token(PathBuf::from(
                 r"./var/run/secrets/tokens/istio-token",

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,7 +1,7 @@
 use boring::error::ErrorStack;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::{Arc, Mutex};
+
 use tokio::net::TcpStream;
 use tracing::info;
 
@@ -25,7 +25,7 @@ pub struct Proxy {
 impl Proxy {
     pub async fn new(
         cfg: config::Config,
-        workloads: Arc<Mutex<WorkloadInformation>>,
+        workloads: WorkloadInformation,
         secret_manager: identity::SecretManager,
     ) -> Result<Proxy, Error> {
         // We setup all the listeners first so we can capture any errors that should block startup

--- a/src/xds/mod.rs
+++ b/src/xds/mod.rs
@@ -15,4 +15,6 @@ pub enum Error {
     /// Attempted to send on a MPSC channel which has been canceled
     #[error(transparent)]
     RequestFailure(#[from] Box<mpsc::error::SendError<DeltaDiscoveryRequest>>),
+    #[error("failed to send on demand resource")]
+    OnDemandSend(),
 }


### PR DESCRIPTION
This is tied to https://github.com/istio/istio/pull/41796, since the resource name changes.

This does NOT enable on-demand XDS yet; its off-by-default. It sort of works though. However, it does some nice cleanup and allows for further development, and allows us to run with https://github.com/istio/istio/pull/41796 which makes the control plane much more efficient (along with supporting on-demand)