### PR TITLE
xds: use TLS (port 15012) to control plane

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -56,9 +56,9 @@ impl Default for Config {
     fn default() -> Config {
         // TODO: copy JWT auth logic from CA client and use TLS here (port 15012)
         let xds_address = Some(if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
-            "http://istiod.istio-system:15010".to_string()
+            "https://istiod.istio-system:15012".to_string()
         } else {
-            "http://localhost:15010".to_string()
+            "https://localhost:15012".to_string()
         });
         Config {
             tls: std::env::var("TLS").ok().as_deref() != Some("off"),


### PR DESCRIPTION
Also refactors the node logic to only send the node on the first request (mirroring envoy; makes requests 50% smaller) since I already had to refactor the node logic anyways.