### PR TITLE
outbound: improve tests and error handling

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -89,6 +89,9 @@ pub enum Error {
 
     #[error("identity error: {0}")]
     Identity(#[from] identity::Error),
+
+    #[error("unknown source: {0}")]
+    UnknownSource(IpAddr),
 }
 
 // TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.


### PR DESCRIPTION
Follow up to https://github.com/istio/ztunnel/pull/125

This allows us to see test results per-testcase like in Go, and keeps the full test case isolated to 1 place.