### PR TITLE
Fix the worker threads environment name typo

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -81,7 +81,7 @@ impl Default for Config {
                 r"./var/run/secrets/tokens/istio-token",
             )),
 
-            num_worker_threads: std::env::var("ZTUNNEL_WOKRER_THREADS")
+            num_worker_threads: std::env::var("ZTUNNEL_WORKER_THREADS")
                 .ok()
                 .map(|v| {
                     v.parse::<usize>()


### PR DESCRIPTION
The commit 7d7883801abc ("Remove option to run with TLS (#186)") captures the 'worker' typo, add the missed environment name typo fix.