### PR TITLE
metrics: implement connections metric with full set of labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +266,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "console-api"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +393,12 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpp_demangle"
@@ -448,6 +497,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -663,7 +756,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -854,6 +947,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1039,15 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1041,7 +1167,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1080,6 +1206,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -1317,6 +1453,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef7a8ed15bcffc55fe0328931ef20d393bb89ad704756a37bd20cffb4804f306"
+dependencies = [
+ "chrono",
+ "itertools",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1631,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1557,6 +1707,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "semver"
@@ -1718,6 +1874,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,6 +1915,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -2036,6 +2212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2261,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2274,6 +2462,7 @@ dependencies = [
  "once_cell",
  "pprof",
  "prometheus-client",
+ "prometheus-parse",
  "prost",
  "prost-build",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ tracing-subscriber = { version = "0.3.11" , features = ["registry", "env-filter"
 dyn-clone = "1.0.9"
 realm_io = "0.3.5"
 go-parse-duration = "0.1.1"
+prometheus-parse = "0.2.3"
 
 [build-dependencies]
 tonic-build = { version = "0.8", default-features=false, features = ["prost"] }

--- a/examples/localhost.yaml
+++ b/examples/localhost.yaml
@@ -6,6 +6,7 @@
   workloadIp: "127.0.0.1"
   protocol: HBONE
   node: local
+  workload_name: foo
 # Define another local address, but this one uses TCP. This allows testing HBONE and TCP with one config.
 - name: local-tcp
   namespace: default

--- a/examples/localhost.yaml
+++ b/examples/localhost.yaml
@@ -6,7 +6,6 @@
   workloadIp: "127.0.0.1"
   protocol: HBONE
   node: local
-  workload_name: foo
 # Define another local address, but this one uses TCP. This allows testing HBONE and TCP with one config.
 - name: local-tcp
   namespace: default

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,7 +31,7 @@ pub async fn build_with_cert(
     cert_manager: impl CertificateProvider,
 ) -> anyhow::Result<Bound> {
     let mut registry = Registry::default();
-    let metrics = Arc::new(Metrics::new(registry.sub_registry_with_prefix("istio")));
+    let metrics = Arc::new(Metrics::from(&mut registry));
 
     let shutdown = signal::Shutdown::new();
     // Setup a drain channel. drain_tx is used to trigger a drain, which will complete

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::fmt;
+use std::io::Write;
 use std::sync::{Arc, RwLock};
 use tokio::sync::watch;
 use tokio::time::{sleep, Duration};
@@ -34,6 +35,12 @@ pub enum Identity {
         namespace: String,
         service_account: String,
     },
+}
+
+impl prometheus_client::encoding::text::Encode for Identity {
+    fn encode(&self, writer: &mut dyn Write) -> Result<(), std::io::Error> {
+        writer.write_all(self.to_string().as_bytes())
+    }
 }
 
 impl fmt::Display for Identity {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -15,6 +15,7 @@
 use prometheus_client::registry::Registry;
 
 mod meta;
+#[allow(non_camel_case_types)]
 pub mod traffic;
 pub mod xds;
 
@@ -27,12 +28,25 @@ pub struct Metrics {
 }
 
 impl Metrics {
-    pub fn new(registry: &mut Registry) -> Self {
+    fn new(registry: &mut Registry) -> Self {
         Self {
             xds: xds::Metrics::new(registry),
             meta: meta::Metrics::new(registry),
             traffic: traffic::Metrics::new(registry),
         }
+    }
+}
+
+impl From<&mut Registry> for Metrics {
+    fn from(registry: &mut Registry) -> Self {
+        Metrics::new(registry.sub_registry_with_prefix("istio"))
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        let mut registry = Registry::default();
+        Metrics::new(registry.sub_registry_with_prefix("istio"))
     }
 }
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -52,27 +52,16 @@ impl Default for Metrics {
     }
 }
 
-// impl<M1, M2> Metrics
-// where
-//     Self: Recorder<M1> + Recorder<M2>,
-//     M1: std::fmt::Debug,
-//     M2: std::fmt::Debug,
-// {
-//     pub fn record_and_defer(&self, metric: &M1) {
-//         self.record(metric)
-//     }
-// }
-
 impl Metrics {
     #[must_use = "metric will be dropped (and thus recorded) immediately if not assign"]
     /// record_defer is used to record a metric now and another metric later once the MetricGuard is dropped
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let connection_open = ConnectionOpen {};
     /// // Record connection opened now
-    /// let connection_close = self.metrics.record_defer<_, ConnectionClosed>(&connection_open);
+    /// let connection_close = self.metrics.record_defer::<_, ConnectionClosed>(&connection_open);
     /// // Eventually, report connection closed
     /// drop(connection_close);
     /// ```

--- a/src/metrics/traffic.rs
+++ b/src/metrics/traffic.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::identity::Identity;
 use prometheus_client::encoding::text::Encode;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
@@ -24,8 +25,57 @@ pub(super) struct Metrics {
 }
 
 #[derive(Clone, Hash, PartialEq, Eq, Encode)]
+pub enum Reporter {
+    source,
+    destination,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+pub enum RequestProtocol {
+    tcp,
+    http,
+}
+
+#[derive(Default, Clone, Hash, PartialEq, Eq, Encode)]
+pub enum ResponseFlags {
+    #[default]
+    none,
+}
+
+#[derive(Default, Clone, Hash, PartialEq, Eq, Encode)]
+pub enum SecurityPolicy {
+    #[default]
+    unknown,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, Encode)]
 pub struct ConnectionOpen {
     // TODO: add full set of labels
+    pub reporter: Reporter,
+
+    pub source_workload: String,
+    pub source_canonical_service: String,
+    pub source_canonical_revision: String,
+    pub source_workload_namespace: String,
+    pub source_principal: Identity,
+    pub source_app: String,
+    pub source_version: String,
+    pub source_cluster: String,
+
+    pub destination_service: String,
+
+    pub destination_workload: String,
+    pub destination_canonical_service: String,
+    pub destination_canonical_revision: String,
+    pub destination_workload_namespace: String,
+    pub destination_principal: Identity,
+    pub destination_app: String,
+    pub destination_version: String,
+    pub destination_cluster: String,
+
+    pub request_protocol: RequestProtocol,
+    pub response_flags: ResponseFlags,
+    pub connection_security_policy: SecurityPolicy,
 }
 
 impl Metrics {

--- a/src/metrics/traffic.rs
+++ b/src/metrics/traffic.rs
@@ -12,87 +12,214 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::identity::Identity;
+use std::io::{Error, Write};
+
 use prometheus_client::encoding::text::Encode;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::registry::Registry;
 
+use crate::identity::Identity;
 use crate::metrics::Recorder;
+use crate::workload::Workload;
 
 pub(super) struct Metrics {
-    pub(super) connection_opens: Family<ConnectionOpen, Counter>,
+    pub(super) connection_opens: Family<ConnectionInternal, Counter>,
+    pub(super) connection_close: Family<ConnectionInternal, Counter>,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Copy, Default, Hash, PartialEq, Eq, Encode)]
 pub enum Reporter {
+    #[default]
     source,
+    #[allow(dead_code)]
     destination,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Copy, Default, Hash, PartialEq, Eq, Encode)]
 pub enum RequestProtocol {
+    #[default]
     tcp,
+    #[allow(dead_code)]
     http,
 }
 
-#[derive(Default, Clone, Hash, PartialEq, Eq, Encode)]
+#[derive(Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum ResponseFlags {
     #[default]
     none,
 }
 
-#[derive(Default, Clone, Hash, PartialEq, Eq, Encode)]
+impl Encode for ResponseFlags {
+    fn encode(&self, writer: &mut dyn Write) -> Result<(), Error> {
+        match self {
+            ResponseFlags::none => writer.write_all(b"-"),
+        }
+    }
+}
+
+#[derive(Default, Copy, Clone, Hash, PartialEq, Eq, Encode)]
 pub enum SecurityPolicy {
     #[default]
     unknown,
 }
+#[derive(Default, Hash, PartialEq, Eq, Clone, Debug)]
+// DefaultedUnknown is a wrapper around an Option that encodes as "unknown" when missing, rather than ""
+struct DefaultedUnknown<T>(Option<T>);
 
-#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+impl From<String> for DefaultedUnknown<String> {
+    fn from(t: String) -> Self {
+        if t.is_empty() {
+            DefaultedUnknown(None)
+        } else {
+            DefaultedUnknown(Some(t))
+        }
+    }
+}
+
+impl<T> From<Option<T>> for DefaultedUnknown<T> {
+    fn from(t: Option<T>) -> Self {
+        DefaultedUnknown(t)
+    }
+}
+
+impl From<Identity> for DefaultedUnknown<Identity> {
+    fn from(t: Identity) -> Self {
+        DefaultedUnknown(Some(t))
+    }
+}
+
+impl<T: Encode> Encode for DefaultedUnknown<T> {
+    fn encode(&self, writer: &mut dyn Write) -> Result<(), Error> {
+        match self {
+            DefaultedUnknown(Some(i)) => i.encode(writer),
+            DefaultedUnknown(None) => writer.write_all(b"unknown"),
+        }
+    }
+}
+
+pub struct ConnectionClose<'a>(&'a ConnectionOpen);
+
+#[derive(Clone)]
 pub struct ConnectionOpen {
-    // TODO: add full set of labels
     pub reporter: Reporter,
-
-    pub source_workload: String,
-    pub source_canonical_service: String,
-    pub source_canonical_revision: String,
-    pub source_workload_namespace: String,
-    pub source_principal: Identity,
-    pub source_app: String,
-    pub source_version: String,
-    pub source_cluster: String,
-
-    pub destination_service: String,
-
-    pub destination_workload: String,
-    pub destination_canonical_service: String,
-    pub destination_canonical_revision: String,
-    pub destination_workload_namespace: String,
-    pub destination_principal: Identity,
-    pub destination_app: String,
-    pub destination_version: String,
-    pub destination_cluster: String,
-
-    pub request_protocol: RequestProtocol,
-    pub response_flags: ResponseFlags,
+    pub source: Workload,
+    pub destination: Option<Workload>,
+    pub destination_service: Option<String>,
     pub connection_security_policy: SecurityPolicy,
+}
+
+impl<'a> From<&'a ConnectionOpen> for ConnectionClose<'a> {
+    fn from(c: &'a ConnectionOpen) -> Self {
+        ConnectionClose(c)
+    }
+}
+
+impl From<ConnectionClose<'_>> for ConnectionInternal {
+    fn from(c: ConnectionClose) -> Self {
+        c.0.into()
+    }
+}
+impl From<&ConnectionOpen> for ConnectionInternal {
+    fn from(c: &ConnectionOpen) -> Self {
+        let mut co = ConnectionInternal {
+            reporter: c.reporter,
+
+            source_workload: c.source.workload_name.clone().into(),
+            source_canonical_service: c.source.canonical_name.clone().into(),
+            source_canonical_revision: c.source.canonical_revision.clone().into(),
+            source_workload_namespace: c.source.namespace.clone().into(),
+            source_principal: c.source.identity().into(),
+            source_app: c.source.canonical_name.clone().into(),
+            source_version: c.source.canonical_revision.clone().into(),
+            source_cluster: "Kubernetes".to_string().into(), // TODO
+
+            destination_service: c.destination_service.clone().into(),
+            request_protocol: RequestProtocol::tcp,
+            response_flags: ResponseFlags::none,
+            connection_security_policy: c.connection_security_policy,
+
+            ..Default::default()
+        };
+        if let Some(w) = c.destination.as_ref() {
+            co.destination_workload = w.workload_name.clone().into();
+            co.destination_canonical_service = w.canonical_name.clone().into();
+            co.destination_canonical_revision = w.canonical_revision.clone().into();
+            co.destination_workload_namespace = w.namespace.clone().into();
+            co.destination_principal = w.identity().into();
+            co.destination_app = w.canonical_name.clone().into();
+            co.destination_version = w.canonical_revision.clone().into();
+            co.destination_cluster = "Kubernetes".to_string().into(); // TODO
+        }
+        co
+    }
+}
+
+#[derive(Clone, Hash, Default, PartialEq, Eq, Encode)]
+pub(super) struct ConnectionInternal {
+    reporter: Reporter,
+
+    source_workload: DefaultedUnknown<String>,
+    source_canonical_service: DefaultedUnknown<String>,
+    source_canonical_revision: DefaultedUnknown<String>,
+    source_workload_namespace: DefaultedUnknown<String>,
+    source_principal: DefaultedUnknown<Identity>,
+    source_app: DefaultedUnknown<String>,
+    source_version: DefaultedUnknown<String>,
+    source_cluster: DefaultedUnknown<String>,
+
+    destination_service: DefaultedUnknown<String>,
+
+    destination_workload: DefaultedUnknown<String>,
+    destination_canonical_service: DefaultedUnknown<String>,
+    destination_canonical_revision: DefaultedUnknown<String>,
+    destination_workload_namespace: DefaultedUnknown<String>,
+    destination_principal: DefaultedUnknown<Identity>,
+    destination_app: DefaultedUnknown<String>,
+    destination_version: DefaultedUnknown<String>,
+    destination_cluster: DefaultedUnknown<String>,
+
+    request_protocol: RequestProtocol,
+    response_flags: ResponseFlags,
+    connection_security_policy: SecurityPolicy,
 }
 
 impl Metrics {
     pub fn new(registry: &mut Registry) -> Self {
         let connection_opens = Family::default();
         registry.register(
-            "connections_opened",
+            "tcp_connections_opened",
             "The total number of TCP connections opened",
             Box::new(connection_opens.clone()),
         );
+        let connection_close = Family::default();
+        registry.register(
+            "tcp_connections_closed",
+            "The total number of TCP connections closed",
+            Box::new(connection_close.clone()),
+        );
 
-        Self { connection_opens }
+        Self {
+            connection_opens,
+            connection_close,
+        }
     }
 }
 
 impl Recorder<ConnectionOpen> for super::Metrics {
     fn record(&self, reason: &ConnectionOpen) {
-        self.traffic.connection_opens.get_or_create(reason).inc();
+        self.traffic
+            .connection_opens
+            .get_or_create(&ConnectionInternal::from(reason))
+            .inc();
+    }
+}
+
+impl Recorder<ConnectionClose<'_>> for super::Metrics {
+    fn record(&self, reason: &ConnectionClose) {
+        self.traffic
+            .connection_close
+            .get_or_create(&ConnectionInternal::from(reason.0))
+            .inc();
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -64,7 +64,7 @@ impl Proxy {
             cert_manager.clone(),
             workloads.clone(),
             inbound.address().port(),
-            metrics,
+            metrics.clone(),
             drain.clone(),
         )
         .await?;
@@ -73,6 +73,7 @@ impl Proxy {
             cert_manager.clone(),
             inbound.address().port(),
             workloads.clone(),
+            metrics,
             drain,
         )
         .await?;

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -24,12 +24,12 @@ use tracing::{debug, error, info, warn};
 use crate::config::Config;
 use crate::identity::CertificateProvider;
 use crate::metrics::traffic::Reporter;
-use crate::metrics::{traffic, Metrics, Recorder};
+use crate::metrics::{traffic, Metrics};
 use crate::proxy::inbound::{Inbound, InboundConnect};
 use crate::proxy::Error;
+use crate::socket;
 use crate::socket::relay;
 use crate::workload::{Protocol, Workload, WorkloadInformation};
-use crate::{identity, socket};
 
 pub struct Outbound {
     cfg: Config,
@@ -151,34 +151,18 @@ impl OutboundConnection {
             req.source.name, orig, req.gateway, req.request_type, req.direction
         );
 
-        self.metrics.record(&traffic::ConnectionOpen {
+        let connection_metrics = traffic::ConnectionOpen {
             reporter: Reporter::source,
-            source_workload: req.source.workload_name.clone(),
-            source_canonical_service: req.source.canonical_name.clone(),
-            source_canonical_revision: req.source.canonical_revision.clone(),
-            source_workload_namespace: req.source.namespace.clone(),
-            source_principal: req.source.identity(),
-            source_app: req.source.canonical_name.clone(),
-            source_version: req.source.canonical_revision.clone(),
-            source_cluster: "Kubernetes".to_string(),
-
-            destination_service: "".to_string(),
-
-            // TODO: get dest workload
-            destination_workload: req.source.workload_name.clone(),
-            destination_canonical_service: req.source.canonical_name.clone(),
-            destination_canonical_revision: req.source.canonical_revision.clone(),
-            destination_workload_namespace: req.source.namespace.clone(),
-            destination_principal: req.source.identity(),
-            destination_app: req.source.canonical_name.clone(),
-            destination_version: req.source.canonical_revision.clone(),
-            destination_cluster: "Kubernetes".to_string(),
-
-            request_protocol: traffic::RequestProtocol::tcp,
-            response_flags: traffic::ResponseFlags::none,
+            source: req.source.clone(),
+            destination: req.destination_workload.clone(),
             // Client doesn't know if server verified, so we can't claim it was mTLS
             connection_security_policy: traffic::SecurityPolicy::unknown,
-        });
+            destination_service: None,
+        };
+        let _connection_close = self
+            .metrics
+            .record_defer::<_, traffic::ConnectionClose>(&connection_metrics);
+        // self.metrics.record(&connection_metrics);
         if req.request_type == RequestType::DirectLocal {
             // For same node, we just access it directly rather than making a full network connection.
             // Pass our `stream` over to the inbound handler, which will process as usual
@@ -215,7 +199,7 @@ impl OutboundConnection {
                 let id = &req.source.identity();
                 let cert = self.cert_manager.fetch_certificate(id).await?;
                 let connector = cert
-                    .connector(&req.destination_identity)?
+                    .connector(&req.destination_workload.map(|w| w.identity()))?
                     .configure()
                     .expect("configure");
                 let tcp_stream = TcpStream::connect(req.gateway).await?;
@@ -285,7 +269,7 @@ impl OutboundConnection {
                 protocol: Protocol::TCP,
                 source: source_workload,
                 destination: target,
-                destination_identity: None,
+                destination_workload: None,
                 gateway: target,
                 direction: Direction::Outbound,
                 request_type: RequestType::Passthrough,
@@ -295,14 +279,13 @@ impl OutboundConnection {
         // For case source client has enabled waypoint
         if !source_workload.waypoint_addresses.is_empty() {
             let waypoint_address = source_workload.choose_waypoint_address().unwrap();
-            let destination_identity = Some(source_workload.identity());
             return Ok(Request {
                 // Always use HBONE here
                 protocol: Protocol::HBONE,
-                source: source_workload,
+                source: source_workload.clone(),
                 // Load balancing decision is deferred to remote proxy
                 destination: target,
-                destination_identity,
+                destination_workload: Some(source_workload), // TODO: should this be the waypoint workload?
                 // Send to the remote proxy
                 gateway: SocketAddr::from((waypoint_address, 15001)),
                 // Let the client remote know we are on the outbound path. The remote proxy should strictly
@@ -326,8 +309,8 @@ impl OutboundConnection {
                 source: source_workload,
                 // Use the original VIP, not translated
                 destination: target,
+                destination_workload: Some(us.workload), // TODO: should this be the waypoint workload?
                 gateway: SocketAddr::from((waypoint_address, 15006)),
-                destination_identity: us.workload.identity().into(),
                 // Let the client remote know we are on the inbound path.
                 direction: Direction::Inbound,
                 request_type: RequestType::ToServerWaypoint,
@@ -342,7 +325,7 @@ impl OutboundConnection {
                 protocol: Protocol::HBONE,
                 source: source_workload,
                 destination: SocketAddr::from((us.workload.workload_ip, us.port)),
-                destination_identity: us.workload.identity().into(),
+                destination_workload: Some(us.workload.clone()),
                 // We would want to send to 127.0.0.1:15008 in theory. However, the inbound listener
                 // expects to lookup the desired certificate based on the destination IP. If we send directly,
                 // we would try to lookup an IP for 127.0.0.1.
@@ -365,7 +348,7 @@ impl OutboundConnection {
             protocol: us.workload.protocol,
             source: source_workload,
             destination: SocketAddr::from((us.workload.workload_ip, us.port)),
-            destination_identity: us.workload.identity().into(),
+            destination_workload: Some(us.workload.clone()),
             gateway: us
                 .workload
                 .gateway_address
@@ -393,7 +376,7 @@ struct Request {
     direction: Direction,
     source: Workload,
     destination: SocketAddr,
-    destination_identity: Option<identity::Identity>,
+    destination_workload: Option<Workload>,
     gateway: SocketAddr,
     request_type: RequestType,
 }
@@ -434,7 +417,7 @@ mod tests {
 
     use bytes::Bytes;
 
-    use crate::workload;
+    use crate::{identity, workload};
 
     use crate::xds::istio::workload::Protocol as XdsProtocol;
     use crate::xds::istio::workload::Workload as XdsWorkload;
@@ -469,7 +452,7 @@ mod tests {
             workloads: wi,
             hbone_port: 15008,
             cfg,
-            metrics: Arc::new(Default::default())
+            metrics: Arc::new(Default::default()),
         };
 
         let req = outbound

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -159,10 +159,10 @@ impl OutboundConnection {
             connection_security_policy: traffic::SecurityPolicy::unknown,
             destination_service: None,
         };
+        // _connection_close will record once dropped
         let _connection_close = self
             .metrics
             .record_defer::<_, traffic::ConnectionClose>(&connection_metrics);
-        // self.metrics.record(&connection_metrics);
         if req.request_type == RequestType::DirectLocal {
             // For same node, we just access it directly rather than making a full network connection.
             // Pass our `stream` over to the inbound handler, which will process as usual


### PR DESCRIPTION
Currently, we just have an empty Connections_opened metric. This introduces the full istio label set (almost - `cluster` is not implemented). It also adds the `closed` variant.

To test this and future metrics, support was added to the tests to parse prometheus metrics and run (trivial) queries over them.