### PR TITLE
performance: set TCP_NODELAY and increase copy buffer

### DIFF
--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -55,12 +55,12 @@ impl Inbound {
                     cert_manager: self.cert_manager.clone(),
                 },
             };
+            let mut listener = hyper::server::conn::AddrIncoming::from_listener(self.listener)
+                .expect("hbone bind");
+            listener.set_nodelay(true);
             let incoming = hyper::server::accept::from_stream(
                 tls_listener::builder(boring_acceptor)
-                    .listen(
-                        hyper::server::conn::AddrIncoming::from_listener(self.listener)
-                            .expect("hbone bind"),
-                    )
+                    .listen(listener)
                     .filter(|conn| {
                         // Avoid 'By default, if a client fails the TLS handshake, that is treated as an error, and the TlsListener will return an Err'
                         if let Err(err) = conn {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -79,6 +79,9 @@ pub enum Error {
     Identity(#[from] identity::Error),
 }
 
+// TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
+const HBONE_BUFFER_SIZE: usize = 16_384 - 64;
+
 pub async fn copy_hbone(
     desc: &str,
     upgraded: &mut hyper::upgrade::Upgraded,
@@ -89,6 +92,8 @@ pub async fn copy_hbone(
     let (mut ro, mut wo) = stream.split();
 
     let client_to_server = async {
+        let mut ri = tokio::io::BufReader::with_capacity(HBONE_BUFFER_SIZE, &mut ri);
+        let mut wo = tokio::io::BufWriter::with_capacity(HBONE_BUFFER_SIZE, &mut wo);
         let res = tokio::io::copy(&mut ri, &mut wo).await;
         info!(?res, ?desc, "hbone -> tcp");
         res.expect("");
@@ -96,6 +101,8 @@ pub async fn copy_hbone(
     };
 
     let server_to_client = async {
+        let mut ro = tokio::io::BufReader::with_capacity(HBONE_BUFFER_SIZE, &mut ro);
+        let mut wi = tokio::io::BufWriter::with_capacity(HBONE_BUFFER_SIZE, &mut wi);
         let res = tokio::io::copy(&mut ro, &mut wi).await;
         info!(?res, ?desc, "tcp -> hbone");
         wi.shutdown().await


### PR DESCRIPTION
io::copy default buffer is 8k, we see increased performance with a more precise 16k buffer.

Results:

Throughput Gb/s
buffer nodelay: 7
nodelay: 4.5
neither: 3.5

Latency p50,p90,p99
buffer nodelay: 0.17ms  0.21ms  0.32ms
nodelay:  0.17ms  0.22ms  0.46ms
neither: 0.17ms  0.22ms  0.54ms

("Neither" is before, "buffer nodelay" is this PR)