### PR TITLE
xds: allow multiple types

### DIFF
--- a/src/xds/types.rs
+++ b/src/xds/types.rs
@@ -38,3 +38,4 @@ pub mod istio {
 }
 
 pub const WORKLOAD_TYPE: &str = "type.googleapis.com/istio.workload.Workload";
+pub const RBAC_TYPE: &str = "type.googleapis.com/istio.workload.Authorization";


### PR DESCRIPTION
Currently, we actually only request `Workload`. In the near future, though, we will also fetch Authz policies. This improves the client to handle this.

Note: while we have logic for Authz in the code now, its essentially dead code. this is just a placeholder, in 1-2 weeks we will utilize it.

As part of this, a few things were refactored:

* Handler: instead of a HandlerContext that can be called to explicitly NACK, just have handlers return an Err to NACK. This is easier to use.
* Remove the `Workload(XdsResource<Workload>)` enum; just use `XdsResource<T>` types directly. The enum didn't provide any value and made things more complex