### PR TITLE
Handle the hbone copy error gracefully

### DIFF
--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -131,9 +131,12 @@ impl Inbound {
                         }
                         Hbone(req) => match hyper::upgrade::on(req).await {
                             Ok(mut upgraded) => {
-                                super::copy_hbone("hbone server", &mut upgraded, &mut stream)
-                                    .await
-                                    .expect("hbone server copy");
+                                if let Err(e) =
+                                    super::copy_hbone("hbone server", &mut upgraded, &mut stream)
+                                        .await
+                                {
+                                    error!("hbone server copy: {}", e);
+                                }
                             }
                             Err(e) => {
                                 // Not sure if this can even happen

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -158,7 +158,6 @@ pub async fn copy_hbone(
         let mut wo = tokio::io::BufWriter::with_capacity(HBONE_BUFFER_SIZE, &mut wo);
         let res = tokio::io::copy(&mut ri, &mut wo).await;
         info!(?res, ?desc, "hbone -> tcp");
-        res.expect("");
         wo.shutdown().await
     };
 


### PR DESCRIPTION
Inspired by the io::copy error handling from:
https://github.com/tokio-rs/tokio/blob/master/examples/proxy.rs

        io::copy(&mut ri, &mut wo).await?;
        wo.shutdown().await

If the io::copy has error, just return error to the upper application to capture the real connection error like:

2022-11-29T08:35:32.680985Z ERROR ztunnel::proxy: tcp -> hbone: broken pipe
2022-11-29T08:35:32.680988Z ERROR ztunnel::proxy: hbone -> tcp: Connection reset by peer (os error 104)
2022-11-29T08:35:32.681038Z ERROR ztunnel::proxy::outbound: hbone client copy: broken pipe
2022-11-29T08:35:32.681045Z ERROR ztunnel::proxy::inbound: hbone server copy Err(Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" })