### PR TITLE
check SAN of CA response

### DIFF
--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -31,4 +31,6 @@ pub enum Error {
     SigningRequest(#[from] tonic::Status),
     #[error("failed to process string: {0}")]
     Utf8(#[from] Utf8Error),
+    #[error("did not find expected SAN: {0}")]
+    SanError(Identity),
 }

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -33,13 +33,13 @@ use boring::stack::Stack;
 use boring::x509::extension::{
     AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName,
 };
-use boring::x509::{self, GeneralName, X509StoreContext, X509StoreContextRef, X509VerifyResult};
+use boring::x509::{self, X509StoreContext, X509StoreContextRef, X509VerifyResult};
 use hyper::client::ResponseFuture;
 use hyper::{Request, Uri};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tonic::body::BoxBody;
 use tower::Service;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use crate::identity::{self, Identity};
 


### PR DESCRIPTION
on second thought, this should probably just warn.

I was accidentally using a `master` control plane and the CA would respond with certs for the ztunnel's own SA instead of the workload's. 

I imagine anytime we `fetch_cert(id)` we want the given certs to present that CA. 