### PR TITLE
Support IPv4 and IPv6 compatibility for function to_canonical_ip

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -129,11 +129,11 @@ fn to_canonical_ip(ip: SocketAddr) -> IpAddr {
     // @zhlsunshine TODO: to_canonical() should be used when it becomes stable a function in Rust
     match ip.ip() {
         IpAddr::V4(i) => IpAddr::V4(i),
-        IpAddr::V6(i) => {
-            match i.octets() {
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d] => IpAddr::V4(Ipv4Addr::new(a, b, c, d)),
-                _ => IpAddr::V6(i),
+        IpAddr::V6(i) => match i.octets() {
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d] => {
+                IpAddr::V4(Ipv4Addr::new(a, b, c, d))
             }
+            _ => IpAddr::V6(i),
         },
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -125,10 +125,10 @@ pub async fn copy_hbone(
 }
 
 fn to_canonical_ip(ip: SocketAddr) -> IpAddr {
-    // For now we only support IPv4 but we are binding to IPv6 address; convert everything to IPv4
-    // TODO: Support IPv6 fully
+    // Return an IPv4addr if it's an IPv4-mapped addresses or IPv6addr by using to_canonical() if
+    // the SocketAddr is a SocketAddrV6
     match ip.ip() {
         IpAddr::V4(i) => IpAddr::V4(i),
-        IpAddr::V6(i) => IpAddr::V4(i.to_ipv4().unwrap()),
+        IpAddr::V6(i) => IpAddr::V6(i).to_canonical(),
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -125,7 +125,7 @@ pub async fn copy_hbone(
 }
 
 fn to_canonical_ip(ip: SocketAddr) -> IpAddr {
-    // add another match has to be used for IPv4 and IPv6 support
+    // another match has to be used for IPv4 and IPv6 support
     // @zhlsunshine TODO: to_canonical() should be used when it becomes stable a function in Rust
     match ip.ip() {
         IpAddr::V4(i) => IpAddr::V4(i),


### PR DESCRIPTION
Another match has to be used for IPv4 and IPv6 support in to_canonical_ip and can not directly use to_canonical() of IpAddr due to it's an unstable function in Rust