### PR TITLE
support original source proxy

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,12 +34,14 @@ const CA_ADDRESS: &str = "CA_ADDRESS";
 const TERMINATION_GRACE_PERIOD: &str = "TERMINATION_GRACE_PERIOD";
 const FAKE_CA: &str = "FAKE_CA";
 const ZTUNNEL_WORKER_THREADS: &str = "ZTUNNEL_WORKER_THREADS";
+const ENABLE_ORIG_SRC: &str = "ISTIO_ENABLE_ORIG_SRC";
 const PROXY_CONFIG: &str = "PROXY_CONFIG";
 
 const DEFAULT_WORKER_THREADS: u16 = 2;
 const DEFAULT_ADMIN_PORT: u16 = 15000;
 const DEFAULT_STATUS_PORT: u16 = 15021;
 const DEFAULT_DRAIN_DURATION: Duration = Duration::from_secs(5);
+const ENABLE_ORIG_SRC_DEFAULT: bool = false;
 
 #[derive(serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum RootCert {
@@ -104,6 +106,9 @@ pub struct Config {
 
     /// Specify the number of worker threads the Tokio Runtime will use.
     pub num_worker_threads: usize,
+
+    // If true, then use original source proxying
+    pub enable_original_source: bool,
 
     // CLI args passed to ztunnel at runtime
     pub proxy_args: String,
@@ -230,6 +235,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
                 .expect("concurrency cannot be negative"),
         )?,
 
+        enable_original_source: parse_default(ENABLE_ORIG_SRC, ENABLE_ORIG_SRC_DEFAULT)?,
         proxy_args: parse_args(),
         zero_copy_enabled: true,
     })

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -283,12 +283,7 @@ pub async fn freebind_connect(local: Option<IpAddr>, addr: SocketAddr) -> io::Re
             let local_addr = SocketAddr::new(src, 0);
             match socket::set_freebind(&socket) {
                 Err(err) => warn!("failed to set freebind: {:?}", err),
-                _ => {
-                    match socket.bind(local_addr) {
-                        Err(err) => warn!("failed to bind local addr: {:?}", err),
-                        _ => (),
-                    };
-                },
+                _ => if let Err(err) = socket.bind(local_addr) { warn!("failed to bind local addr: {:?}", err) },
 
             };
             Ok(socket.connect(addr).await?)

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -33,7 +33,7 @@ use crate::proxy::outbound::Outbound;
 use crate::proxy::socks5::Socks5;
 use crate::workload::WorkloadInformation;
 use crate::{config, identity, socket, tls};
-// use hyper::{header, Body, Request};
+use hyper::{header, Body, Request};
 
 mod inbound;
 mod inbound_passthrough;
@@ -243,37 +243,37 @@ impl TryFrom<&str> for TraceParent {
         })
     }
 }
