### PR TITLE
verify certs/sans on outbound

### DIFF
--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -71,7 +71,10 @@ impl CaClient {
         Ok(tls::cert_from(
             &pkey,
             resp.cert_chain.first().unwrap().as_bytes(),
-            resp.cert_chain[1..].into_iter().map(|s| s.as_bytes()).collect(),
+            resp.cert_chain[1..]
+                .into_iter()
+                .map(|s| s.as_bytes())
+                .collect(),
         ))
     }
 }

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -66,15 +66,17 @@ impl CaClient {
                 )]),
             }),
         };
-        let resp = self.client.create_certificate(req).await?;
-        let resp = resp.into_inner();
-        Ok(tls::cert_from(
-            &pkey,
-            resp.cert_chain.first().unwrap().as_bytes(),
+        let resp = self.client.create_certificate(req).await?.into_inner();
+
+        let leaf = resp.cert_chain.first().unwrap().as_bytes();
+        let chain = if resp.cert_chain.len() > 1 {
             resp.cert_chain[1..]
                 .into_iter()
                 .map(|s| s.as_bytes())
-                .collect(),
-        ))
+                .collect()
+        } else {
+            vec![]
+        };
+        Ok(tls::cert_from(&pkey, leaf, chain))
     }
 }

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -45,7 +45,7 @@ impl CaClient {
     }
 
     #[instrument(skip_all)]
