### PR TITLE
Initial full request end to end tests

### DIFF
--- a/examples/localhost.yaml
+++ b/examples/localhost.yaml
@@ -6,3 +6,10 @@
   workload_ip: "127.0.0.1"
   protocol: Hbone
   node: local
+# Define another local address, but this one uses TCP. This allows testing HBONE and TCP with one config.
+- name: local-tcp
+  namespace: default
+  service_account: default
+  workload_ip: "127.0.0.2"
+  protocol: Tcp
+  node: local

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -39,7 +39,7 @@ impl CaClient {
         } else {
             "https://localhost:15012"
         };
-        let svc = tls::grpc_connector(address).unwrap();
+        let svc = tls::grpc_connector(address.to_string()).unwrap();
         let client = IstioCertificateServiceClient::with_interceptor(svc, auth);
         CaClient { client }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,5 @@ pub mod tls;
 pub mod version;
 pub mod workload;
 pub mod xds;
+
+pub mod test_helpers;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -57,6 +57,10 @@ impl Inbound {
         })
     }
 
+    pub(super) fn address(&self) -> SocketAddr {
+        self.listener.local_addr().unwrap()
+    }
+
     pub(super) async fn run(self) {
         let addr = self.listener.local_addr().unwrap();
         if self.cfg.tls {

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -1,0 +1,100 @@
+use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use hyper::{Body, Client, Method, Request, Response};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use super::helpers::*;
+use crate::*;
+
+pub struct TestApp {
+    admin_address: SocketAddr,
+    proxy_addresses: proxy::Addresses,
+}
+
+pub async fn with_app<F, Fut, FO>(cfg: config::Config, f: F)
+where
+    F: Fn(TestApp) -> Fut,
+    Fut: Future<Output = FO>,
+{
+    initialize_telemetry();
+
+    let app = app::build(cfg).await.unwrap();
+    let shutdown = app.shutdown.trigger().clone();
+
+    let ta = TestApp {
+        admin_address: app.admin_address,
+        proxy_addresses: app.proxy_addresses,
+    };
+    let run_and_shutdown = async {
+        f(ta).await;
+        shutdown.shutdown_now().await;
+    };
+    let (app, _shutdown) = tokio::join!(app.spawn(), run_and_shutdown);
+    app.expect("app exits without error");
+}
+
+impl TestApp {
+    pub async fn admin_request(&self, path: &str) -> Response<Body> {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(format!(
+                "http://localhost:{}/{path}",
+                self.admin_address.port()
+            ))
+            .header("content-type", "application/json")
+            .body(Body::default())
+            .unwrap();
+        let client = Client::new();
+        client.request(req).await.expect("admin request")
+    }
+
+    pub async fn socks5_connect(&self, addr: SocketAddr) -> TcpStream {
+        // let addr = net::lookup_host(addr)
+        //     .await
+        //     .expect("must get localhost address")
+        //     .next()
+        //     .expect("must get at least one localhost address");
+        // Always use IPv4 address. In theory, we can resolve `localhost` to pick to support any machine
+        // However, we need to make sure the WorkloadStore knows about both families then.
+        let socks_addr = with_ip(
+            self.proxy_addresses.socks5,
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        );
+
+        let mut stream = TcpStream::connect(socks_addr).await.expect("must connect");
+
+        let addr_type = if addr.ip().is_ipv4() { 0x01u8 } else { 0x04u8 };
+        stream
+            .write_all(&[
+                0x05u8, // socks5
+                0x1u8,  // 1 auth method
+                0x0u8,  // unauthenticated auth method
+            ])
+            .await
+            .unwrap();
+        let mut auth = [0u8; 2];
+        stream.read_exact(&mut auth).await.unwrap();
+
+        let mut cmd = vec![
+            0x05u8, // socks5
+            0x1u8,  // establish tcp stream
+            0x0u8,  // RSV
+            addr_type,
+        ];
+        match proxy::to_canonical_ip(addr) {
+            IpAddr::V6(ip) => cmd.extend_from_slice(&ip.octets()),
+            IpAddr::V4(ip) => cmd.extend_from_slice(&ip.octets()),
+        };
+        cmd.extend_from_slice(&addr.port().to_be_bytes());
+        stream.write_all(&cmd).await.unwrap();
+
+        // We don't care about response but need to clear out the stream
+        let mut resp = [0u8; 10];
+        stream.read_exact(&mut resp).await.unwrap();
+
+        stream
+    }
+}

--- a/src/test_helpers/echo.rs
+++ b/src/test_helpers/echo.rs
@@ -1,0 +1,48 @@
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tracing::info;
+
+pub struct TestServer {
+    listener: TcpListener,
+}
+
+impl TestServer {
+    pub async fn new() -> TestServer {
+        let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0);
+        let listener = TcpListener::bind(addr).await.unwrap();
+        TestServer { listener }
+    }
+
+    pub fn address(&self) -> SocketAddr {
+        self.listener.local_addr().unwrap()
+    }
+
+    pub async fn run(self) {
+        loop {
+            let (mut socket, _) = self.listener.accept().await.unwrap();
+
+            tokio::spawn(async move {
+                let mut buf = vec![0; 1024];
+
+                // In a loop, read data from the socket and write the data back.
+                loop {
+                    let n = socket
+                        .read(&mut buf)
+                        .await
+                        .expect("failed to read data from socket");
+
+                    info!("echo received {n}: {:?}", &buf[0..n]);
+                    if n == 0 {
+                        return;
+                    }
+
+                    socket
+                        .write_all(&buf[0..n])
+                        .await
+                        .expect("failed to write data to socket");
+                }
+            });
+        }
+    }
+}

--- a/src/test_helpers/helpers.rs
+++ b/src/test_helpers/helpers.rs
@@ -12,8 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::telemetry;
 use once_cell::sync::Lazy;
-use ztunnel::telemetry;
+use std::net::{IpAddr, SocketAddr};
 
 // Ensure that the `tracing` stack is only initialised once using `once_cell`
-pub static TRACING: Lazy<()> = Lazy::new(telemetry::setup_logging);
+static TRACING: Lazy<()> = Lazy::new(telemetry::setup_logging);
+
+pub fn initialize_telemetry() {
+    Lazy::force(&TRACING);
+}
+
+pub fn with_ip(s: SocketAddr, ip: IpAddr) -> SocketAddr {
+    SocketAddr::new(ip, s.port())
+}

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -1,0 +1,3 @@
+pub mod app;
+pub mod echo;
+pub mod helpers;

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -103,7 +103,7 @@ pub struct TlsGrpcChannel {
 }
 
 /// grpc_connector provides a client TLS channel for gRPC requests.
-pub fn grpc_connector(uri: &'static str) -> Result<TlsGrpcChannel, Error> {
+pub fn grpc_connector(uri: String) -> Result<TlsGrpcChannel, Error> {
     let mut conn = ssl::SslConnector::builder(ssl::SslMethod::tls_client())?;
 
     conn.set_verify(ssl::SslVerifyMode::NONE);
@@ -129,7 +129,7 @@ pub fn grpc_connector(uri: &'static str) -> Result<TlsGrpcChannel, Error> {
     // correct https connector.
     let hyper = hyper::Client::builder().http2_only(true).build(https);
 
-    let uri = Uri::from_static(uri);
+    let uri = Uri::try_from(uri)?;
 
     Ok(TlsGrpcChannel { uri, client: hyper })
 }

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -24,5 +24,5 @@ pub enum Error {
     SslError(#[from] ErrorStack),
 
     #[error("invalid uri: {0}")]
-    InvalidUri(#[from] InvalidUri)
+    InvalidUri(#[from] InvalidUri),
 }

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -16,9 +16,13 @@ pub mod boring;
 
 pub use crate::tls::boring::*;
 use ::boring::error::ErrorStack;
+use hyper::http::uri::InvalidUri;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("invalid operation: {0}")]
     SslError(#[from] ErrorStack),
+
+    #[error("invalid uri: {0}")]
+    InvalidUri(#[from] InvalidUri)
 }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{fmt, net};
 use std::collections::{HashMap, HashSet};
 use std::convert::Into;
 use std::net::{IpAddr, SocketAddr};
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
-use std::{fmt, net};
 
 use futures::future::TryFutureExt;
 use rand::prelude::IteratorRandom;
@@ -26,10 +26,10 @@ use tracing::{debug, error, info, warn};
 
 use xds::istio::workload::Workload as XdsWorkload;
 
+use crate::{config, xds};
 use crate::identity::Identity;
 use crate::workload::WorkloadError::ProtocolParse;
-use crate::xds::{Demander, HandlerContext, XdsUpdate};
-use crate::{config, xds};
+use crate::xds::{AdsClient, Demander, HandlerContext, XdsUpdate};
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum Protocol {
@@ -203,8 +203,8 @@ impl TryFrom<&XdsWorkload> for Workload {
 
 pub struct WorkloadManager {
     workloads: WorkloadInformation,
-    xds_client: xds::AdsClient,
-    local_client: LocalClient,
+    xds_client: Option<xds::AdsClient>,
+    local_client: Option<LocalClient>,
 }
 
 fn handle_xds<F: FnOnce() -> anyhow::Result<()>>(ctx: &mut HandlerContext, name: String, f: F) {
@@ -243,20 +243,22 @@ impl WorkloadManager {
     pub fn new(config: config::Config) -> WorkloadManager {
         let workloads: Arc<Mutex<WorkloadStore>> = Arc::new(Mutex::new(WorkloadStore::default()));
         let xds_workloads = workloads.clone();
-        let xds_client = xds::Config::new(config.clone())
-            .with_workload_handler(xds_workloads)
-            .watch(xds::WORKLOAD_TYPE.into())
-            .build();
-        let local_workloads = workloads.clone();
-        let local_client = LocalClient {
-            path: config.local_xds_path,
-            workloads: local_workloads,
-        };
-        let demand = if config.xds_on_demand {
-            Some(xds_client.demander())
+        let xds_client = if config.xds_address.is_some() {
+            Some(xds::Config::new(config.clone())
+                .with_workload_handler(xds_workloads)
+                .watch(xds::WORKLOAD_TYPE.into())
+                .build())
         } else {
             None
         };
+        let local_workloads = workloads.clone();
+        let local_client = config.local_xds_path.map(|path| {
+            LocalClient {
+                path,
+                workloads: local_workloads,
+            }
+        });
+        let demand = xds_client.as_ref().and_then(AdsClient::demander);
         let workloads = WorkloadInformation {
             info: workloads,
             demand,
@@ -269,10 +271,23 @@ impl WorkloadManager {
     }
 
     pub async fn run(self) -> anyhow::Result<()> {
-        tokio::try_join!(
-            self.xds_client.run().map_err(|e| anyhow::anyhow!(e)),
-            self.local_client.run()
-        )?;
+        let xds = self.xds_client.map(|c| {
+            c.run().map_err(|e| anyhow::anyhow!(e))
+        });
+        let local = self.local_client.map(|c| c.run());
+
+        match (xds, local) {
+            (Some(x), Some(l)) => {
+                tokio::try_join!(x, l)?;
+            },
+            (Some(x), _) => {
+                x.await?;
+            },
+            (_, Some(l)) => {
+                l.await?;
+            },
+            _ => {}
+        }
         Ok(())
     }
 
@@ -283,19 +298,15 @@ impl WorkloadManager {
 
 /// LocalClient serves as a local file reader alternative for XDS. This is intended for testing.
 struct LocalClient {
-    path: Option<String>,
+    path: String,
     workloads: Arc<Mutex<WorkloadStore>>,
 }
 
 impl LocalClient {
     async fn run(self) -> Result<(), anyhow::Error> {
-        let path = match self.path {
-            Some(p) => p,
-            None => return Ok(()),
-        };
         info!("running local client");
         // Currently, we just load the file once. In the future, we could dynamically reload.
-        let data = tokio::fs::read_to_string(path).await?;
+        let data = tokio::fs::read_to_string(self.path).await?;
         let r: Vec<Workload> = serde_yaml::from_str(&data)?;
         let mut wli = self.workloads.lock().unwrap();
         for wl in r {
@@ -605,7 +616,7 @@ mod tests {
             name: "some name".to_string(),
             ..Default::default()
         })
-        .unwrap();
+            .unwrap();
         assert_eq!((wi.workloads.len()), 1);
         assert_eq!(
             wi.find_workload(&ip1),
@@ -655,7 +666,7 @@ mod tests {
             )]),
             ..Default::default()
         })
-        .unwrap();
+            .unwrap();
         wi.insert_xds_workload(XdsWorkload {
             address: xds_ip2,
             name: "some name2".to_string(),
@@ -670,7 +681,7 @@ mod tests {
             )]),
             ..Default::default()
         })
-        .unwrap();
+            .unwrap();
 
         assert_vips(&wi, vec!["some name", "some name2"]);
         wi.remove("127.0.0.2".to_string());
@@ -710,7 +721,7 @@ mod tests {
             .to_string();
         let workloads: Arc<Mutex<WorkloadStore>> = Arc::new(Mutex::new(WorkloadStore::default()));
         let local_client = LocalClient {
-            path: Some(dir),
+            path: dir,
             workloads: workloads.clone(),
         };
         local_client.run().await.expect("client should run");

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -28,6 +28,7 @@ use ztunnel::*;
 
 fn test_config() -> config::Config {
     config::Config {
+        xds_address: None,
         local_xds_path: Some("examples/localhost.yaml".to_string()),
         socks5_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),


### PR DESCRIPTION
This just adds a fairly simple "hello world" hitting the full system end to end.

Currently tested: socks5 outbound, TCP proxying, local XDS file config

HBONE is close to being able to be added, just need the fake CA from Brian's PR.

Major changes here:
* Bind to random ports everywhere; this involves passing hbone port around some places
* Move test helpers to src/ not tests/ since you cannot import between test modules.
* Allow turning off xds server
* Create a test Echo server