### PR TITLE
Revert "unit test caclient directly (#215)" causing stack overflow

### DIFF
--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -17,45 +17,22 @@ use std::collections::BTreeMap;
 use async_trait::*;
 use prost_types::value::Kind;
 use prost_types::Struct;
-
-use dyn_clone::DynClone;
+use tonic::codegen::InterceptedService;
 use tracing::{instrument, warn};
 
 use crate::identity::auth::AuthSource;
 use crate::identity::manager::Identity;
 use crate::identity::Error;
+use crate::tls::TlsGrpcChannel;
 use crate::tls::{self, SanChecker};
 use crate::xds::istio::ca::istio_certificate_service_client::IstioCertificateServiceClient;
-use crate::xds::istio::ca::{IstioCertificateRequest, IstioCertificateResponse};
+use crate::xds::istio::ca::IstioCertificateRequest;
 
-#[async_trait]
-pub trait IstioCertificateService: DynClone + Send + Sync + 'static {
-    async fn create_certificate(
-        &mut self,
-        request: IstioCertificateRequest,
-    ) -> Result<tonic::Response<IstioCertificateResponse>, tonic::Status>;
-}
-
-dyn_clone::clone_trait_object!(IstioCertificateService);
-
-#[async_trait]
-impl<T> IstioCertificateService for IstioCertificateServiceClient<T>
-where
-    T: Sync + Send + Clone + 'static,
-{
-    async fn create_certificate(
-        &mut self,
-        request: IstioCertificateRequest,
-    ) -> Result<tonic::Response<IstioCertificateResponse>, tonic::Status> {
-        self.create_certificate(request).await
-    }
-}
-
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CaClient {
-    pub client: Box<dyn IstioCertificateService>,
+    pub client: IstioCertificateServiceClient<InterceptedService<TlsGrpcChannel, AuthSource>>,
 }
-
+use dyn_clone::DynClone;
 #[async_trait]
 pub trait CertificateProvider: DynClone + Send + Sync + 'static {
     async fn fetch_certificate(&mut self, id: &Identity) -> Result<tls::Certs, Error>;
@@ -72,12 +49,6 @@ impl CaClient {
         };
         let svc = tls::grpc_connector(address.to_string()).unwrap();
         let client = IstioCertificateServiceClient::with_interceptor(svc, auth);
-        CaClient {
-            client: Box::new(client),
-        }
-    }
-
-    pub fn with_client(client: Box<dyn IstioCertificateService>) -> CaClient {
         CaClient { client }
     }
 }
@@ -107,11 +78,8 @@ impl CertificateProvider for CaClient {
             }),
         };
         let resp = self.client.create_certificate(req).await?.into_inner();
-        let leaf = resp
-            .cert_chain
-            .first()
-            .ok_or_else(|| Error::EmptyResponse(id.clone()))?
-            .as_bytes();
+
+        let leaf = resp.cert_chain.first().unwrap().as_bytes();
         let chain = if resp.cert_chain.len() > 1 {
             resp.cert_chain[1..].iter().map(|s| s.as_bytes()).collect()
         } else {
@@ -123,99 +91,5 @@ impl CertificateProvider for CaClient {
             .verify_san(id)
             .map_err(|_| Error::SanError(id.clone()))?;
         Ok(certs)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use super::{CaClient, CertificateProvider, IstioCertificateService};
-    use crate::{
-        identity::{Error, Identity},
-        tls,
-        xds::istio::ca::{IstioCertificateRequest, IstioCertificateResponse},
-    };
-    use async_trait::async_trait;
-
-    #[derive(Clone, Default)]
-    struct MockCertService {
-        response: Option<IstioCertificateResponse>,
-        error: Option<tonic::Status>,
-    }
-
-    impl MockCertService {
-        fn set_response(&mut self, res: IstioCertificateResponse) {
-            self.error = None;
-            self.response = Some(res);
-        }
-
-        #[allow(dead_code)]
-        fn set_error(&mut self, err: tonic::Status) {
-            self.response = None;
-            self.error = Some(err);
-        }
-    }
-
-    #[async_trait]
-    impl IstioCertificateService for MockCertService {
-        async fn create_certificate(
-            &mut self,
-            _request: IstioCertificateRequest,
-        ) -> Result<tonic::Response<IstioCertificateResponse>, tonic::Status> {
-            if let Some(res) = &self.response {
-                Ok(tonic::Response::new(res.clone()))
-            } else if let Some(err) = &self.error {
-                Err(err.clone())
-            } else {
-                Err(tonic::Status::not_found("response not setup yet"))
-            }
-        }
-    }
-
-    async fn test_ca_client_with_response(
-        res: IstioCertificateResponse,
-    ) -> Result<crate::tls::Certs, crate::identity::Error> {
-        let mut mock_service = Box::new(MockCertService::default());
-        mock_service.set_response(res);
-        let mut ca_client = CaClient::with_client(mock_service);
-        ca_client.fetch_certificate(&Identity::default()).await
-    }
-
-    #[tokio::test]
-    async fn empty_chain() {
-        let res =
-            test_ca_client_with_response(IstioCertificateResponse { cert_chain: vec![] }).await;
-        assert!(matches!(res, Err(Error::EmptyResponse(_))));
-    }
-
-    #[tokio::test]
-    async fn wrong_identity() {
-        let id = &Identity::Spiffe {
-            service_account: "wrong-sa".to_string(),
-            namespace: "foo".to_string(),
-            trust_domain: "cluster.local".to_string(),
-        };
-        let certs = tls::generate_test_certs(id, Duration::from_secs(0), Duration::from_secs(0));
-
-        let res = test_ca_client_with_response(IstioCertificateResponse {
-            cert_chain: vec![String::from_utf8(certs.x509().to_pem().unwrap()).unwrap()],
-        })
-        .await;
-        assert!(matches!(res, Err(Error::SanError(_))));
-    }
-
-    #[tokio::test]
-    async fn fetch_certificate() {
-        let certs = tls::generate_test_certs(
-            &Identity::default(),
-            Duration::from_secs(0),
-            Duration::from_secs(0),
-        );
-        let res = test_ca_client_with_response(IstioCertificateResponse {
-            cert_chain: vec![String::from_utf8(certs.x509().to_pem().unwrap()).unwrap()],
-        })
-        .await;
-        assert!(matches!(res, Ok(_)));
     }
 }

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -33,6 +33,4 @@ pub enum Error {
     Utf8(#[from] Utf8Error),
     #[error("did not find expected SAN: {0}")]
     SanError(Identity),
-    #[error("chain returned from CA is empty for: {0}")]
-    EmptyResponse(Identity),
 }

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -169,10 +169,6 @@ impl Certs {
             .checked_sub(elapsed)
             .unwrap_or_else(|| Duration::from_secs(0))
     }
-
-    pub fn x509(&self) -> &x509::X509 {
-        &self.cert.x509
-    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This reverts commit 1fc47c6aac337f3397840cd0779920f98e8598d5.