### PR TITLE
Add version subcommand to report version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1246,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -1903,6 +1918,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "rand",
+ "rustc_version",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tryhard = "0.5.0"
 tonic-build = "0.8"
 prost-build = "0.11"
 anyhow = "1.0.65"
+rustc_version = "0.4.0"
 
 [profile.release]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod signal;
 pub mod socket;
 pub mod telemetry;
 pub mod tls;
+pub mod version;
 pub mod workload;
 pub mod xds;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,14 +12,32 @@ use ztunnel::*;
 
 fn main() -> anyhow::Result<()> {
     telemetry::setup_logging();
-    let config = ztunnel::config::Config {
-        ..Default::default()
-    };
-
+    let config: config::Config = Default::default();
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(config.num_worker_threads)
         .enable_all()
         .build()
         .unwrap()
-        .block_on(async move { app::spawn(signal::Shutdown::new(), config).await })
+        .block_on(async move { run(config).await })
+}
+
+async fn run(cfg: config::Config) -> anyhow::Result<()> {
+    // For now we don't need a complex CLI, so rather than pull in dependencies just use basic argv[1]
+    match std::env::args().nth(1).as_deref() {
+        None | Some("proxy") => proxy(cfg).await,
+        Some("version") => version().await,
+        Some(unknown) => {
+            eprintln!("unknown command: {unknown}");
+            std::process::exit(1)
+        }
+    }
+}
+
+async fn version() -> anyhow::Result<()> {
+    println!("{}", version::BuildInfo::new());
+    Ok(())
+}
+
+async fn proxy(cfg: config::Config) -> anyhow::Result<()> {
+    app::spawn(signal::Shutdown::new(), cfg).await
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,38 @@
+use std::env;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::string::String;
+
+const BUILD_VERSION: &str = env!("ZTUNNEL_BUILD_buildVersion");
+const BUILD_GIT_REVISION: &str = env!("ZTUNNEL_BUILD_buildGitRevision");
+const BUILD_STATUS: &str = env!("ZTUNNEL_BUILD_buildStatus");
+const BUILD_TAG: &str = env!("ZTUNNEL_BUILD_buildTag");
+const BUILD_RUST_VERSION: &str = env!("ZTUNNEL_BUILD_RUSTC_VERSION");
+
+#[derive(Clone, Debug, Default)]
+pub struct BuildInfo {
+    version: String,
+    git_revision: String,
+    rust_version: String,
+    build_status: String,
+    git_tag: String,
+}
+
+impl BuildInfo {
+    pub fn new() -> Self {
+        BuildInfo {
+            version: BUILD_VERSION.to_string(),
+            git_revision: BUILD_GIT_REVISION.to_string(),
+            rust_version: BUILD_RUST_VERSION.to_string(),
+            build_status: BUILD_STATUS.to_string(),
+            git_tag: BUILD_TAG.to_string(),
+        }
+    }
+}
+
+impl Display for BuildInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "version.BuildInfo{{Version:\"{}\", GitRevision:\"{}\", RustVersion:\"{}\", BuildStatus:\"{}\", GitTag:\"{}\"}}",
+        self.version, self.git_revision, self.rust_version, self.build_status, self.git_tag)
+    }
+}


### PR DESCRIPTION
This mirrors the logic in Go binaries

example:

```
$ cargo run version
version.BuildInfo{Version:"6463977f8a47172a2aa2f6f6c2b2e6e485f7f90b-dirty", GitRevision:"6463977f8a47172a2aa2f6f6c2b2e6e485f7f90b-dirty", RustVersion:"1.65.0", BuildStatus:"Modified", GitTag:"6463977"}
```