-    pub async fn fetch_certificate(&mut self, id: Identity) -> Result<tls::Certs, Error> {
+    pub async fn fetch_certificate(&mut self, id: &Identity) -> Result<tls::Certs, Error> {
         let cs = tls::CsrOptions {
             san: id.to_string(),
         }

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -71,6 +71,7 @@ impl CaClient {
         Ok(tls::cert_from(
             &pkey,
             resp.cert_chain.first().unwrap().as_bytes(),
+            resp.cert_chain[1..].into_iter().map(|s| s.as_bytes()).collect(),
         ))
     }
 }

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -70,10 +70,7 @@ impl CaClient {
 
         let leaf = resp.cert_chain.first().unwrap().as_bytes();
         let chain = if resp.cert_chain.len() > 1 {
-            resp.cert_chain[1..]
-                .into_iter()
-                .map(|s| s.as_bytes())
-                .collect()
+            resp.cert_chain[1..].iter().map(|s| s.as_bytes()).collect()
         } else {
             vec![]
         };

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -55,7 +55,7 @@ impl SecretManager {
     }
 
     #[instrument(skip_all, fields(%id))]
-    pub async fn fetch_certificate(&self, id: Identity) -> Result<tls::Certs, Error> {
+    pub async fn fetch_certificate(&self, id: &Identity) -> Result<tls::Certs, Error> {
         self.client.clone().fetch_certificate(id).await
     }
 }

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -186,7 +186,7 @@ impl crate::tls::CertProvider for InboundCertProvider {
                 .identity()
         };
         info!("tls: accepting connection to {:?} ({})", orig, identity);
-        let cert = self.cert_manager.fetch_certificate(identity).await?;
+        let cert = self.cert_manager.fetch_certificate(&identity).await?;
         let acc = cert.acceptor()?;
         Ok(acc)
     }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -150,7 +150,7 @@ impl OutboundConnection {
                 let mut request_sender = if self.cfg.tls {
                     let id = req.source.identity();
                     let cert = self.cert_manager.fetch_certificate(&id).await?;
-                    let connector = cert.connector(&id)?.configure()?;
+                    let connector = cert.connector(&req.destination_identity)?.configure()?;
                     let tcp_stream = TcpStream::connect(req.gateway).await?;
                     let tls_stream = connect_tls(connector, tcp_stream).await?;
                     let (request_sender, connection) = builder
@@ -338,9 +338,9 @@ struct Request {
     direction: Direction,
     source: Workload,
     destination: SocketAddr,
+    destination_identity: Option<identity::Identity>,
     gateway: SocketAddr,
     request_type: RequestType,
-    destination_identity: Option<identity::Identity>,
 }
 
 #[derive(Debug)]

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -149,8 +149,8 @@ impl OutboundConnection {
 
                 let mut request_sender = if self.cfg.tls {
                     let id = req.source.identity();
-                    let cert = self.cert_manager.fetch_certificate(id.clone()).await?;
-                    let connector = cert.connector(id)?.configure()?;
+                    let cert = self.cert_manager.fetch_certificate(&id).await?;
+                    let connector = cert.connector(&id)?.configure()?;
                     let tcp_stream = TcpStream::connect(req.gateway).await?;
                     let tls_stream = connect_tls(connector, tcp_stream).await?;
                     let (request_sender, connection) = builder
@@ -359,15 +359,6 @@ async fn connect_tls(
 ) -> Result<tokio_boring::SslStream<TcpStream>, tokio_boring::HandshakeError<TcpStream>> {
     connector.set_verify_hostname(false);
     connector.set_use_server_name_indication(false);
-    // let addr = stream.local_addr();
-    // let verify_mode = {
-    //     use boring::ssl::SslVerifyMode;
-    //     SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT
-    // };
-    // connector.set_verify_callback(verify_mode, move |_, x509| {
-    //     info!("TLS callback for {:?}: {:?}", addr, x509.error());
-    //     true
-    // });
     tokio_boring::connect(connector, "", stream).await
 }
 

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -209,7 +209,7 @@ impl Verifier {
 
         // internally, openssl tends to .expect the results of these methods.
         // TODO bubble up better error message
-        let ssl_idx = X509StoreContext::ssl_idx().map_err(|e| Error::SslError(e))?;
+        let ssl_idx = X509StoreContext::ssl_idx().map_err(Error::SslError)?;
         let cert = ctx
             .ex_data(ssl_idx)
             .ok_or(TlsError::SanError)?
@@ -218,7 +218,7 @@ impl Verifier {
 
         let want_san = format!("{identity}");
         cert.subject_alt_names()
-            .unwrap_or(boring::stack::Stack::<GeneralName>::new().map_err(|e| Error::SslError(e))?)
+            .unwrap_or(boring::stack::Stack::<GeneralName>::new().map_err(Error::SslError)?)
             .iter()
             .find(|san| san.uri().unwrap_or("<non-uri>") == want_san)
             .ok_or(TlsError::SanError)


### PR DESCRIPTION
This is the result of a short bit of hacking around and getting familiar with boringssl, needs to be reorganized and cleaned up a lot. 

A couple of mysteries:


The first request will always log this failure (but the request succeeds)

```
2022-11-14T18:56:32.873206Z  INFO ztunnel::proxy::outbound: Proxying to 127.0.0.1:8080 using HBONE via 127.0.0.1:15008 type Direct
2022-11-14T18:56:32.875826Z  INFO fetch_certificate{id=spiffe://cluster.local/ns/default/sa/default}:fetch_certificate: ztunnel::tls::boring: ssl: X509VerifyResult { code: 20, error: "unable to get local issuer certificate" }
2022-11-14T18:56:32.875869Z  INFO fetch_certificate{id=spiffe://cluster.local/ns/default/sa/default}:fetch_certificate: ztunnel::tls::boring: ssl: X509VerifyResult { code: 21, error: "unable to verify the first certificate" }
2022-11-14T18:56:32.930733Z  INFO ztunnel::proxy::inbound: tls: accepting connection to 127.0.0.1:15008 (spiffe://cluster.local/ns/default/sa/default)
```

This log from the tls verify callback is always printed twice per request:

```
2022-11-14T18:56:50.053081Z  INFO ztunnel::proxy::inbound: tls: accepting connection to 127.0.0.1:15008 (spiffe://cluster.local/ns/default/sa/default)
2022-11-14T18:56:50.106757Z  INFO ztunnel::tls::boring: verified SAN spiffe://cluster.local/ns/default/sa/default
2022-11-14T18:56:50.106858Z  INFO ztunnel::tls::boring: verified SAN spiffe://cluster.local/ns/default/sa/default
```