### PR TITLE
Clean up logging a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tokio-stream = "0.1.9"
 tonic = { version = "0.8", default-features=false, features = ["channel", "transport", "prost", "codegen"]}
 tower = { version = "0.4.12", features = ["full"] }
 tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.11" , features = ["registry", "env-filter"]}
+tracing-subscriber = { version = "0.3.16" , features = ["registry", "env-filter"]}
 dyn-clone = "1.0.9"
 realm_io = "0.3.5"
 go-parse-duration = "0.1.1"

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -113,13 +113,15 @@ impl Drop for BlockReady {
         let dur = telemetry::APPLICATION_START_TIME.elapsed();
         if left == 0 {
             info!(
-                "Task '{}' complete ({dur:?}), marking server ready",
-                self.name
+                task=self.name,
+                ?dur,
+                "Readiness blocker complete, marking server ready",
             );
         } else {
             info!(
-                "Task '{}' complete ({dur:?}), still awaiting {left} tasks",
-                self.name
+                task=self.name,
+                ?dur,
+                "Readiness blocker complete, still awaiting {left} tasks",
             );
         }
     }
@@ -252,7 +254,12 @@ impl Server {
                 }
                 info!("starting drain of admin server");
             });
-        info!("Serving admin server at {}", self.addr);
+
+        info!(
+            address=%self.addr,
+            component="admin",
+            "listener established",
+        );
         let shutdown_trigger = self.shutdown_trigger;
         tokio::spawn(async move {
             if let Err(err) = server.await {

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -113,13 +113,13 @@ impl Drop for BlockReady {
         let dur = telemetry::APPLICATION_START_TIME.elapsed();
         if left == 0 {
             info!(
-                task=self.name,
+                task = self.name,
                 ?dur,
                 "Readiness blocker complete, marking server ready",
             );
         } else {
             info!(
-                task=self.name,
+                task = self.name,
                 ?dur,
                 "Readiness blocker complete, still awaiting {left} tasks",
             );

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -18,7 +18,7 @@ use hyper::server::conn::AddrIncoming;
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::{Stream, StreamExt};
-use tracing::{info, warn};
+use tracing::{info, debug, warn};
 
 use crate::tls::{BoringTlsAcceptor, CertProvider, TlsError};
 pub fn tls_server<T: CertProvider + Clone + 'static>(
@@ -39,7 +39,7 @@ pub fn tls_server<T: CertProvider + Clone + 'static>(
                 warn!("TLS handshake error: {}", err);
                 false
             } else {
-                info!("TLS handshake succeeded");
+                debug!("TLS handshake succeeded");
                 true
             }
         })

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -18,7 +18,7 @@ use hyper::server::conn::AddrIncoming;
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::{Stream, StreamExt};
-use tracing::{info, debug, warn};
+use tracing::{debug, warn};
 
 use crate::tls::{BoringTlsAcceptor, CertProvider, TlsError};
 pub fn tls_server<T: CertProvider + Clone + 'static>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,6 @@ fn version() -> anyhow::Result<()> {
 }
 
 async fn proxy(cfg: config::Config) -> anyhow::Result<()> {
-    info!("running with config {cfg:?}");
+    info!("running with config: {cfg:#?}");
     app::build(cfg).await?.wait_termination().await
 }

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -52,7 +52,10 @@ impl InboundPassthrough {
             match socket {
                 Ok((mut stream, remote)) => {
                     tokio::spawn(async move {
-                        if let Err(e) = Self::proxy_inbound_plaintext(remote, &mut stream).await {
+                        if let Err(e) =
+                            Self::proxy_inbound_plaintext(socket::to_canonical(remote), &mut stream)
+                                .await
+                        {
                             warn!("plaintext proxying failed: {}", e)
                         }
                     });
@@ -69,7 +72,10 @@ impl InboundPassthrough {
         }
     }
 
-    async fn proxy_inbound_plaintext(source: SocketAddr, inbound: &mut TcpStream) -> Result<(), Error> {
+    async fn proxy_inbound_plaintext(
+        source: SocketAddr,
+        inbound: &mut TcpStream,
+    ) -> Result<(), Error> {
         let orig = socket::orig_dst_addr_or_default(inbound);
         info!(%source, destination=%orig, component="inbound plaintext", "accepted connection");
         let mut outbound = TcpStream::connect(orig).await?;

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
-use byteorder::{BigEndian, ByteOrder};
-use drain::Watch;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+
+use anyhow::Result;
+use byteorder::{BigEndian, ByteOrder};
+use drain::Watch;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
@@ -53,6 +54,12 @@ impl Socks5 {
             .await
             .map_err(|e| Error::Bind(cfg.socks5_addr, e))?;
 
+        info!(
+            address=%listener.local_addr().unwrap(),
+            component="socks5",
+            "listener established",
+        );
+
         Ok(Socks5 {
             cfg,
             cert_manager,
@@ -69,8 +76,6 @@ impl Socks5 {
     }
 
     pub async fn run(self) {
-        info!("socks5 listener established {}", self.address());
-
         let accept = async move {
             loop {
                 // Asynchronously wait for an inbound socket.

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Debug;
 use std::time::Instant;
 
 use once_cell::sync::Lazy;
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::{EnvFilter, fmt, Layer, Registry};
+use tracing_subscriber::{fmt, EnvFilter, Layer, Registry};
 
 pub static APPLICATION_START_TIME: Lazy<Instant> = Lazy::new(Instant::now);
 

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -132,7 +132,7 @@ impl TestApp {
             0x0u8,  // RSV
             addr_type,
         ];
-        match proxy::to_canonical_ip(addr) {
+        match socket::to_canonical(addr).ip() {
             IpAddr::V6(ip) => cmd.extend_from_slice(&ip.octets()),
             IpAddr::V4(ip) => cmd.extend_from_slice(&ip.octets()),
         };

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -278,7 +278,7 @@ struct LocalClient {
 }
 
 impl LocalClient {
-    #[instrument(skip_all, name="local_client")]
+    #[instrument(skip_all, name = "local_client")]
     async fn run(self) -> Result<(), anyhow::Error> {
         // Currently, we just load the file once. In the future, we could dynamically reload.
         let data = tokio::fs::read_to_string(self.path).await?;
@@ -310,7 +310,7 @@ impl WorkloadInformation {
     // only support workload
     pub async fn fetch_workload(&self, addr: &IpAddr) -> Option<Workload> {
         // Wait for it on-demand, *if* needed
-        debug!("lookup workload for {addr}");
+        debug!(%addr, "fetch workload");
         match self.find_workload(addr) {
             None => {
                 self.fetch_on_demand(addr).await;
@@ -330,7 +330,7 @@ impl WorkloadInformation {
     // It is to do on demand workload fetch if necessary, it handles both workload ip and clusterIP
     async fn fetch_address(&self, addr: &SocketAddr) {
         // Wait for it on-demand, *if* needed
-        debug!("lookup workload for {addr}");
+        debug!(%addr, "fetch address");
         // 1. handle workload ip, if workload not found fallback to clusterIP.
         if self.find_workload(&addr.ip()).is_none() {
             // 2. handle clusterIP
@@ -344,9 +344,9 @@ impl WorkloadInformation {
 
     async fn fetch_on_demand(&self, ip: &IpAddr) {
         if let Some(demand) = &self.demand {
-            debug!("sending demand request for: {}", ip);
+            debug!(%ip, "sending demand request");
             demand.demand(ip.to_string()).await.recv().await;
-            debug!("on demand ready: {}", ip);
+            debug!(%ip, "on demand ready");
         }
     }
 


### PR DESCRIPTION
* General cleanup of making log messages more clear, concise, detailed, and at the right level
* Use spans where its useful
* Assign each request and id. This is used as the span to correlate all logs, similar to how Envoy does it. Difference from envoy is we also send this over the wire using the `traceparent` header (OTEL standard). This allows correlating the ID across ztunnels, for ease of debugging. Note: waypoint drops the header, but we could make it propagate in the future.
* Use canonical_ip everywhere. I thought this was just improving logging, but it actually fixes running on dual stack environments; previously we would try to lookup a workload by its V4-in-V6 address and fail