### PR TITLE
Implement to configure the Tokio worker threads number

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,12 @@ pub struct Config {
     pub auth: identity::AuthSource,
 
     pub termination_grace_period: time::Duration,
+
+    /// Specify the number of worker threads the Tokio Runtime will use.
+    pub num_worker_threads: usize,
 }
+
+const DEFAULT_WOKRER_THREADS: usize = 2;
 
 impl Default for Config {
     fn default() -> Config {
@@ -53,6 +58,16 @@ impl Default for Config {
             auth: identity::AuthSource::Token(PathBuf::from(
                 r"./var/run/secrets/tokens/istio-token",
             )),
+
+            num_worker_threads: std::env::var("ZTUNNEL_WOKRER_THREADS")
+                .ok()
+                .map(|v| {
+                    v.parse::<usize>()
+                        .ok()
+                        .filter(|n| *n > 0)
+                        .unwrap_or(DEFAULT_WOKRER_THREADS)
+                })
+                .unwrap_or(DEFAULT_WOKRER_THREADS),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use ztunnel::*;
 // #[global_allocator]
 // static GLOBAL: tcmalloc::TCMalloc = tcmalloc::TCMalloc;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     telemetry::setup_logging();
     let config = ztunnel::config::Config {
         ..Default::default()
@@ -21,7 +21,5 @@ fn main() {
         .enable_all()
         .build()
         .unwrap()
-        .block_on(async move {
-            let _ = app::spawn(signal::Shutdown::new(), config).await;
-        });
+        .block_on(async move { app::spawn(signal::Shutdown::new(), config).await })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,18 @@ use ztunnel::*;
 // #[global_allocator]
 // static GLOBAL: tcmalloc::TCMalloc = tcmalloc::TCMalloc;
 
-#[tokio::main(worker_threads = 2)]
-async fn main() -> anyhow::Result<()> {
+fn main() {
     telemetry::setup_logging();
     let config = ztunnel::config::Config {
         ..Default::default()
     };
-    app::spawn(signal::Shutdown::new(), config).await
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(config.num_worker_threads)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async move {
+            let _ = app::spawn(signal::Shutdown::new(), config).await;
+        });
 }


### PR DESCRIPTION
Builds Tokio Runtime with custom configuration values, instead of fixed setting by macro '#[tokio::main]'.

Since the ztunnel works on node level, the workloads will be heavy, add one environment variable for tuning the Tokio worker threads number.

Use 'istioctl --set values.ztunnel.env.ZTUNNEL_WOKRER_THREADS=5' to set worker threads if needed, and default value is 2.

Signed-off-by: Haiyue Wang <haiyue.wang@intel.com>