### PR TITLE
Fixes to work in real k8s cluster

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
     let workload_manager = workload::WorkloadManager::new(config.clone());
 
     let workloads = workload_manager.workloads();
-    admin::Builder::new("[::]:15022".parse().unwrap(), workloads)
+    admin::Builder::new("[::]:15021".parse().unwrap(), workloads)
         .set_ready()
         .bind()
         .expect("admin server starts")

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -236,7 +236,7 @@ impl OutboundConnection {
             // so we need to explicitly send it to ourselves.
             // In the future this could be optimized to avoid a full network traversal.
             req.request_type = RequestType::DirectLocal;
-            req.gateway = "127.0.0.1:15008".parse().unwrap();
+            req.gateway = "127.0.0.1:15088".parse().unwrap();
         } else if us.workload.name.is_empty() {
             req.request_type = RequestType::Passthrough;
         } else {


### PR DESCRIPTION
* Set admin port to match Envoy so various tooling works (probes)
* Use magic 15088 redirection so the inbound knows which certificate to serve