### PR TITLE
Explicitly fallback on orig_dst lookup failure

### DIFF
--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
-use std::os::unix::io::RawFd;
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
@@ -219,8 +218,8 @@ struct InboundCertProvider {
 
 #[async_trait::async_trait]
 impl crate::tls::CertProvider for InboundCertProvider {
-    async fn fetch_cert(&mut self, fd: RawFd) -> Result<boring::ssl::SslAcceptor, TlsError> {
-        let orig = crate::socket::orig_dst_addr_fd(fd).map_err(TlsError::DestinationLookup)?;
+    async fn fetch_cert(&mut self, fd: &TcpStream) -> Result<boring::ssl::SslAcceptor, TlsError> {
+        let orig = crate::socket::orig_dst_addr_or_default(fd);
         let identity = {
             let remote_addr = super::to_canonical_ip(orig);
             self.workloads

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Error;
-
 use tokio::io;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
@@ -21,6 +19,8 @@ use tracing::{error, info, warn};
 
 use crate::config::Config;
 use crate::socket;
+
+use super::Error;
 
 pub struct InboundPassthrough {
     cfg: Config,
@@ -62,7 +62,7 @@ impl InboundPassthrough {
     }
 
     async fn proxy_inbound_plaintext(inbound: &mut TcpStream) -> Result<(), Error> {
-        let orig = socket::orig_dst_addr(inbound).expect("must have original dst enabled");
+        let orig = socket::orig_dst_addr_or_default(inbound);
         let mut outbound = TcpStream::connect(orig).await?;
 
         let (mut ri, mut wi) = inbound.split();

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -124,9 +124,9 @@ pub struct OutboundConnection {
 
 impl OutboundConnection {
     async fn proxy(&mut self, stream: TcpStream) -> Result<(), Error> {
-        let remote_addr =
-            super::to_canonical_ip(stream.peer_addr().expect("must receive peer addr"));
-        let orig = socket::orig_dst_addr(&stream).expect("must have original dst enabled");
+        let peer = stream.peer_addr().expect("must receive peer addr");
+        let remote_addr = super::to_canonical_ip(peer);
+        let orig = socket::orig_dst_addr_or_default(&stream);
         self.proxy_to(stream, remote_addr, orig).await
     }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -39,20 +39,8 @@ pub fn set_transparent(l: &TcpListener) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
-#[allow(unsafe_code)]
-pub fn orig_dst_addr_fd<T: AsRawFd>(sock: T) -> io::Result<SocketAddr> {
-    let fd = sock.as_raw_fd();
-
-    unsafe { linux::so_original_dst(fd) }
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn orig_dst_addr_fd<T: AsRawFd>(_: T) -> io::Result<SocketAddr> {
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        "SO_ORIGINAL_DST not supported on this operating system",
-    ))
+pub fn orig_dst_addr_or_default(sock: &tokio::net::TcpStream) -> SocketAddr {
+    orig_dst_addr(sock).unwrap_or_else(|_| sock.peer_addr().expect("must get peer address"))
 }
 
 #[cfg(target_os = "linux")]

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::fmt;
 use std::future::Future;
-use std::io;
+
 use std::net::IpAddr;
-use std::os::unix::io::{AsRawFd, RawFd};
+
 use std::pin::Pin;
 use std::task::Poll;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -35,8 +34,10 @@ use boring::x509::extension::{
 };
 use boring::x509::{self, GeneralName, X509StoreContext, X509StoreContextRef, X509VerifyResult};
 use hyper::client::ResponseFuture;
+use hyper::server::conn::AddrStream;
 use hyper::{Request, Uri};
-use tokio::io::{AsyncRead, AsyncWrite};
+
+use tokio::net::TcpStream;
 use tonic::body::BoxBody;
 use tower::Service;
 use tracing::{error, info};
@@ -321,7 +322,7 @@ impl Alpn {
 
 #[async_trait::async_trait]
 pub trait CertProvider: Send + Sync {
-    async fn fetch_cert(&mut self, fd: RawFd) -> Result<ssl::SslAcceptor, TlsError>;
+    async fn fetch_cert(&mut self, fd: &TcpStream) -> Result<ssl::SslAcceptor, TlsError>;
 }
 
 #[derive(Clone)]
@@ -339,8 +340,6 @@ pub enum TlsError {
     Verification(X509VerifyResult),
     #[error("certificate lookup error: {0} is not a known destination")]
     CertificateLookup(IpAddr),
-    #[error("destination lookup error")]
-    DestinationLookup(#[source] io::Error),
     #[error("signing error: {0}")]
     SigningError(#[from] identity::Error),
     #[error("san verification error: remote did not present the expected SAN")]
@@ -349,21 +348,20 @@ pub enum TlsError {
     SslError(#[from] Error),
 }
 
-impl<C, F> tls_listener::AsyncTls<C> for BoringTlsAcceptor<F>
+impl<F> tls_listener::AsyncTls<AddrStream> for BoringTlsAcceptor<F>
 where
-    C: AsRawFd + AsyncRead + AsyncWrite + Unpin + Send + fmt::Debug + 'static,
     F: CertProvider + Clone + 'static,
 {
-    type Stream = tokio_boring::SslStream<C>;
+    type Stream = tokio_boring::SslStream<TcpStream>;
     type Error = TlsError;
     type AcceptFuture = Pin<Box<dyn Future<Output = Result<Self::Stream, Self::Error>> + Send>>;
 
-    fn accept(&self, conn: C) -> Self::AcceptFuture {
-        let fd = conn.as_raw_fd();
+    fn accept(&self, conn: AddrStream) -> Self::AcceptFuture {
+        let inner = conn.into_inner();
         let mut acceptor = self.acceptor.clone();
         Box::pin(async move {
-            let tls = acceptor.fetch_cert(fd).await?;
-            tokio_boring::accept(&tls, conn)
+            let tls = acceptor.fetch_cert(&inner).await?;
+            tokio_boring::accept(&tls, inner)
                 .await
                 .map_err(|_| TlsError::Handshake)
         })

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -87,7 +87,6 @@ async fn run_request_test(target: &str) {
     .await;
 }
 
-#[ignore] // TODO: re-enable it when CI passes; for some reason it only works locally
 #[tokio::test]
 async fn test_hbone_request() {
     run_request_test("127.0.0.1").await;


### PR DESCRIPTION
Typically, if you do orig_dst lookup and there was no iptables redirect, you get back the unredirected address: this is what we want.

However, it turns out that if there are no iptables rules in the network namespace, regardless of whether they apply to the request, the orig_dst lookup fails.

To workaround this, we explicitly fallback to the unredirected address instead of relying on the kernel to do it for us.

This fixes the tests in CI, which have no iptables rules setup.

As part of this, we move `BoringTlsAcceptor` from generic to explicit struct. Its possible to make it generic but I don't see a need for now; I expect moving forward we will likely want to have some concrete structs passed between stages (tcp connection, tls connection, http connection) storing metadata along the way at each hop, so having concrete types kind of aligns with that.