### PR TITLE
separate threads for admin and proxy

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 use prometheus_client::registry::Registry;
-use tokio::task::JoinHandle;
 use tokio::time;
 use tracing::{error, info, warn};
 
@@ -39,8 +40,6 @@ pub async fn build_with_cert(
     // Note: there is still a hard timeout if the draining takes too long
     let (drain_tx, drain_rx) = drain::channel();
 
-    let mut tasks: Vec<JoinHandle<()>> = Vec::new();
-
     let ready = admin::Ready::new();
     let proxy_task = ready.register_task("proxy listeners");
 
@@ -51,12 +50,13 @@ pub async fn build_with_cert(
     )
     .await?;
 
+    let shutdown_trigger = shutdown.trigger();
     let admin = admin::Builder::new(config.clone(), workload_manager.workloads(), ready)
-        .bind(registry)
+        .bind(registry, shutdown_trigger)
         .expect("admin server starts");
     let admin_address = admin.address();
-    admin.spawn(&shutdown, drain_rx.clone());
 
+    let drain_rx_amdin = drain_rx.clone();
     let proxy = proxy::Proxy::new(
         config.clone(),
         workload_manager.workloads(),
@@ -67,14 +67,30 @@ pub async fn build_with_cert(
     .await?;
     drop(proxy_task);
 
-    let proxy_addresses = proxy.addresses();
-
-    tasks.push(tokio::spawn(async move {
+    // spawn admin task and xds client task
+    admin.spawn(drain_rx_amdin);
+    tokio::spawn(async move {
         if let Err(e) = workload_manager.run().await {
             error!("workload manager: {}", e);
         }
-    }));
-    tasks.push(tokio::spawn(proxy.run()));
+    });
+
+    let proxy_addresses = proxy.addresses();
+    thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(config.num_worker_threads)
+            .thread_name_fn(|| {
+                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+                format!("ztunnel-proxy-{}", id)
+            })
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            proxy.run().await;
+        });
+    });
 
     Ok(Bound {
         drain_tx,
@@ -82,7 +98,6 @@ pub async fn build_with_cert(
         shutdown,
         admin_address,
         proxy_addresses,
-        tasks,
     })
 }
 
@@ -101,17 +116,12 @@ pub struct Bound {
     pub proxy_addresses: proxy::Addresses,
 
     pub shutdown: signal::Shutdown,
-    tasks: Vec<JoinHandle<()>>,
     config: config::Config,
     drain_tx: drain::Signal,
 }
 
 impl Bound {
     pub async fn spawn(self) -> anyhow::Result<()> {
-        tokio::spawn(async move {
-            futures::future::join_all(self.tasks).await;
-        });
-
         // Wait for a signal to shutdown from explicit admin shutdown or signal
         self.shutdown.wait().await;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,7 +56,7 @@ pub async fn build_with_cert(
         .expect("admin server starts");
     let admin_address = admin.address();
 
-    let drain_rx_amdin = drain_rx.clone();
+    let drain_rx_admin = drain_rx.clone();
     let proxy = proxy::Proxy::new(
         config.clone(),
         workload_manager.workloads(),
@@ -68,7 +68,7 @@ pub async fn build_with_cert(
     drop(proxy_task);
 
     // spawn admin task and xds client task
-    admin.spawn(drain_rx_amdin);
+    admin.spawn(drain_rx_admin);
     tokio::spawn(async move {
         if let Err(e) = workload_manager.run().await {
             error!("workload manager: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ extern crate core;
 #[cfg(feature = "gperftools")]
 extern crate gperftools;
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::info;
 use ztunnel::*;
 
@@ -40,13 +39,7 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(config.num_worker_threads)
-        .thread_name_fn(|| {
-            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-            let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-            format!("proxy-{}", id)
-        })
+    tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .unwrap()

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -65,7 +65,7 @@ impl Proxy {
             workloads.clone(),
             inbound.address().port(),
             metrics,
-            drain,
+            drain.clone(),
         )
         .await?;
         let socks5 = Socks5::new(
@@ -73,6 +73,7 @@ impl Proxy {
             cert_manager.clone(),
             inbound.address().port(),
             workloads.clone(),
+            drain,
         )
         .await?;
         Ok(Proxy {


### PR DESCRIPTION
Admin（debug, xds client) use one thread

proxy use by default 2 threads.

fix #14


```
root@opensrc:~/rust/ztunnel# top -H -p 844183
top - 10:23:41 up 5 days, 18:37,  3 users,  load average: 0.17, 0.27, 0.24
Threads:   5 total,   0 running,   5 sleeping,   0 stopped,   0 zombie
%Cpu(s):  1.0 us,  0.4 sy,  0.0 ni, 98.5 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  16012.5 total,   4429.1 free,   6529.1 used,   5054.2 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.   8996.5 avail Mem 

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                                                              
 844183 root      20   0  367912  18312  14744 S   0.0   0.1   0:00.20 ztunnel                                                                                                              
 844497 root      20   0  367912  18312  14744 S   0.0   0.1   0:00.13 tokio-runtime-w                                                                                                      
 844498 root      20   0  367912  18312  14744 S   0.0   0.1   0:00.00 ztunnel                                                                                                              
 844499 root      20   0  367912  18312  14744 S   0.0   0.1   0:00.00 proxy                                                                                                                
 844500 root      20   0  367912  18312  14744 S   0.0   0.1   0:00.00 proxy   
```