-// pub fn get_original_src_from_fwded(req: &Request<Body>) -> Option<IpAddr> {
-//     let deli: &[_] = &[' ', '"'];
-//     let first = req.headers().get(header::FORWARDED)?;
-//     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
-//     // https://www.rfc-editor.org/rfc/rfc7239#section-4
-//     let first = first
-//         .to_str()
-//         .unwrap_or("")
-//         .split(',')
-//         .next()?
-//         .trim()
-//         .split(';')
-//         .find(|x| x.trim().to_lowercase().starts_with("for="))?
-//         .split('=')
-//         .nth(1)?
-//         .trim_matches(deli);
-//     info!("chun, stripped value: {:?}", first);
-//     if first.starts_with('[') {
-//         let deli: &[_] = &[' ', '[', ']'];
-//         first
-//             .trim_matches(deli)
-//             .split("]:")
-//             .next()?
-//             .parse::<IpAddr>()
-//             .ok()
-//     } else {
-//         first
-//             .parse::<IpAddr>()
-//             .map_or_else(|_| first.split(':').next()?.parse::<IpAddr>().ok(), Some)
-//     }
-// }
+
+pub fn get_original_src_from_fwded(req: &Request<Body>) -> Option<IpAddr> {
+    let deli: &[_] = &[' ', '"'];
+    let first = req.headers().get(header::FORWARDED)?;
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+    // https://www.rfc-editor.org/rfc/rfc7239#section-4
+    let first = first
+        .to_str()
+        .unwrap_or("")
+        .split(',')
+        .next()?
+        .trim()
+        .split(';')
+        .find(|x| x.trim().to_lowercase().starts_with("for="))?
+        .split('=')
+        .nth(1)?
+        .trim_matches(deli);
+    if first.starts_with('[') {
+        let deli: &[_] = &[' ', '[', ']'];
+        first
+            .trim_matches(deli)
+            .split("]:")
+            .next()?
+            .parse::<IpAddr>()
+            .ok()
+    } else {
+        first
+            .parse::<IpAddr>()
+            .map_or_else(|_| first.split(':').next()?.parse::<IpAddr>().ok(), Some)
+    }
+}
 
 pub fn get_original_src_from_stream(stream: &TcpStream) -> Option<IpAddr> {
     stream

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -22,7 +22,7 @@ use drain::Watch;
 use rand::Rng;
 use tokio::net::{TcpSocket, TcpStream};
 
-use tracing::{error, info, trace, warn};
+use tracing::{error, trace, warn};
 
 use inbound::Inbound;
 
@@ -33,7 +33,7 @@ use crate::proxy::outbound::Outbound;
 use crate::proxy::socks5::Socks5;
 use crate::workload::WorkloadInformation;
 use crate::{config, identity, socket, tls};
-use hyper::{header, Body, Request};
+// use hyper::{header, Body, Request};
 
 mod inbound;
 mod inbound_passthrough;
@@ -243,37 +243,37 @@ impl TryFrom<&str> for TraceParent {
         })
     }
 }
