### PR TITLE
Add option to use the builtin mock as a fake CA.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use tokio::task::JoinHandle;
 use tokio::time;
@@ -75,8 +76,13 @@ pub async fn build_with_cert(
 }
 
 pub async fn build(config: config::Config) -> anyhow::Result<Bound> {
-    let cert_manager = identity::SecretManager::new(config.clone());
-    build_with_cert(config, cert_manager).await
+    if config.fake_ca {
+        let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(86400));
+        build_with_cert(config, cert_manager).await
+    } else {
+        let cert_manager = identity::SecretManager::new(config.clone());
+        build_with_cert(config, cert_manager).await
+    }
 }
 
 pub struct Bound {

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,8 @@ pub struct Config {
     /// If true, on-demand XDS will be used
     pub xds_on_demand: bool,
 
+    /// If true, then use builtin fake CA with self-signed certificates.
+    pub fake_ca: bool,
     pub auth: identity::AuthSource,
 
     pub termination_grace_period: time::Duration,
@@ -77,6 +79,7 @@ impl Default for Config {
             local_xds_path: std::env::var("LOCAL_XDS_PATH").ok(),
             xds_on_demand: std::env::var("XDS_ON_DEMAND").ok().as_deref() == Some("on"),
 
+            fake_ca: std::env::var("FAKE_CA").ok().as_deref() == Some("on"),
             auth: identity::AuthSource::Token(PathBuf::from(
                 r"./var/run/secrets/tokens/istio-token",
             )),


### PR DESCRIPTION
This is useful for local development without Istio.

Fixes #140.

Signed-off-by: Piotr Sikora <piotr@aviatrix.com>