### PR TITLE
Use socket2 crate instead of reimplementing socket options.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,6 +2283,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "socket2",
  "thiserror",
  "tls-listener",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
 serde_json = "1.0.85"
 serde_yaml = "0.9.13"
+socket2 = "0.4.7"
 byteorder = "1.3.4"
 thiserror = "1.0.34"
 tls-listener = { version  = "0.5.1", features = ["hyper-h2"] }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -26,19 +26,19 @@ pub fn set_transparent(l: &TcpListener) -> io::Result<()> {
 }
 
 pub fn orig_dst_addr_or_default(stream: &tokio::net::TcpStream) -> SocketAddr {
-    let sock = SockRef::from(stream);
-    match orig_dst_addr(&sock) {
+    match orig_dst_addr(stream) {
         Ok(Some(addr)) => addr,
         _ => stream.local_addr().expect("must get local address"),
     }
 }
 
 #[cfg(target_os = "linux")]
-fn orig_dst_addr(sock: &SockRef) -> io::Result<Option<SocketAddr>> {
+fn orig_dst_addr(stream: &tokio::net::TcpStream) -> io::Result<Option<SocketAddr>> {
+    let sock = SockRef::from(stream);
     // Dual-stack IPv4/IPv6 sockets require us to check both options.
-    match linux::original_dst(sock) {
+    match linux::original_dst(&sock) {
         Ok(Some(addr)) => Ok(addr.as_socket()),
-        _ => match linux::original_dst_ipv6(sock) {
+        _ => match linux::original_dst_ipv6(&sock) {
             Ok(Some(addr)) => Ok(addr.as_socket()),
             Ok(None) => Ok(None),
             Err(e) => Err(e),

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -34,7 +34,7 @@ pub fn orig_dst_addr_or_default(stream: &tokio::net::TcpStream) -> SocketAddr {
 }
 
 #[cfg(target_os = "linux")]
-fn orig_dst_addr(stream: &tokio::net::TcpStream) -> io::Result<Option<SocketAddr>> {
+pub fn orig_dst_addr(stream: &tokio::net::TcpStream) -> io::Result<Option<SocketAddr>> {
     let sock = SockRef::from(stream);
     // Dual-stack IPv4/IPv6 sockets require us to check both options.
     match linux::original_dst(&sock) {
@@ -54,7 +54,7 @@ fn orig_dst_addr(stream: &tokio::net::TcpStream) -> io::Result<Option<SocketAddr
 }
 
 #[cfg(not(target_os = "linux"))]
-fn orig_dst_addr(_: &tokio::net::TcpStream) -> io::Result<Option<SocketAddr>> {
+pub fn orig_dst_addr(_: &tokio::net::TcpStream) -> io::Result<Option<SocketAddr>> {
     Err(io::Error::new(
         io::ErrorKind::Other,
         "SO_ORIGINAL_DST not supported on this operating system",

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -14,47 +14,40 @@
 
 use std::io::Error;
 use std::net::SocketAddr;
-use std::os::unix::io::AsRawFd;
 
 use realm_io;
+use socket2::SockRef;
 use tokio::io;
 use tokio::net::TcpListener;
 
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code)]
 pub fn set_transparent(l: &TcpListener) -> io::Result<()> {
-    let fd = l.as_raw_fd();
-
-    unsafe {
-        let optval: libc::c_int = 1;
-        let ret = libc::setsockopt(
-            fd,
-            libc::SOL_IP,
-            libc::IP_TRANSPARENT,
-            &optval as *const _ as *const libc::c_void,
-            std::mem::size_of_val(&optval) as libc::socklen_t,
-        );
-        if ret != 0 {
-            return Err(io::Error::last_os_error());
-        }
-    }
-    Ok(())
+    SockRef::from(l).set_ip_transparent(true)
 }
 
-pub fn orig_dst_addr_or_default(sock: &tokio::net::TcpStream) -> SocketAddr {
-    orig_dst_addr(sock).unwrap_or_else(|_| sock.local_addr().expect("must get local address"))
+pub fn orig_dst_addr_or_default(stream: &tokio::net::TcpStream) -> SocketAddr {
+    let sock = SockRef::from(stream);
+    match orig_dst_addr(&sock) {
+        Ok(Some(addr)) => addr,
+        _ => stream.local_addr().expect("must get local address"),
+    }
 }
 
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code)]
-pub fn orig_dst_addr(sock: &tokio::net::TcpStream) -> io::Result<SocketAddr> {
-    let fd = sock.as_raw_fd();
-
-    unsafe { linux::so_original_dst(fd) }
+fn orig_dst_addr(sock: &SockRef) -> io::Result<Option<SocketAddr>> {
+    // Dual-stack IPv4/IPv6 sockets require us to check both options.
+    match linux::original_dst(sock) {
+        Ok(Some(addr)) => Ok(addr.as_socket()),
+        _ => match linux::original_dst_ipv6(sock) {
+            Ok(Some(addr)) => Ok(addr.as_socket()),
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+        },
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn orig_dst_addr(_: &tokio::net::TcpStream) -> io::Result<SocketAddr> {
+fn orig_dst_addr(_: &tokio::net::TcpStream) -> io::Result<Option<SocketAddr>> {
     Err(io::Error::new(
         io::ErrorKind::Other,
         "SO_ORIGINAL_DST not supported on this operating system",
@@ -62,7 +55,6 @@ pub fn orig_dst_addr(_: &tokio::net::TcpStream) -> io::Result<SocketAddr> {
 }
 
 #[cfg(not(target_os = "linux"))]
-#[allow(unsafe_code)]
 pub fn set_transparent(_: &TcpListener) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Other,
@@ -73,99 +65,63 @@ pub fn set_transparent(_: &TcpListener) -> io::Result<()> {
 #[cfg(target_os = "linux")]
 #[allow(unsafe_code)]
 mod linux {
-    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-    use std::os::unix::io::RawFd;
-    use std::{io, mem};
+    use std::os::unix::io::AsRawFd;
 
-    use log::warn;
+    use socket2::{SockAddr, SockRef};
+    use tokio::io;
 
-    pub unsafe fn so_original_dst(fd: RawFd) -> io::Result<SocketAddr> {
-        let mut sockaddr: libc::sockaddr_storage = mem::zeroed();
-        let mut socklen: libc::socklen_t = mem::size_of::<libc::sockaddr_storage>() as u32;
-
-        let ret = libc::getsockopt(
-            fd,
-            libc::SOL_IP,
-            libc::SO_ORIGINAL_DST,
-            &mut sockaddr as *mut _ as *mut _,
-            &mut socklen as *mut _ as *mut _,
-        );
-        if ret != 0 {
-            let e = io::Error::last_os_error();
-            warn!("failed to read SO_ORIGINAL_DST: {:?}", e);
-            return Err(e);
+    // Replace with socket2's version once there is a release that contains
+    // https://github.com/rust-lang/socket2/pull/360
+    pub fn original_dst(sock: &SockRef) -> io::Result<Option<SockAddr>> {
+        // Safety: `getsockopt` initialises the `SockAddr` for us.
+        unsafe {
+            SockAddr::init(|storage, len| {
+                match libc::getsockopt(
+                    sock.as_raw_fd(),
+                    libc::SOL_IP,
+                    libc::SO_ORIGINAL_DST,
+                    storage.cast(),
+                    len,
+                ) {
+                    -1 => Err(std::io::Error::last_os_error()),
+                    retval => Ok(retval),
+                }
+            })
         }
-
-        mk_addr(&sockaddr, socklen)
+        .map_or_else(
+            |e| match e.raw_os_error() {
+                Some(libc::ENOENT) => Ok(None),
+                _ => Err(e),
+            },
+            |(_, addr)| Ok(Some(addr)),
+        )
     }
 
-    // Borrowed with love from net2-rs
-    // https://github.com/rust-lang-nursery/net2-rs/blob/1b4cb4fb05fbad750b271f38221eab583b666e5e/src/socket.rs#L103
-    //
-    // Copyright (c) 2014 The Rust Project Developers
-    fn mk_addr(storage: &libc::sockaddr_storage, len: libc::socklen_t) -> io::Result<SocketAddr> {
-        match storage.ss_family as libc::c_int {
-            libc::AF_INET => {
-                assert!(len as usize >= mem::size_of::<libc::sockaddr_in>());
-
-                let sa = {
-                    let sa = storage as *const _ as *const libc::sockaddr_in;
-                    unsafe { *sa }
-                };
-
-                let bits = ntoh32(sa.sin_addr.s_addr);
-                let ip = Ipv4Addr::new(
-                    (bits >> 24) as u8,
-                    (bits >> 16) as u8,
-                    (bits >> 8) as u8,
-                    bits as u8,
-                );
-                let port = sa.sin_port;
-                Ok(SocketAddr::V4(SocketAddrV4::new(ip, ntoh16(port))))
-            }
-            libc::AF_INET6 => {
-                assert!(len as usize >= mem::size_of::<libc::sockaddr_in6>());
-
-                let sa = {
-                    let sa = storage as *const _ as *const libc::sockaddr_in6;
-                    unsafe { *sa }
-                };
-
-                let arr = sa.sin6_addr.s6_addr;
-                let ip = Ipv6Addr::new(
-                    (arr[0] as u16) << 8 | (arr[1] as u16),
-                    (arr[2] as u16) << 8 | (arr[3] as u16),
-                    (arr[4] as u16) << 8 | (arr[5] as u16),
-                    (arr[6] as u16) << 8 | (arr[7] as u16),
-                    (arr[8] as u16) << 8 | (arr[9] as u16),
-                    (arr[10] as u16) << 8 | (arr[11] as u16),
-                    (arr[12] as u16) << 8 | (arr[13] as u16),
-                    (arr[14] as u16) << 8 | (arr[15] as u16),
-                );
-
-                let port = sa.sin6_port;
-                let flowinfo = sa.sin6_flowinfo;
-                let scope_id = sa.sin6_scope_id;
-                Ok(SocketAddr::V6(SocketAddrV6::new(
-                    ip,
-                    ntoh16(port),
-                    flowinfo,
-                    scope_id,
-                )))
-            }
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "invalid argument",
-            )),
+    // Replace with socket2's version once there is a release that contains
+    // https://github.com/rust-lang/socket2/pull/360
+    pub fn original_dst_ipv6(sock: &SockRef) -> io::Result<Option<SockAddr>> {
+        // Safety: `getsockopt` initialises the `SockAddr` for us.
+        unsafe {
+            SockAddr::init(|storage, len| {
+                match libc::getsockopt(
+                    sock.as_raw_fd(),
+                    libc::SOL_IPV6,
+                    libc::IP6T_SO_ORIGINAL_DST,
+                    storage.cast(),
+                    len,
+                ) {
+                    -1 => Err(std::io::Error::last_os_error()),
+                    retval => Ok(retval),
+                }
+            })
         }
-    }
-
-    fn ntoh16(i: u16) -> u16 {
-        <u16>::from_be(i)
-    }
-
-    fn ntoh32(i: u32) -> u32 {
-        <u32>::from_be(i)
+        .map_or_else(
+            |e| match e.raw_os_error() {
+                Some(libc::ENOENT) => Ok(None),
+                _ => Err(e),
+            },
+            |(_, addr)| Ok(Some(addr)),
+        )
     }
 }
 


### PR DESCRIPTION
While there, fix original destination detection for IPv6 traffic.

Signed-off-by: Piotr Sikora <piotr@aviatrix.com>