### PR TITLE
Use more standard casing in outputs

### DIFF
--- a/examples/localhost.yaml
+++ b/examples/localhost.yaml
@@ -2,14 +2,14 @@
 # This allows local testing by sending requests through the local ztunnel to other servers running on localhost.
 - name: local
   namespace: default
-  service_account: default
-  workload_ip: "127.0.0.1"
-  protocol: Hbone
+  serviceAccount: default
+  workloadIp: "127.0.0.1"
+  protocol: HBONE
   node: local
 # Define another local address, but this one uses TCP. This allows testing HBONE and TCP with one config.
 - name: local-tcp
   namespace: default
-  service_account: default
-  workload_ip: "127.0.0.2"
-  protocol: Tcp
+  serviceAccount: default
+  workloadIp: "127.0.0.2"
+  protocol: TCP
   node: local

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -151,7 +151,7 @@ impl OutboundConnection {
                 .map_err(Error::Io);
         }
         match req.protocol {
-            Protocol::Hbone => {
+            Protocol::HBONE => {
                 info!(
                     "Proxying to {} using HBONE via {} type {:#?}",
                     req.destination, req.gateway, req.request_type
@@ -209,7 +209,7 @@ impl OutboundConnection {
                 info!("request complete");
                 Ok(())
             }
-            Protocol::Tcp => {
+            Protocol::TCP => {
                 info!(
                     "Proxying to {} using TCP via {} type {:?}",
                     req.destination, req.gateway, req.request_type
@@ -245,7 +245,7 @@ impl OutboundConnection {
         if us.is_none() {
             // For case no upstream found, passthrough it
             return Ok(Request {
-                protocol: Protocol::Tcp,
+                protocol: Protocol::TCP,
                 source: source_workload,
                 destination: target,
                 destination_identity: None,
@@ -261,7 +261,7 @@ impl OutboundConnection {
             let destination_identity = Some(source_workload.identity());
             return Ok(Request {
                 // Always use HBONE here
-                protocol: Protocol::Hbone,
+                protocol: Protocol::HBONE,
                 source: source_workload,
                 // Load balancing decision is deferred to remote proxy
                 destination: target,
@@ -285,7 +285,7 @@ impl OutboundConnection {
             // Typically this is all or nothing, but if not we should probably send to remote proxy if *any* upstream has one.
             return Ok(Request {
                 // Always use HBONE here
-                protocol: Protocol::Hbone,
+                protocol: Protocol::HBONE,
                 source: source_workload,
                 // Use the original VIP, not translated
                 destination: target,
@@ -299,10 +299,10 @@ impl OutboundConnection {
         // For case source client and upstream server are on the same node
         if !us.workload.node.is_empty()
             && self.cfg.local_node == Some(us.workload.node.clone())
-            && us.workload.protocol == Protocol::Hbone
+            && us.workload.protocol == Protocol::HBONE
         {
             return Ok(Request {
-                protocol: Protocol::Hbone,
+                protocol: Protocol::HBONE,
                 source: source_workload,
                 destination: SocketAddr::from((us.workload.workload_ip, us.port)),
                 destination_identity: us.workload.identity().into(),
@@ -463,7 +463,7 @@ mod tests {
                 ..Default::default()
             },
             Some(ExpectedRequest {
-                protocol: Protocol::Tcp,
+                protocol: Protocol::TCP,
                 destination: "1.2.3.4:80",
                 gateway: "1.2.3.4:80",
                 request_type: RequestType::Passthrough,
@@ -486,7 +486,7 @@ mod tests {
                 ..Default::default()
             },
             Some(ExpectedRequest {
-                protocol: Protocol::Tcp,
+                protocol: Protocol::TCP,
                 destination: "127.0.0.2:80",
                 gateway: "127.0.0.2:80",
                 request_type: RequestType::Direct,
@@ -509,7 +509,7 @@ mod tests {
                 ..Default::default()
             },
             Some(ExpectedRequest {
-                protocol: Protocol::Hbone,
+                protocol: Protocol::HBONE,
                 destination: "127.0.0.2:80",
                 gateway: "127.0.0.2:15008",
                 request_type: RequestType::Direct,
@@ -532,7 +532,7 @@ mod tests {
                 ..Default::default()
             },
             Some(ExpectedRequest {
-                protocol: Protocol::Tcp,
+                protocol: Protocol::TCP,
                 destination: "127.0.0.2:80",
                 gateway: "127.0.0.2:80",
                 request_type: RequestType::Direct,
@@ -555,7 +555,7 @@ mod tests {
                 ..Default::default()
             },
             Some(ExpectedRequest {
-                protocol: Protocol::Hbone,
+                protocol: Protocol::HBONE,
                 destination: "127.0.0.2:80",
                 gateway: "127.0.0.2:15088",
                 request_type: RequestType::DirectLocal,

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -56,7 +56,7 @@ impl TryFrom<Option<xds::istio::workload::Protocol>> for Protocol {
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields, )]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Workload {
     pub workload_ip: IpAddr,
     #[serde(default)]

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -33,13 +33,13 @@ use crate::{admin, config, xds};
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum Protocol {
-    Tcp,
-    Hbone,
+    TCP,
+    HBONE,
 }
 
 impl Default for Protocol {
     fn default() -> Self {
-        Protocol::Tcp
+        Protocol::TCP
     }
 }
 
@@ -48,15 +48,15 @@ impl TryFrom<Option<xds::istio::workload::Protocol>> for Protocol {
 
     fn try_from(value: Option<xds::istio::workload::Protocol>) -> Result<Self, Self::Error> {
         match value {
-            Some(xds::istio::workload::Protocol::Http) => Ok(Protocol::Hbone),
-            Some(xds::istio::workload::Protocol::Direct) => Ok(Protocol::Tcp),
+            Some(xds::istio::workload::Protocol::Http) => Ok(Protocol::HBONE),
+            Some(xds::istio::workload::Protocol::Direct) => Ok(Protocol::TCP),
             None => Err(ProtocolParse("unknown type".into())),
         }
     }
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase", deny_unknown_fields, )]
 pub struct Workload {
     pub workload_ip: IpAddr,
     #[serde(default)]
@@ -456,14 +456,14 @@ impl WorkloadStore {
     fn set_gateway_address(us: &mut Upstream, hbone_port: u16) {
         if us.workload.gateway_address.is_none() {
             us.workload.gateway_address = Some(match us.workload.protocol {
-                Protocol::Hbone => {
+                Protocol::HBONE => {
                     let ip = us
                         .workload
                         .choose_waypoint_address()
                         .unwrap_or(us.workload.workload_ip);
                     SocketAddr::from((ip, hbone_port))
                 }
-                Protocol::Tcp => SocketAddr::from((us.workload.workload_ip, us.port)),
+                Protocol::TCP => SocketAddr::from((us.workload.workload_ip, us.port)),
             });
         }
     }


### PR DESCRIPTION
`camelCase` and all caps enum are standard across Istio