### PR TITLE
Implement basic graceful drain/exit of proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "drain"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f1a0abf3fcefad9b4dd0e414207a7408e12b68414a01e6bb19b897d5bd7632d"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1887,7 @@ dependencies = [
  "boring",
  "bytes",
  "console-subscriber",
+ "drain",
  "futures",
  "futures-util",
  "gperftools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "overload"
@@ -1897,6 +1897,7 @@ dependencies = [
  "libc",
  "log",
  "num_cpus",
+ "once_cell",
  "pprof",
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,15 @@ default = []
 gperftools = ["dep:gperftools"]
 console = ["dep:console-subscriber"]
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 name = "ztunnel"
 path = "src/main.rs"
 
 [dependencies]
+#tikv-jemallocator = { version = "0.5", features = ["profiling", "stats"]}
 anyhow = "1.0.65"
 async-stream = "0.3.3"
 async-trait = "0.1.58"
@@ -30,6 +34,7 @@ lazy_static = "1.4.0"
 libc = "0.2.126"
 log = "0.4"
 num_cpus = "1.13.1"
+once_cell = "1.16.0"
 pprof = { version = "0.10.1", features = ["protobuf", "protobuf-codec"] }
 prost = "0.11"
 prost-types = "0.11.1"
@@ -38,7 +43,6 @@ serde = { version = "1.0.144", features = ["derive", "rc"] }
 serde_json = "1.0.85"
 serde_yaml = "0.9.13"
 thiserror = "1.0.34"
-#tikv-jemallocator = { version = "0.5", features = ["profiling", "stats"]}
 tls-listener = { version  = "0.5.1", features = ["hyper-h2"] }
 tokio = {"version"= "1", features=["full"]}
 tokio-boring = { version = "2.1.5", features = ['fips'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,39 +14,40 @@ name = "ztunnel"
 path = "src/main.rs"
 
 [dependencies]
-#tikv-jemallocator = { version = "0.5", features = ["profiling", "stats"]}
-futures = "0.3.12"
-hyper = { version = "0.14.18", features = ["full"] }
-tokio = {"version"= "1", features=["full"]}
+anyhow = "1.0.65"
+async-stream = "0.3.3"
+async-trait = "0.1.58"
+boring = { version = "2.1.0", features = ['fips'] }
 bytes = { version = "1", features=["serde"]}
-log = "0.4"
-tower = { version = "0.4.12", features = ["full"] }
-libc = "0.2.126"
+console-subscriber = { version = "0.1.6" , optional = true}
+drain = "0.1.1"
+futures = "0.3.12"
 futures-util = "0.3.21"
-tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.11" , features = ["registry", "env-filter"]}
-tonic = "0.8"
+gperftools = { version = "0.2.0", features = ["heap"], optional = true }
+hyper = { version = "0.14.18", features = ["full"] }
+hyper-boring = { version= "2.1.2", features = ['fips'] }
+lazy_static = "1.4.0"
+libc = "0.2.126"
+log = "0.4"
+num_cpus = "1.13.1"
+pprof = { version = "0.10.1", features = ["protobuf", "protobuf-codec"] }
 prost = "0.11"
 prost-types = "0.11.1"
-tokio-stream = "0.1.9"
-console-subscriber = { version = "0.1.6" , optional = true}
-async-stream = "0.3.3"
-tls-listener = { version  = "0.5.1", features = ["hyper-h2"] }
-thiserror = "1.0.34"
-lazy_static = "1.4.0"
-pprof = { version = "0.10.1", features = ["protobuf", "protobuf-codec"] }
-gperftools = { version = "0.2.0", features = ["heap"], optional = true }
+rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
 serde_json = "1.0.85"
-tryhard = "0.5.0"
-num_cpus = "1.13.1"
-boring = { version = "2.1.0", features = ['fips'] }
-tokio-boring = { version = "2.1.5", features = ['fips'] }
-hyper-boring = { version= "2.1.2", features = ['fips'] }
-anyhow = "1.0.65"
 serde_yaml = "0.9.13"
-async-trait = "0.1.58"
-rand = "0.8.5"
+thiserror = "1.0.34"
+#tikv-jemallocator = { version = "0.5", features = ["profiling", "stats"]}
+tls-listener = { version  = "0.5.1", features = ["hyper-h2"] }
+tokio = {"version"= "1", features=["full"]}
+tokio-boring = { version = "2.1.5", features = ['fips'] }
+tokio-stream = "0.1.9"
+tonic = "0.8"
+tower = { version = "0.4.12", features = ["full"] }
+tracing = "0.1.34"
+tracing-subscriber = { version = "0.3.11" , features = ["registry", "env-filter"]}
+tryhard = "0.5.0"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,50 @@
+use crate::{admin, config, identity, proxy, signal, workload};
+use tokio::task::JoinHandle;
+use tokio::time;
+use tracing::{error, info, warn};
+
+pub async fn spawn(shutdown: signal::Shutdown, config: config::Config) -> anyhow::Result<()> {
+    // Setup a drain channel. drain_tx is used to trigger a drain, which will complete
+    // once all drain_rx handlers are dropped.
+    // Any component which wants time to gracefully exit should take in a drain_rx clone, await drain_rx.signaled(), then cleanup.
+    // Note: there is still a hard timeout if the draining takes too long
+    let (drain_tx, drain_rx) = drain::channel();
+    let mut tasks: Vec<JoinHandle<()>> = Vec::new();
+    let workload_manager = workload::WorkloadManager::new(config.clone());
+
+    let workloads = workload_manager.workloads();
+    admin::Builder::new("[::]:15021".parse().unwrap(), workloads)
+        .set_ready()
+        .bind()
+        .expect("admin server starts")
+        .spawn();
+    let workloads = workload_manager.workloads();
+    let secrets = identity::SecretManager::new(config.clone());
+    let proxy = proxy::Proxy::new(config.clone(), workloads, secrets, drain_rx).await?;
+    tasks.push(tokio::spawn(async move {
+        if let Err(e) = workload_manager.run().await {
+            error!("workload manager: {}", e);
+        }
+    }));
+    tasks.push(tokio::spawn(proxy.run()));
+
+    tokio::spawn(async move {
+        futures::future::join_all(tasks).await;
+    });
+
+    // Wait for a signal to shutdown
+    // TODO: add a explicit way to trigger this from admin server
+    shutdown.wait().await;
+
+    // Start a drain; this will wait for all drain_rx handles to be dropped before completing,
+    // allowing components to terminate.
+    // If they take too long, terminate anyways.
+    match time::timeout(config.termination_grace_period, drain_tx.drain()).await {
+        Ok(()) => info!("Shutdown completed gracefully"),
+        Err(_) => warn!(
+            "Graceful shutdown did not complete in {:?}, terminating now",
+            config.termination_grace_period
+        ),
+    }
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use crate::identity;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
+use tokio::time;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -23,6 +25,8 @@ pub struct Config {
     pub xds_on_demand: bool,
 
     pub auth: identity::AuthSource,
+
+    pub termination_grace_period: time::Duration,
 }
 
 impl Default for Config {
@@ -32,6 +36,8 @@ impl Default for Config {
             window_size: 4 * 1024 * 1024,
             connection_window_size: 4 * 1024 * 1024,
             frame_size: 1024 * 1024,
+
+            termination_grace_period: Duration::from_secs(5),
 
             inbound_addr: "[::]:15008".parse().unwrap(),
             inbound_plaintext_addr: "[::]:15006".parse().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod admin;
+pub mod app;
+pub mod config;
+pub mod identity;
+pub mod proxy;
+pub mod signal;
+pub mod socket;
+pub mod telemetry;
+pub mod tls;
+pub mod workload;
+pub mod xds;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,20 +2,7 @@ extern crate core;
 #[cfg(feature = "gperftools")]
 extern crate gperftools;
 
-use tokio::task::JoinHandle;
-use tokio::time;
-use tracing::{error, info, warn};
-use tracing_subscriber::prelude::*;
-
-mod admin;
-mod config;
-mod identity;
-mod proxy;
-mod signal;
-mod socket;
-mod tls;
-mod workload;
-mod xds;
+use ztunnel::*;
 
 // #[global_allocator]
 // static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
@@ -23,80 +10,11 @@ mod xds;
 // #[global_allocator]
 // static GLOBAL: tcmalloc::TCMalloc = tcmalloc::TCMalloc;
 
-#[cfg(feature = "console")]
-fn setup_logging() {
-    let console_layer = console_subscriber::spawn();
-
-    let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
-        .or_else(|_| tracing_subscriber::EnvFilter::try_new("info"))
-        .unwrap();
-    tracing_subscriber::registry()
-        .with(console_layer)
-        .with(filter_layer)
-        .with(tracing_subscriber::fmt::layer())
-        .init();
-}
-
-#[cfg(not(feature = "console"))]
-fn setup_logging() {
-    let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
-        .or_else(|_| tracing_subscriber::EnvFilter::try_new("info"))
-        .unwrap();
-    tracing_subscriber::registry()
-        .with(filter_layer)
-        .with(tracing_subscriber::fmt::layer())
-        .init();
-}
-
 #[tokio::main(worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
-    setup_logging();
-
-    let mut tasks: Vec<JoinHandle<()>> = Vec::new();
-
-    // Setup a drain channel. drain_tx is used to trigger a drain, which will complete
-    // once all drain_rx handlers are dropped.
-    // Any component which wants time to gracefully exit should take in a drain_rx clone, await drain_rx.signaled(), then cleanup.
-    // Note: there is still a hard timeout if the draining takes too long
-    let (drain_tx, drain_rx) = drain::channel();
-    let config = config::Config {
+    telemetry::setup_logging();
+    let config = ztunnel::config::Config {
         ..Default::default()
     };
-    let workload_manager = workload::WorkloadManager::new(config.clone());
-
-    let workloads = workload_manager.workloads();
-    admin::Builder::new("[::]:15021".parse().unwrap(), workloads)
-        .set_ready()
-        .bind()
-        .expect("admin server starts")
-        .spawn();
-    let workloads = workload_manager.workloads();
-    let secrets = identity::SecretManager::new(config.clone());
-    let proxy = proxy::Proxy::new(config.clone(), workloads, secrets, drain_rx).await?;
-    tasks.push(tokio::spawn(async move {
-        if let Err(e) = workload_manager.run().await {
-            error!("workload manager: {}", e);
-        }
-    }));
-    tasks.push(tokio::spawn(proxy.run()));
-
-    tokio::spawn(async move {
-        futures::future::join_all(tasks).await;
-    });
-
-    // Wait for a signal to shutdown
-    // TODO: add a explicit way to trigger this from admin server
-    signal::shutdown().await;
-
-    // Start a drain; this will wait for all drain_rx handles to be dropped before completing,
-    // allowing components to terminate.
-    // If they take too long, terminate anyways.
-    match time::timeout(config.termination_grace_period, drain_tx.drain()).await {
-        Ok(()) => info!("Shutdown completed gracefully"),
-        Err(_) => warn!(
-            "Graceful shutdown did not complete in {:?}, terminating now",
-            config.termination_grace_period
-        ),
-    }
-    Ok(())
+    app::spawn(signal::Shutdown::new(), config).await
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,4 +1,5 @@
 use boring::error::ErrorStack;
+use drain::Watch;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
@@ -27,11 +28,12 @@ impl Proxy {
         cfg: config::Config,
         workloads: WorkloadInformation,
         secret_manager: identity::SecretManager,
+        drain: Watch,
     ) -> Result<Proxy, Error> {
         // We setup all the listeners first so we can capture any errors that should block startup
         let inbound_passthrough = InboundPassthrough::new(cfg.clone());
         let inbound = Inbound::new(cfg.clone(), workloads.clone(), secret_manager.clone()).await?;
-        let outbound = Outbound::new(cfg.clone(), secret_manager, workloads).await?;
+        let outbound = Outbound::new(cfg.clone(), secret_manager, workloads, drain).await?;
         Ok(Proxy {
             inbound,
             inbound_passthrough,

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -1,6 +1,7 @@
 use std::net::{IpAddr, SocketAddr};
 
 use boring::ssl::ConnectConfiguration;
+use drain::Watch;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, error, info, warn};
@@ -15,6 +16,7 @@ pub struct Outbound {
     cert_manager: identity::SecretManager,
     workloads: WorkloadInformation,
     listener: TcpListener,
+    pub drain: Watch,
 }
 
 impl Outbound {
@@ -22,6 +24,7 @@ impl Outbound {
         cfg: Config,
         cert_manager: identity::SecretManager,
         workloads: WorkloadInformation,
+        drain: Watch,
     ) -> Result<Outbound, Error> {
         let listener: TcpListener = TcpListener::bind(cfg.outbound_addr)
             .await
@@ -36,6 +39,7 @@ impl Outbound {
             cert_manager,
             workloads,
             listener,
+            drain,
         })
     }
 
@@ -43,27 +47,39 @@ impl Outbound {
         let addr = self.listener.local_addr().unwrap();
         info!("outbound listener established {}", addr);
 
-        loop {
-            // Asynchronously wait for an inbound socket.
-            let socket = self.listener.accept().await;
-            match socket {
-                Ok((stream, remote)) => {
-                    info!("accepted outbound connection from {}", remote);
-                    let cfg = self.cfg.clone();
-                    let oc = OutboundConnection {
-                        cert_manager: self.cert_manager.clone(),
-                        workloads: self.workloads.clone(),
-                        cfg,
-                    };
-                    tokio::spawn(async move {
-                        let res = oc.proxy(stream).await;
-                        match res {
-                            Ok(_) => info!("outbound proxy complete"),
-                            Err(ref e) => warn!("outbound proxy failed: {}", e),
+        let accept = async move {
+            loop {
+                // Asynchronously wait for an inbound socket.
+                let socket = self.listener.accept().await;
+                match socket {
+                    Ok((stream, remote)) => {
+                        info!("accepted outbound connection from {}", remote);
+                        let cfg = self.cfg.clone();
+                        let oc = OutboundConnection {
+                            cert_manager: self.cert_manager.clone(),
+                            workloads: self.workloads.clone(),
+                            cfg,
                         };
-                    });
+                        tokio::spawn(async move {
+                            let res = oc.proxy(stream).await;
+                            match res {
+                                Ok(_) => info!("outbound proxy complete"),
+                                Err(ref e) => warn!("outbound proxy failed: {}", e),
+                            };
+                        });
+                    }
+                    Err(e) => error!("Failed TCP handshake {}", e),
                 }
-                Err(e) => error!("Failed TCP handshake {}", e),
+            }
+        };
+
+        // Stop accepting once we drain.
+        // Note: we are *not* waiting for all connections to be closed. In the future, we may consider
+        // this, but will need some timeout period, as we have no back-pressure mechanism on connections.
+        tokio::select! {
+            res = accept => { res }
+            _ = self.drain.signaled() => {
+                info!("outbound drained");
             }
         }
     }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -16,7 +16,7 @@ pub struct Outbound {
     cert_manager: identity::SecretManager,
     workloads: WorkloadInformation,
     listener: TcpListener,
-    pub drain: Watch,
+    drain: Watch,
 }
 
 impl Outbound {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,0 +1,36 @@
+/// Returns a `Future` that completes when the proxy should start to shutdown.
+pub async fn shutdown() {
+    imp::shutdown().await
+}
+
+#[cfg(unix)]
+mod imp {
+    use tokio::signal::unix::{signal, SignalKind};
+    use tracing::info;
+
+    pub(super) async fn shutdown() {
+        tokio::select! {
+            () = watch_signal(SignalKind::interrupt(), "SIGINT") => {}
+            () = watch_signal(SignalKind::terminate(), "SIGTERM") => {}
+        };
+    }
+
+    async fn watch_signal(kind: SignalKind, name: &'static str) {
+        signal(kind)
+            .expect("Failed to register signal handler")
+            .recv()
+            .await;
+        info!("received signal {}, starting shutdown", name,);
+    }
+}
+
+#[cfg(not(unix))]
+mod imp {
+    pub(super) async fn shutdown() {
+        // This isn't quite right, but close enough for windows...
+        tokio::signal::windows::ctrl_c()
+            .expect("Failed to register signal handler")
+            .recv()
+            .await;
+    }
+}

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,17 +1,64 @@
-/// Returns a `Future` that completes when the proxy should start to shutdown.
-pub async fn shutdown() {
-    imp::shutdown().await
+// #[async_trait::async_trait]
+// pub trait Shutdown {
+//     async fn shutdown();
+// }
+
+use tokio::sync::mpsc;
+
+pub struct Shutdown {
+    shutdown_tx: mpsc::Sender<()>,
+    shutdown_rx: mpsc::Receiver<()>,
+}
+
+impl Shutdown {
+    pub fn new() -> Self {
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        Shutdown {
+            shutdown_tx,
+            shutdown_rx,
+        }
+    }
+
+    /// Trigger returns a ShutdownTrigger which can be used to trigger a shutdown immediately
+    pub fn trigger(&self) -> ShutdownTrigger {
+        ShutdownTrigger {
+            shutdown_tx: self.shutdown_tx.clone(),
+        }
+    }
+
+    /// Wait completes when the shutdown as been triggered
+    pub async fn wait(mut self) {
+        imp::shutdown(&mut self.shutdown_rx).await
+    }
+}
+
+impl Default for Shutdown {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct ShutdownTrigger {
+    shutdown_tx: mpsc::Sender<()>,
+}
+
+impl ShutdownTrigger {
+    pub async fn shutdown_now(&self) {
+        self.shutdown_tx.send(()).await.unwrap();
+    }
 }
 
 #[cfg(unix)]
 mod imp {
     use tokio::signal::unix::{signal, SignalKind};
+    use tokio::sync::mpsc::Receiver;
     use tracing::info;
 
-    pub(super) async fn shutdown() {
+    pub(super) async fn shutdown(receiver: &mut Receiver<()>) {
         tokio::select! {
-            () = watch_signal(SignalKind::interrupt(), "SIGINT") => {}
-            () = watch_signal(SignalKind::terminate(), "SIGTERM") => {}
+            _ = watch_signal(SignalKind::interrupt(), "SIGINT") => {}
+            _ = watch_signal(SignalKind::terminate(), "SIGTERM") => {}
+            _ = receiver.recv() => { info!("received explicit shutdown signal")}
         };
     }
 
@@ -26,7 +73,9 @@ mod imp {
 
 #[cfg(not(unix))]
 mod imp {
-    pub(super) async fn shutdown() {
+    use tokio::sync::mpsc::Receiver;
+
+    pub(super) async fn shutdown(receiver: Receiver<()>) {
         // This isn't quite right, but close enough for windows...
         tokio::signal::windows::ctrl_c()
             .expect("Failed to register signal handler")

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,26 @@
+use tracing_subscriber::prelude::*;
+
+#[cfg(feature = "console")]
+pub fn setup_logging() {
+    let console_layer = console_subscriber::spawn();
+
+    let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new("info"))
+        .unwrap();
+    tracing_subscriber::registry()
+        .with(console_layer)
+        .with(filter_layer)
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+}
+
+#[cfg(not(feature = "console"))]
+pub fn setup_logging() {
+    let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new("info"))
+        .unwrap();
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+}

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,0 +1,5 @@
+use once_cell::sync::Lazy;
+use ztunnel::telemetry;
+
+// Ensure that the `tracing` stack is only initialised once using `once_cell`
+pub static TRACING: Lazy<()> = Lazy::new(telemetry::setup_logging);

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,0 +1,22 @@
+use helpers::*;
+use once_cell::sync::Lazy;
+use std::time::Duration;
+use tokio::time;
+use ztunnel::*;
+mod helpers;
+
+#[tokio::test]
+async fn test_lifecycle() {
+    Lazy::force(&TRACING);
+    let config = config::Config {
+        ..Default::default()
+    };
+    let shutdown = signal::Shutdown::new();
+
+    shutdown.trigger().shutdown_now().await;
+
+    time::timeout(Duration::from_secs(1), app::spawn(shutdown, config))
+        .await
+        .expect("app shuts down")
+        .expect("app exits without error")
+}


### PR DESCRIPTION
Currently the proxy just runs forever on SIGTERM. This makes it exit, and puts some *very basic* graceful draining in place.