### PR TITLE
Move the argv handling out of async context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,17 @@ use ztunnel::*;
 fn main() -> anyhow::Result<()> {
     telemetry::setup_logging();
     let config: config::Config = Default::default();
+
+    // For now we don't need a complex CLI, so rather than pull in dependencies just use basic argv[1]
+    match std::env::args().nth(1).as_deref() {
+        None | Some("proxy") => (),
+        Some("version") => return version(),
+        Some(unknown) => {
+            eprintln!("unknown command: {unknown}");
+            std::process::exit(1)
+        }
+    };
+
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(config.num_worker_threads)
         .thread_name_fn(|| {
@@ -38,22 +49,10 @@ fn main() -> anyhow::Result<()> {
         .enable_all()
         .build()
         .unwrap()
-        .block_on(async move { run(config).await })
+        .block_on(async move { proxy(config).await })
 }
 
-async fn run(cfg: config::Config) -> anyhow::Result<()> {
-    // For now we don't need a complex CLI, so rather than pull in dependencies just use basic argv[1]
-    match std::env::args().nth(1).as_deref() {
-        None | Some("proxy") => proxy(cfg).await,
-        Some("version") => version().await,
-        Some(unknown) => {
-            eprintln!("unknown command: {unknown}");
-            std::process::exit(1)
-        }
-    }
-}
-
-async fn version() -> anyhow::Result<()> {
+fn version() -> anyhow::Result<()> {
     println!("{}", version::BuildInfo::new());
     Ok(())
 }


### PR DESCRIPTION
The async context is expensive, like spawning worker threads, scheduling the task etc. So move the argv handling into the main thread.

Also, the CLI can be used to add more configuration into config::Config, which the proxy may need for run.