### PR TITLE
logging: cleanup and expand scope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,6 +2516,7 @@ dependencies = [
  "gperftools",
  "hyper",
  "hyper-boring",
+ "itertools",
  "libc",
  "log",
  "matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ realm_io = "0.3.5"
 go-parse-duration = "0.1.1"
 prometheus-parse = "0.2.3"
 url = "2.2"
+itertools = "0.10.5"
 
 [build-dependencies]
 tonic-build = { version = "0.8", default-features=false, features = ["prost"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,7 +65,7 @@ pub async fn build_with_cert(
         drain_rx.clone(),
     )
     .await?;
-    drop(proxy_task);
+    std::mem::forget(proxy_task);
 
     // spawn admin task and xds client task
     admin.spawn(drain_rx_admin);


### PR DESCRIPTION
This adds a variety of improvements to the recent dynamic logging:
* use Result instead of Option and bool when appopriate
* DRY a bit of the hyper responses
* Add a `reset` parameter, otherwise its not possible to reset logs back to normal. Envoy doesn't really have this issue since setting the level to "info" means "set all loggers to info"; in `tracing` this means "set all *unset* loggers to info". So setting it doesn't imply resetting
* Simplify some of the code
* Properly parse query params