### PR TITLE
outbound: pick random upstream instead of first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "rand",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ hyper-boring = { version= "2.1.2", features = ['fips'] }
 anyhow = "1.0.65"
 serde_yaml = "0.9.13"
 async-trait = "0.1.58"
+rand = "0.8.5"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -1,3 +1,4 @@
+use rand::prelude::IteratorRandom;
 use std::collections::{HashMap, HashSet};
 use std::convert::Into;
 use std::net::{IpAddr, SocketAddr};
@@ -352,7 +353,9 @@ impl WorkloadStore {
 
     fn find_upstream(&self, addr: SocketAddr) -> (Upstream, bool) {
         if let Some(upstream) = self.vips.get(&addr) {
-            let us: &Upstream = upstream.iter().next().unwrap();
+            // Randomly pick an upstream
+            // TODO: do this more efficiently, and not just randomly
+            let us: &Upstream = upstream.iter().choose(&mut rand::thread_rng()).unwrap();
             // TODO: avoid clone
             let mut us: Upstream = us.clone();
             Self::set_gateway_ip(&mut us);


### PR DESCRIPTION
This is not a proper load balancing solution, but a quick stop-gap to get us reasonable behavior, rather than always sending to 1 pod for Services.