### PR TITLE
Add test for request to a VIP

### DIFF
--- a/examples/localhost.yaml
+++ b/examples/localhost.yaml
@@ -6,6 +6,9 @@
   workloadIp: "127.0.0.1"
   protocol: HBONE
   node: local
+  vips:
+    "127.10.0.1":
+      80: 8080
 # Define another local address, but this one uses TCP. This allows testing HBONE and TCP with one config.
 - name: local-tcp
   namespace: default
@@ -13,3 +16,6 @@
   workloadIp: "127.0.0.2"
   protocol: TCP
   node: local
+  vips:
+    "127.10.0.1":
+      80: 8080

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -349,18 +349,18 @@ async fn handle_server_shutdown(
 }
 
 async fn handle_config_dump(mut dump: ConfigDump, _req: Request<Body>) -> Response<Body> {
-    if let Some(path) = dump.config.local_xds_path.clone() {
-        match tokio::fs::read_to_string(path).await {
+    if let Some(cfg) = dump.config.local_xds_config.clone() {
+        match cfg.read_to_string().await {
             Ok(data) => match serde_yaml::from_str(&data) {
                 Ok(raw_workloads) => dump.static_workloads = raw_workloads,
                 Err(e) => error!(
                     "Failed to load static workloads from local XDS {:?}:{:?}",
-                    dump.config.local_xds_path, e
+                    dump.config.local_xds_config, e
                 ),
             },
             Err(e) => error!(
-                "Failed to read local XDS file {:?}:{:?}",
-                dump.config.local_xds_path, e
+                "Failed to read local XDS config {:?}:{:?}",
+                dump.config.local_xds_config, e
             ),
         }
     }

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -12,18 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::config;
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+
+use bytes::{BufMut, Bytes};
+
+use crate::config;
+use crate::config::ConfigSource;
+use crate::workload::Protocol::{HBONE, TCP};
+use crate::workload::{LocalWorkload, Workload};
 
 pub mod app;
 pub mod ca;
 pub mod helpers;
 pub mod tcp;
 
-pub fn test_config() -> config::Config {
+pub fn test_config_with_port(port: u16) -> config::Config {
     config::Config {
         xds_address: None,
-        local_xds_path: Some("examples/localhost.yaml".to_string()),
+        fake_ca: true,
+        local_xds_config: Some(ConfigSource::Static(local_xds_config(port).unwrap())),
         socks5_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         admin_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
@@ -31,4 +39,58 @@ pub fn test_config() -> config::Config {
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         ..config::parse_config().unwrap()
     }
+}
+
+pub fn test_config() -> config::Config {
+    test_config_with_port(80)
+}
+
+const HBONE_IP: &str = "127.0.0.1";
+const TCP_IP: &str = "127.0.0.2";
+const TEST_VIP: &str = "127.10.0.1";
+
+fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
+    let mut b = bytes::BytesMut::new().writer();
+    let res: Vec<LocalWorkload> = vec![
+        LocalWorkload {
+            workload: Workload {
+                workload_ip: HBONE_IP.parse()?,
+                protocol: HBONE,
+                name: "local-hbone".to_string(),
+                namespace: "default".to_string(),
+                service_account: "default".to_string(),
+                node: "local".to_string(),
+
+                waypoint_addresses: vec![],
+                gateway_address: None,
+                workload_name: "".to_string(),
+                workload_type: "".to_string(),
+                canonical_name: "".to_string(),
+                canonical_revision: "".to_string(),
+                native_hbone: false,
+            },
+            vips: HashMap::from([(TEST_VIP.to_string(), HashMap::from([(80u16, echo_port)]))]),
+        },
+        LocalWorkload {
+            workload: Workload {
+                workload_ip: TCP_IP.parse()?,
+                protocol: TCP,
+                name: "local-tcp".to_string(),
+                namespace: "default".to_string(),
+                service_account: "default".to_string(),
+                node: "local".to_string(),
+
+                waypoint_addresses: vec![],
+                gateway_address: None,
+                workload_name: "".to_string(),
+                workload_type: "".to_string(),
+                canonical_name: "".to_string(),
+                canonical_revision: "".to_string(),
+                native_hbone: false,
+            },
+            vips: HashMap::from([(TEST_VIP.to_string(), HashMap::from([(80u16, echo_port)]))]),
+        },
+    ];
+    serde_yaml::to_writer(&mut b, &res)?;
+    Ok(b.into_inner().freeze())
 }


### PR DESCRIPTION
Currently we only test requests to workloads directly. This adds a VIP test.

As part of this, we needed to extend the local XDS reading. I made a new LocalWorkload that takes in a slight extension to the internal `Workload` type. Using Xds workload isn't really viable since the format is very hard to mix with yaml.

For the VIP, we need to set the target port. This cannot be done easily in the tests, which use dynamic ports. To fix this, I made the config allow File OR static config. Tests dynamically generate the test config based on the assigned port.