-pub fn get_original_src_from_fwded(req: &Request<Body>) -> Option<IpAddr> {
-    let deli: &[_] = &[' ', '"'];
-    let first = req.headers().get(header::FORWARDED)?;
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
-    // https://www.rfc-editor.org/rfc/rfc7239#section-4
-    let first = first
-        .to_str()
-        .unwrap_or("")
-        .split(',')
-        .next()?
-        .trim()
-        .split(';')
-        .find(|x| x.trim().to_lowercase().starts_with("for="))?
-        .split('=')
-        .nth(1)?
-        .trim_matches(deli);
-    info!("chun, stripped value: {:?}", first);
-    if first.starts_with('[') {
-        let deli: &[_] = &[' ', '[', ']'];
-        first
-            .trim_matches(deli)
-            .split("]:")
-            .next()?
-            .parse::<IpAddr>()
-            .ok()
-    } else {
-        first
-            .parse::<IpAddr>()
-            .map_or_else(|_| first.split(':').next()?.parse::<IpAddr>().ok(), Some)
-    }
-}
+// pub fn get_original_src_from_fwded(req: &Request<Body>) -> Option<IpAddr> {
+//     let deli: &[_] = &[' ', '"'];
+//     let first = req.headers().get(header::FORWARDED)?;
+//     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+//     // https://www.rfc-editor.org/rfc/rfc7239#section-4
+//     let first = first
+//         .to_str()
+//         .unwrap_or("")
+//         .split(',')
+//         .next()?
+//         .trim()
+//         .split(';')
+//         .find(|x| x.trim().to_lowercase().starts_with("for="))?
+//         .split('=')
+//         .nth(1)?
+//         .trim_matches(deli);
+//     info!("chun, stripped value: {:?}", first);
+//     if first.starts_with('[') {
+//         let deli: &[_] = &[' ', '[', ']'];
+//         first
+//             .trim_matches(deli)
+//             .split("]:")
+//             .next()?
+//             .parse::<IpAddr>()
+//             .ok()
+//     } else {
+//         first
+//             .parse::<IpAddr>()
+//             .map_or_else(|_| first.split(':').next()?.parse::<IpAddr>().ok(), Some)
+//     }
+// }
 
 pub fn get_original_src_from_stream(stream: &TcpStream) -> Option<IpAddr> {
     stream

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -284,6 +284,9 @@ pub fn get_original_src_from_stream(stream: &TcpStream) -> Option<IpAddr> {
 pub async fn freebind_connect(local: Option<IpAddr>, addr: SocketAddr) -> io::Result<TcpStream> {
     match local {
         None => Ok(TcpStream::connect(addr).await?),
+        // TODO: Need figure out how to handle case of loadbalancing to itself.
+        //       We use ztunnel addr instead, otherwise app side will be confused.
+        Some(src) if src == socket::to_canonical(addr).ip() => Ok(TcpStream::connect(addr).await?),
         Some(src) => {
             let socket = if src.is_ipv4() {
                 TcpSocket::new_v4()?

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -32,7 +32,7 @@ use crate::proxy::inbound_passthrough::InboundPassthrough;
 use crate::proxy::outbound::Outbound;
 use crate::proxy::socks5::Socks5;
 use crate::workload::WorkloadInformation;
-use crate::{config, identity, tls, socket};
+use crate::{config, identity, socket, tls};
 use hyper::{Body, Request};
 
 mod inbound;
@@ -266,7 +266,7 @@ pub fn get_original_src_from_xff(req: &Request<Body>) -> Option<IpAddr> {
 pub fn get_original_src_from_stream(stream: &TcpStream) -> Option<IpAddr> {
     match stream.peer_addr() {
         Ok(sa) => Some(to_canonical_ip(sa)),
-        _ => None
+        _ => None,
     }
 }
 
@@ -283,8 +283,11 @@ pub async fn freebind_connect(local: Option<IpAddr>, addr: SocketAddr) -> io::Re
             let local_addr = SocketAddr::new(src, 0);
             match socket::set_freebind(&socket) {
                 Err(err) => warn!("failed to set freebind: {:?}", err),
-                _ => if let Err(err) = socket.bind(local_addr) { warn!("failed to bind local addr: {:?}", err) },
-
+                _ => {
+                    if let Err(err) = socket.bind(local_addr) {
+                        warn!("failed to bind local addr: {:?}", err)
+                    }
+                }
             };
             Ok(socket.connect(addr).await?)
         }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -22,7 +22,7 @@ use drain::Watch;
 use rand::Rng;
 use tokio::net::{TcpSocket, TcpStream};
 
-use tracing::{error, trace, warn, info};
+use tracing::{error, info, trace, warn};
 
 use inbound::Inbound;
 
@@ -278,7 +278,7 @@ pub fn get_original_src_from_fwded(req: &Request<Body>) -> Option<IpAddr> {
 pub fn get_original_src_from_stream(stream: &TcpStream) -> Option<IpAddr> {
     stream
         .peer_addr()
-        .map_or(None, |sa| Some(to_canonical_ip(sa)))
+        .map_or(None, |sa| Some(socket::to_canonical(sa).ip()))
 }
 
 pub async fn freebind_connect(local: Option<IpAddr>, addr: SocketAddr) -> io::Result<TcpStream> {
@@ -304,5 +304,3 @@ pub async fn freebind_connect(local: Option<IpAddr>, addr: SocketAddr) -> io::Re
         }
     }
 }
-
-const ERR_TOKIO_RUNTIME_SHUTDOWN: &str = "A Tokio 1.x context was found, but it is being shutdown.";

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -138,7 +138,7 @@ impl Inbound {
                 Hbone(req) => {
                     let origin_src = if origin_src.is_some() {
                         // overwrite the original source if encoded in fwded from waypoint
-                        super::get_original_src_from_fwded(req)
+                        super::get_original_src_from_fwded(req).map_or(origin_src, Some)
                     } else {
                         origin_src
                     };

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -135,7 +135,7 @@ impl Inbound {
                 InboundConnect::DirectPath(stream) => {
                     let org_src = super::get_original_src_from_stream(stream);
                     super::freebind_connect(org_src, addr).await
-                },
+                }
                 Hbone(req) => {
                     let org_src = super::get_original_src_from_xff(req);
                     super::freebind_connect(org_src, addr).await

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -274,12 +274,12 @@ impl Inbound {
                     }
                 }
                 let status_code = match Self::handle_inbound(Hbone(req), org_src, addr)
-                        .instrument(tracing::span::Span::current())
-                        .await
-                    {
-                        Ok(_) => StatusCode::OK,
-                        Err(_) => StatusCode::SERVICE_UNAVAILABLE,
-                    };
+                    .instrument(tracing::span::Span::current())
+                    .await
+                {
+                    Ok(_) => StatusCode::OK,
+                    Err(_) => StatusCode::SERVICE_UNAVAILABLE,
+                };
 
                 Ok(Response::builder()
                     .status(status_code)

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -137,7 +137,7 @@ impl Inbound {
                     super::freebind_connect(org_src, addr).await
                 }
                 Hbone(req) => {
-                    let org_src = super::get_original_src_from_xff(req);
+                    let org_src = super::get_original_src_from_fwded(req);
                     super::freebind_connect(org_src, addr).await
                 }
             }

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{error, info, warn};
@@ -53,8 +53,14 @@ impl InboundPassthrough {
             let pi = self.pi.clone();
             match socket {
                 Ok((stream, remote)) => {
+                    let orig_src = if self.cfg.enable_original_source {
+                        super::get_original_src_from_stream(&stream)
+                    } else {
+                        None
+                    };
                     tokio::spawn(async move {
                         if let Err(e) = Self::proxy_inbound_plaintext(
+                            orig_src,
                             pi.clone(),
                             socket::to_canonical(remote),
                             stream,
@@ -76,6 +82,7 @@ impl InboundPassthrough {
     }
 
     async fn proxy_inbound_plaintext(
+        orig_src: Option<IpAddr>,
         pi: ProxyInputs,
         source: SocketAddr,
         mut inbound: TcpStream,
@@ -111,7 +118,7 @@ impl InboundPassthrough {
             return Ok(());
         }
         info!(%source, destination=%orig, component="inbound plaintext", "accepted connection");
-        let mut outbound = TcpStream::connect(orig).await?;
+        let mut outbound = super::freebind_connect(orig_src, orig).await?;
         relay(&mut inbound, &mut outbound, true).await?;
         info!(%source, destination=%orig, component="inbound plaintext", "connection complete");
         Ok(())

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -27,6 +27,7 @@ use crate::rbac;
 
 pub(super) struct InboundPassthrough {
     listener: TcpListener,
+    enable_orig_src: bool,
     pi: ProxyInputs,
 }
 
@@ -43,7 +44,10 @@ impl InboundPassthrough {
             transparent,
             "listener established",
         );
-        Ok(InboundPassthrough { listener, pi })
+        Ok(InboundPassthrough {
+            listener,
+            enable_orig_src: cfg.enable_original_source,
+       , pi })
     }
 
     pub(super) async fn run(self) {
@@ -53,7 +57,7 @@ impl InboundPassthrough {
             let pi = self.pi.clone();
             match socket {
                 Ok((stream, remote)) => {
-                    let orig_src = if self.cfg.enable_original_source {
+                    let orig_src = if self.enable_orig_src {
                         super::get_original_src_from_stream(&stream)
                     } else {
                         None

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -159,7 +159,11 @@ impl OutboundConnection {
             // We *could* apply this to all traffic, rather than just for destinations that are "captured"
             // However, we would then get inconsistent behavior where only node-local pods have RBAC enforced.
             info!("proxying to {} using node local fast path", req.destination);
-            let origin_src = super::get_original_src_from_stream(&stream);
+            let origin_src = if self.cfg.enable_original_source {
+                super::get_original_src_from_stream(&stream)
+            } else {
+                None
+            };
             let conn = rbac::Connection {
                 src_identity: Some(req.source.identity()),
                 src_ip: remote_addr,
@@ -199,18 +203,27 @@ impl OutboundConnection {
                     .method(hyper::Method::CONNECT)
                     .version(hyper::Version::HTTP_2)
                     .header(BAGGAGE_HEADER, baggage(&req))
-                    .header(TRACEPARENT_HEADER, self.id.header())
-                    // .header(hyper::header::FORWARDED, format!("for={}", remote_addr))
-                    .body(hyper::Body::empty())
-                    .unwrap();
-
+                    .header(TRACEPARENT_HEADER, self.id.header());
+                let request =
+                    if self.cfg.enable_original_source && req.request_type != RequestType::Direct {
+                        request.header(hyper::header::FORWARDED, format!("for={}", remote_addr))
+                    } else {
+                        request
+                    };
+                let request = request.body(hyper::Body::empty()).unwrap();
+                let local =
+                    if self.cfg.enable_original_source && req.request_type == RequestType::Direct {
+                        Some(remote_addr)
+                    } else {
+                        None
+                    };
                 let id = &req.source.identity();
                 let cert = self.pi.cert_manager.fetch_certificate(id).await?;
                 let connector = cert
                     .connector(req.destination_workload.map(|w| w.identity()).as_ref())?
                     .configure()
                     .expect("configure");
-                let tcp_stream = super::freebind_connect(Some(remote_addr), req.gateway).await?;
+                let tcp_stream = super::freebind_connect(local, req.gateway).await?;
                 tcp_stream.set_nodelay(true)?;
                 let tls_stream = connect_tls(connector, tcp_stream).await?;
                 let (mut request_sender, connection) = builder
@@ -242,11 +255,12 @@ impl OutboundConnection {
                     req.destination, req.gateway, req.request_type
                 );
                 // Create a TCP connection to upstream
-                let mut outbound = super::freebind_connect(
-                    super::get_original_src_from_stream(&stream),
-                    req.gateway,
-                )
-                .await?;
+                let local = if self.cfg.enable_original_source {
+                    super::get_original_src_from_stream(&stream)
+                } else {
+                    None
+                };
+                let mut outbound = super::freebind_connect(local, req.gateway).await?;
                 // Proxying data between downstrean and upstream
                 match relay(&mut stream, &mut outbound, self.pi.cfg.zero_copy_enabled).await {
                     // Connection closed with count of bytes transferred between streams

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -195,7 +195,7 @@ impl OutboundConnection {
                     .version(hyper::Version::HTTP_2)
                     .header(BAGGAGE_HEADER, baggage(&req))
                     .header(TRACEPARENT_HEADER, self.id.header())
-                    .header("X-Forwarded-For", remote_addr.to_string())
+                    .header(hyper::header::FORWARDED, format!("for={}", remote_addr))
                     .body(hyper::Body::empty())
                     .unwrap();
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -237,7 +237,11 @@ impl OutboundConnection {
                     req.destination, req.gateway, req.request_type
                 );
                 // Create a TCP connection to upstream
-                let mut outbound = super::freebind_connect(super::get_original_src_from_stream(&stream),req.gateway).await?;
+                let mut outbound = super::freebind_connect(
+                    super::get_original_src_from_stream(&stream),
+                    req.gateway,
+                )
+                .await?;
                 // Proxying data between downstrean and upstream
                 match relay(&mut stream, &mut outbound, self.pi.cfg.zero_copy_enabled).await {
                     // Connection closed with count of bytes transferred between streams

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -19,11 +19,19 @@ use realm_io;
 use socket2::SockRef;
 use tokio::io;
 use tokio::net::TcpListener;
+use tokio::net::TcpSocket;
 use tracing::warn;
 
 #[cfg(target_os = "linux")]
 pub fn set_transparent(l: &TcpListener) -> io::Result<()> {
     SockRef::from(l).set_ip_transparent(true)
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_freebind(sock: &TcpSocket) -> io::Result<()> {
+    let sock = SockRef::from(sock);
+    sock.set_ip_transparent(true)?;
+    linux::set_ip_freebind(&sock)
 }
 
 pub fn to_canonical(addr: SocketAddr) -> SocketAddr {
@@ -87,6 +95,14 @@ pub fn set_transparent(_: &TcpListener) -> io::Result<()> {
     ))
 }
 
+#[cfg(not(target_os = "linux"))]
+pub fn set_freebind(sock: &TcpSocket) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        "IP_FREEBIND not supported on this operating system",
+    ))
+}
+
 #[cfg(target_os = "linux")]
 #[allow(unsafe_code)]
 mod linux {
@@ -94,6 +110,23 @@ mod linux {
 
     use socket2::{SockAddr, SockRef};
     use tokio::io;
+
+    pub fn set_ip_freebind(sock: &SockRef) -> io::Result<()> {
+        unsafe {
+            let optval: libc::c_int = 1;
+            let ret = libc::setsockopt(
+                sock.as_raw_fd(),
+                libc::IPPROTO_IP,
+                libc::IP_FREEBIND,
+                &optval as *const _ as *const libc::c_void,
+                std::mem::size_of_val(&optval) as libc::socklen_t,
+            );
+            if ret != 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(())
+    }
 
     // Replace with socket2's version once there is a release that contains
     // https://github.com/rust-lang/socket2/pull/360

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -59,21 +59,6 @@ pub fn to_canonical(addr: SocketAddr) -> SocketAddr {
     SocketAddr::from((ip, addr.port()))
 }
 
-pub fn to_canonical(addr: SocketAddr) -> SocketAddr {
-    // another match has to be used for IPv4 and IPv6 support
-    // @zhlsunshine TODO: to_canonical() should be used when it becomes stable a function in Rust
-    let ip = match addr.ip() {
-        IpAddr::V4(_) => return addr,
-        IpAddr::V6(i) => match i.octets() {
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d] => {
-                IpAddr::V4(Ipv4Addr::new(a, b, c, d))
-            }
-            _ => return addr,
-        },
-    };
-    SocketAddr::from((ip, addr.port()))
-}
-
 pub fn orig_dst_addr_or_default(stream: &tokio::net::TcpStream) -> SocketAddr {
     to_canonical(match orig_dst_addr(stream) {
         Ok(addr) => addr,


### PR DESCRIPTION
Related to #241 
support original source proxy

-  HBONE connection:  use XFF header to encode the original source information.
-  local shortcut or direct tcp stream:  retrieve original source information from socket directly.


```shell
lichun@lichun-ws:~$ kubectl get pods -o wide 
NAME                                   READY   STATUS    RESTARTS      AGE   IP            NODE            NOMINATED NODE   READINESS GATES
httpbin-no-mesh-654476d4ff-pfgxp       1/1     Running   0             35m   10.101.2.14   kind1-worker3   <none>           <none>
httpbin-worker1-5d5748d687-pf4cb       1/1     Running   0             77m   10.101.3.15   kind1-worker    <none>           <none>
httpbin-worker2-f4b4788cb-vw2hz        1/1     Running   0             77m   10.101.1.9    kind1-worker2   <none>           <none>
httpbin-worker3-6989c5fb68-46g6r       1/1     Running   0             77m   10.101.2.13   kind1-worker3   <none>           <none>
notsleep-7dc8b55755-trgqk              1/1     Running   4 (29h ago)   3d    10.101.2.2    kind1-worker3   <none>           <none>
purchase-history-v1-6cdb997954-6rhfd   1/1     Running   4 (29h ago)   3d    10.101.3.2    kind1-worker    <none>           <none>
recommendation-79f7844ff-scmjq         1/1     Running   4 (29h ago)   3d    10.101.3.3    kind1-worker    <none>           <none>
sleep-5f5d4b5bfb-cdtrr                 1/1     Running   4 (29h ago)   24d   10.101.2.5    kind1-worker3   <none>           <none>
web-api-6c95c8d759-92d42               1/1     Running   4 (29h ago)   3d    10.101.3.4    kind1-worker    <none>           <none>
lichun@lichun-ws:~$ kubectl exec deploy/sleep -- curl -s http://httpbin-worker1:8000/ip
{
  "origin": "10.101.2.5"
}
lichun@lichun-ws:~$ kubectl exec deploy/sleep -- curl -s http://httpbin-worker2:8000/ip
{
  "origin": "10.101.2.5"
}
lichun@lichun-ws:~$ kubectl exec deploy/sleep -- curl -s http://httpbin-worker3:8000/ip
{
  "origin": "10.101.2.5"
}

```