### PR TITLE
remove unnecessary tcp listener on inbound

### DIFF
--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -32,6 +32,7 @@ use super::Error;
 
 pub struct Inbound {
     cfg: Config,
+    sock_addr: SocketAddr,
     cert_manager: Box<dyn CertificateProvider>,
     workloads: WorkloadInformation,
 }
@@ -49,15 +50,17 @@ impl Inbound {
             Err(_e) => info!("running without transparent mode"),
             _ => info!("running with transparent mode"),
         };
+        let sock_addr = listener.local_addr().unwrap();
         Ok(Inbound {
             cfg,
+            sock_addr,
             workloads,
             cert_manager,
         })
     }
 
     pub(super) fn address(&self) -> SocketAddr {
-        self.cfg.inbound_addr
+        self.sock_addr
     }
 
     pub(super) async fn run(self) {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -73,8 +73,8 @@ impl Inbound {
                     cert_manager: self.cert_manager.clone(),
                 },
             };
-            let mut incoming_listener = hyper::server::conn::AddrIncoming::bind(&addr)
-                .expect("hbone bind");
+            let mut incoming_listener =
+                hyper::server::conn::AddrIncoming::bind(&addr).expect("hbone bind");
             incoming_listener.set_nodelay(true);
             let incoming = hyper::server::accept::from_stream(
                 tls_listener::builder(boring_acceptor)


### PR DESCRIPTION
remove tcp listener on inbound, there may be tcp or tls listener on inbound based on cfg flag, so unnecessary to store the tcp listener on inbound in advance.