### PR TITLE
fix two e2e test flakes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::Context;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -53,7 +54,7 @@ pub async fn build_with_cert(
     let shutdown_trigger = shutdown.trigger();
     let admin = admin::Builder::new(config.clone(), workload_manager.workloads(), ready)
         .bind(registry, shutdown_trigger)
-        .expect("admin server starts");
+        .context("admin server starts")?;
     let admin_address = admin.address();
 
     let drain_rx_admin = drain_rx.clone();

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -55,7 +55,7 @@ impl Proxy {
         drain: Watch,
     ) -> Result<Proxy, Error> {
         // We setup all the listeners first so we can capture any errors that should block startup
-        let inbound_passthrough = InboundPassthrough::new(cfg.clone());
+        let inbound_passthrough = InboundPassthrough::new(cfg.clone()).await?;
         let inbound = Inbound::new(
             cfg.clone(),
             workloads.clone(),


### PR DESCRIPTION
* Bind test always used static port. make it dynamic to avoid conflicts on test. Also test all 5 ports. Found inbound_passthrough and admin are broken, fixed them
* Metrics test fetches metrics 1x then checks them repeatedly. Need to fetch+check in the assert.