### PR TITLE
lint: fix spammy makefile invocation

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -6,14 +6,12 @@ test:
 build:
 	cargo build
 
-# override target in common/Makefile.common.mk, only check golang and rust codes
-# load order: Makefile -> Makefile.overrides -> Makefile.core -> Makefile.common
-# cannot override in Makefile.overrides
-lint-copyright-banner:
+# target in common/Makefile.common.mk doesn't handle our third party vendored files; only check golang and rust codes
+lint-copyright:
 	@${FINDFILES} \( -name '*.go' -o -name '*.rs' \) \( ! \( -name '*.gen.go' -o -name '*.pb.go' -o -name '*_pb2.py' \) \) -print0 |\
 		${XARGS} common/scripts/lint_copyright_banner.sh
 
-lint: lint-scripts lint-yaml lint-markdown lint-licenses lint-copyright-banner
+lint: lint-scripts lint-yaml lint-markdown lint-licenses lint-copyright
 	cargo clippy
 
 check:


### PR DESCRIPTION
```
Makefile.core.mk:13: warning: overriding recipe for target
'lint-copyright-banner'
common/Makefile.common.mk:38: warning: ignoring old recipe for target
'lint-copyright-banner'
```

was happening before