### PR TITLE
Integ test: improve coverage and remove sleep

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,10 +12,86 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{admin, config, identity, proxy, signal, workload};
+use std::net::SocketAddr;
 use tokio::task::JoinHandle;
 use tokio::time;
 use tracing::{error, info, warn};
+
+use crate::{admin, config, identity, proxy, signal, workload};
+
+pub async fn build(shutdown: signal::Shutdown, config: config::Config) -> anyhow::Result<Bound> {
+    // Setup a drain channel. drain_tx is used to trigger a drain, which will complete
+    // once all drain_rx handlers are dropped.
+    // Any component which wants time to gracefully exit should take in a drain_rx clone, await drain_rx.signaled(), then cleanup.
+    // Note: there is still a hard timeout if the draining takes too long
+    let (drain_tx, drain_rx) = drain::channel();
+
+    let mut tasks: Vec<JoinHandle<()>> = Vec::new();
+
+    let workload_manager = workload::WorkloadManager::new(config.clone());
+
+    let admin = admin::Builder::new(config.clone(), workload_manager.workloads())
+        .set_ready()
+        .bind()
+        .expect("admin server starts");
+    let admin_address = admin.address();
+    admin.spawn(&shutdown, drain_rx.clone());
+
+    let secrets = identity::SecretManager::new(config.clone());
+    let proxy = proxy::Proxy::new(
+        config.clone(),
+        workload_manager.workloads(),
+        secrets,
+        drain_rx.clone(),
+    )
+    .await?;
+
+    tasks.push(tokio::spawn(async move {
+        if let Err(e) = workload_manager.run().await {
+            error!("workload manager: {}", e);
+        }
+    }));
+    tasks.push(tokio::spawn(proxy.run()));
+
+    Ok(Bound {
+        drain_tx,
+        config,
+        shutdown,
+        admin_address,
+        tasks,
+    })
+}
+
+pub struct Bound {
+    pub admin_address: SocketAddr,
+    tasks: Vec<JoinHandle<()>>,
+    shutdown: signal::Shutdown,
+    config: config::Config,
+    drain_tx: drain::Signal,
+}
+
+impl Bound {
+    pub async fn spawn(self) -> anyhow::Result<()> {
+        tokio::spawn(async move {
+            futures::future::join_all(self.tasks).await;
+        });
+
+        // Wait for a signal to shutdown from explicit admin shutdown or signal
+        self.shutdown.wait().await;
+
+        // Start a drain; this will wait for all drain_rx handles to be dropped before completing,
+        // allowing components to terminate.
+        // If they take too long, terminate anyways.
+        match time::timeout(self.config.termination_grace_period, self.drain_tx.drain()).await {
+            Ok(()) => info!("Shutdown completed gracefully"),
+            Err(_) => warn!(
+                "Graceful shutdown did not complete in {:?}, terminating now",
+                self.config.termination_grace_period
+            ),
+        }
+        Ok(())
+    }
+}
 
 pub async fn spawn(shutdown: signal::Shutdown, config: config::Config) -> anyhow::Result<()> {
     // Setup a drain channel. drain_tx is used to trigger a drain, which will complete
@@ -27,14 +103,14 @@ pub async fn spawn(shutdown: signal::Shutdown, config: config::Config) -> anyhow
     let workload_manager = workload::WorkloadManager::new(config.clone());
 
     let workloads = workload_manager.workloads();
-    admin::Builder::new(workloads)
+    admin::Builder::new(config.clone(), workloads)
         .set_ready()
         .bind()
         .expect("admin server starts")
-        .spawn(&shutdown);
+        .spawn(&shutdown, drain_rx.clone());
     let workloads = workload_manager.workloads();
     let secrets = identity::SecretManager::new(config.clone());
-    let proxy = proxy::Proxy::new(config.clone(), workloads, secrets, drain_rx).await?;
+    let proxy = proxy::Proxy::new(config.clone(), workloads, secrets, drain_rx.clone()).await?;
     tasks.push(tokio::spawn(async move {
         if let Err(e) = workload_manager.run().await {
             error!("workload manager: {}", e);
@@ -46,6 +122,7 @@ pub async fn spawn(shutdown: signal::Shutdown, config: config::Config) -> anyhow
         futures::future::join_all(tasks).await;
     });
 
+    drop(drain_rx);
     // Wait for a signal to shutdown
     // There is an explicit way to trigger this from admin server
     shutdown.wait().await;

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,7 +19,8 @@ use tracing::{error, info, warn};
 
 use crate::{admin, config, identity, proxy, signal, workload};
 
-pub async fn build(shutdown: signal::Shutdown, config: config::Config) -> anyhow::Result<Bound> {
+pub async fn build(config: config::Config) -> anyhow::Result<Bound> {
+    let shutdown = signal::Shutdown::new();
     // Setup a drain channel. drain_tx is used to trigger a drain, which will complete
     // once all drain_rx handlers are dropped.
     // Any component which wants time to gracefully exit should take in a drain_rx clone, await drain_rx.signaled(), then cleanup.
@@ -64,8 +65,8 @@ pub async fn build(shutdown: signal::Shutdown, config: config::Config) -> anyhow
 
 pub struct Bound {
     pub admin_address: SocketAddr,
+    pub shutdown: signal::Shutdown,
     tasks: Vec<JoinHandle<()>>,
-    shutdown: signal::Shutdown,
     config: config::Config,
     drain_tx: drain::Signal,
 }
@@ -91,51 +92,4 @@ impl Bound {
         }
         Ok(())
     }
-}
-
-pub async fn spawn(shutdown: signal::Shutdown, config: config::Config) -> anyhow::Result<()> {
-    // Setup a drain channel. drain_tx is used to trigger a drain, which will complete
-    // once all drain_rx handlers are dropped.
-    // Any component which wants time to gracefully exit should take in a drain_rx clone, await drain_rx.signaled(), then cleanup.
-    // Note: there is still a hard timeout if the draining takes too long
-    let (drain_tx, drain_rx) = drain::channel();
-    let mut tasks: Vec<JoinHandle<()>> = Vec::new();
-    let workload_manager = workload::WorkloadManager::new(config.clone());
-
-    let workloads = workload_manager.workloads();
-    admin::Builder::new(config.clone(), workloads)
-        .set_ready()
-        .bind()
-        .expect("admin server starts")
-        .spawn(&shutdown, drain_rx.clone());
-    let workloads = workload_manager.workloads();
-    let secrets = identity::SecretManager::new(config.clone());
-    let proxy = proxy::Proxy::new(config.clone(), workloads, secrets, drain_rx.clone()).await?;
-    tasks.push(tokio::spawn(async move {
-        if let Err(e) = workload_manager.run().await {
-            error!("workload manager: {}", e);
-        }
-    }));
-    tasks.push(tokio::spawn(proxy.run()));
-
-    tokio::spawn(async move {
-        futures::future::join_all(tasks).await;
-    });
-
-    drop(drain_rx);
-    // Wait for a signal to shutdown
-    // There is an explicit way to trigger this from admin server
-    shutdown.wait().await;
-
-    // Start a drain; this will wait for all drain_rx handles to be dropped before completing,
-    // allowing components to terminate.
-    // If they take too long, terminate anyways.
-    match time::timeout(config.termination_grace_period, drain_tx.drain()).await {
-        Ok(()) => info!("Shutdown completed gracefully"),
-        Err(_) => warn!(
-            "Graceful shutdown did not complete in {:?}, terminating now",
-            config.termination_grace_period
-        ),
-    }
-    Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub connection_window_size: u32,
     pub frame_size: u32,
 
+    pub admin_addr: SocketAddr,
     pub inbound_addr: SocketAddr,
     pub inbound_plaintext_addr: SocketAddr,
     pub outbound_addr: SocketAddr,
@@ -58,6 +59,7 @@ impl Default for Config {
 
             termination_grace_period: Duration::from_secs(5),
 
+            admin_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15021),
             inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15008),
             inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15006),
             outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15001),

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub connection_window_size: u32,
     pub frame_size: u32,
 
+    pub socks5_addr: SocketAddr,
     pub admin_addr: SocketAddr,
     pub inbound_addr: SocketAddr,
     pub inbound_plaintext_addr: SocketAddr,
@@ -60,6 +61,7 @@ impl Default for Config {
             termination_grace_period: Duration::from_secs(5),
 
             admin_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15021),
+            socks5_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15080),
             inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15008),
             inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15006),
             outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15001),

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,5 +53,5 @@ async fn version() -> anyhow::Result<()> {
 }
 
 async fn proxy(cfg: config::Config) -> anyhow::Result<()> {
-    app::spawn(signal::Shutdown::new(), cfg).await
+    app::build(cfg).await?.spawn().await
 }

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -43,7 +43,7 @@ impl Inbound {
     ) -> Result<Inbound, Error> {
         let listener: TcpListener = TcpListener::bind(cfg.inbound_addr)
             .await
-            .map_err(Error::Bind)?;
+            .map_err(|e| Error::Bind(cfg.inbound_addr, e))?;
         match crate::socket::set_transparent(&listener) {
             Err(_e) => info!("running without transparent mode"),
             _ => info!("running with transparent mode"),

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -81,7 +81,7 @@ impl Proxy {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("failed to bind to address: {0}")]
-    Bind(#[source] io::Error),
+    Bind(SocketAddr, io::Error),
 
     #[error("io error: {0}")]
     Io(#[from] io::Error),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -41,7 +41,7 @@ impl Outbound {
     ) -> Result<Outbound, Error> {
         let listener: TcpListener = TcpListener::bind(cfg.outbound_addr)
             .await
-            .map_err(Error::Bind)?;
+            .map_err(|e| Error::Bind(cfg.outbound_addr, e))?;
         match socket::set_transparent(&listener) {
             Err(_e) => info!("running without transparent mode"),
             _ => info!("running with transparent mode"),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -57,7 +57,8 @@ impl Outbound {
     }
 
     pub(super) async fn run(self) {
-        info!("outbound listener established {}", self.cfg.outbound_addr);
+        let addr = self.listener.local_addr().unwrap();
+        info!("outbound listener established {}", addr);
 
         let accept = async move {
             loop {

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -24,9 +24,9 @@ impl Socks5 {
         cert_manager: identity::SecretManager,
         workloads: WorkloadInformation,
     ) -> Result<Socks5, Error> {
-        let listener: TcpListener = TcpListener::bind("127.0.0.1:15080")
+        let listener: TcpListener = TcpListener::bind(cfg.socks5_addr)
             .await
-            .map_err(Error::Bind)?;
+            .map_err(|e| Error::Bind(cfg.socks5_addr, e))?;
 
         Ok(Socks5 {
             cfg,

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -38,7 +38,7 @@ impl Socks5 {
 
     pub async fn run(self) {
         let addr = self.listener.local_addr().unwrap();
-        info!("outbound listener established {}", addr);
+        info!("socks5 listener established {}", addr);
 
         loop {
             // Asynchronously wait for an inbound socket.

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -108,7 +108,7 @@ impl TestApp {
             .body(Body::default())
             .unwrap();
         let client = Client::new();
-        client.request(req).await.unwrap()
+        client.request(req).await.expect("admin request")
     }
 }
 
@@ -121,6 +121,6 @@ async fn admin_shutdown(addr: SocketAddr) {
         .body(Body::default())
         .unwrap();
     let client = Client::new();
-    let resp = client.request(req).await;
-    assert_eq!(resp.unwrap().status(), hyper::StatusCode::OK);
+    let resp = client.request(req).await.expect("admin shutdown request");
+    assert_eq!(resp.status(), hyper::StatusCode::OK);
 }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -103,7 +103,10 @@ impl TestApp {
     async fn admin_request(&self, path: &str) -> Response<Body> {
         let req = Request::builder()
             .method(Method::GET)
-            .uri(format!("http://localhost:{}/{path}", self.admin_address.port()))
+            .uri(format!(
+                "http://localhost:{}/{path}",
+                self.admin_address.port()
+            ))
             .header("content-type", "application/json")
             .body(Body::default())
             .unwrap();

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -103,7 +103,7 @@ impl TestApp {
     async fn admin_request(&self, path: &str) -> Response<Body> {
         let req = Request::builder()
             .method(Method::GET)
-            .uri(format!("http://{}/{path}", self.admin_address))
+            .uri(format!("http://localhost:{}/{path}", self.admin_address.port()))
             .header("content-type", "application/json")
             .body(Body::default())
             .unwrap();
@@ -116,7 +116,7 @@ impl TestApp {
 async fn admin_shutdown(addr: SocketAddr) {
     let req = Request::builder()
         .method(Method::POST)
-        .uri(format!("http://{}/quitquitquit", addr))
+        .uri(format!("http://localhost:{}/quitquitquit", addr.port()))
         .header("content-type", "application/json")
         .body(Body::default())
         .unwrap();

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -26,6 +26,7 @@ mod helpers;
 
 fn test_config() -> config::Config {
     config::Config {
+        socks5_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         admin_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -12,27 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use helpers::*;
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+
+use std::time::Duration;
 use hyper::{Body, Client, Method, Request};
 use once_cell::sync::Lazy;
-use std::thread;
-use std::time::Duration;
 use tokio::time;
-use tracing::warn;
+use tracing::info;
+
+use helpers::*;
 use ztunnel::*;
+
 mod helpers;
+
+fn test_config() -> config::Config {
+    config::Config {
+        inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+        admin_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+        outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+        inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+        ..Default::default()
+    }
+}
 
 #[tokio::test]
 async fn test_lifecycle() {
     Lazy::force(&TRACING);
-    let config = config::Config {
-        ..Default::default()
-    };
     let shutdown = signal::Shutdown::new();
 
     shutdown.trigger().shutdown_now().await;
 
-    time::timeout(Duration::from_secs(1), app::spawn(shutdown, config))
+    time::timeout(Duration::from_secs(1), app::spawn(shutdown, test_config()))
         .await
         .expect("app shuts down")
         .expect("app exits without error")
@@ -40,30 +50,29 @@ async fn test_lifecycle() {
 
 #[tokio::test]
 async fn test_quit_lifecycle() {
-    // need to wait for the previous test release the port resource
-    thread::sleep(Duration::from_secs(1));
     Lazy::force(&TRACING);
-    let config = config::Config {
-        ..Default::default()
-    };
 
     let shutdown = signal::Shutdown::new();
-    time::timeout(Duration::from_secs(1), app::spawn(shutdown, config))
-        .await
-        .ok();
+    let app = app::build(shutdown, test_config()).await.unwrap();
+    let addr = app.admin_address;
+    info!("address {addr}");
+    let (app, _shutdown) = tokio::join!(
+        time::timeout(Duration::from_secs(1), app.spawn()),
+        admin_shutdown(addr)
+    );
+    app.expect("app shuts down")
+        .expect("app exits without error");
+}
 
-    thread::sleep(Duration::from_secs(1));
-
+#[track_caller]
+async fn admin_shutdown(addr: SocketAddr) {
     let req = Request::builder()
         .method(Method::POST)
-        .uri("http://localhost:15021/quitquitquit")
+        .uri(format!("http://{}/quitquitquit", addr))
         .header("content-type", "application/json")
         .body(Body::default())
         .unwrap();
     let client = Client::new();
     let resp = client.request(req).await;
-    match resp {
-        Ok(resbody) => assert_eq!(resbody.status(), hyper::StatusCode::OK),
-        Err(ref e) => warn!("request get error info: {}", e),
-    };
+    assert_eq!(resp.unwrap().status(), hyper::StatusCode::OK);
 }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use hyper::{Body, Client, Method, Request, Response};
+use once_cell::sync::Lazy;
 use std::future::Future;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
-use hyper::{Body, Client, Method, Request, Response};
-use once_cell::sync::Lazy;
 use tokio::time;
 
 use helpers::*;


### PR DESCRIPTION
This refactors the app to allow binding to port `0` and propogating the port back up to tests. This allows us to bind to random ports, making our tests better and remove sleeps. I also added a test for `/healthz/ready` to validate the abstraction