### PR TITLE
Logging: fix build error when console is enabled

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -24,8 +24,8 @@ static LOG_HANDLE: OnceCell<LogHandle> = OnceCell::new();
 pub fn setup_logging() {
     Lazy::force(&APPLICATION_START_TIME);
     tracing_subscriber::registry()
-        .with(console_subscriber::spawn())
         .with(fmt_layer())
+        .with(console_subscriber::spawn())
         .init();
 }
 


### PR DESCRIPTION
- build log with console enabled
```
$ RUSTFLAGS="--cfg tokio_unstable" cargo build --features console
   Compiling proc-macro2 v1.0.47
   Compiling quote v1.0.21
   Compiling unicode-ident v1.0.5
   Compiling autocfg v1.1.0
   Compiling syn v1.0.104
   Compiling cfg-if v1.0.0
   Compiling libc v0.2.137
   Compiling memchr v2.5.0
   Compiling serde_derive v1.0.148
   Compiling serde v1.0.148
   Compiling log v0.4.17
   Compiling parking_lot_core v0.9.5
   Compiling hashbrown v0.12.3
   Compiling futures-core v0.3.25
   Compiling lazy_static v1.4.0
   Compiling futures-task v0.3.25
   Compiling futures-channel v0.3.25
   Compiling minimal-lexical v0.2.1
   Compiling futures-util v0.3.25
   Compiling bitflags v1.3.2
   Compiling either v1.8.0
   Compiling cc v1.0.77
   Compiling anyhow v1.0.66
   Compiling regex-syntax v0.6.28
   Compiling rustversion v1.0.9
   Compiling glob v0.3.0
   Compiling lock_api v0.4.9
   Compiling tokio v1.22.0
   Compiling indexmap v1.9.2
   Compiling slab v0.4.7
   Compiling num-traits v0.2.15
   Compiling itertools v0.10.5
   Compiling httparse v1.8.0
   Compiling crossbeam-utils v0.8.14
   Compiling clang-sys v1.4.0
   Compiling want v0.3.0
   Compiling crc32fast v1.3.2
   Compiling memoffset v0.7.1
   Compiling libloading v0.7.4
   Compiling bindgen v0.60.1
   Compiling flate2 v1.0.25
   Compiling nom v7.1.1
   Compiling num_cpus v1.14.0
   Compiling signal-hook-registry v1.4.0
   Compiling mio v0.8.5
   Compiling socket2 v0.4.7
   Compiling getrandom v0.2.8
   Compiling parking_lot v0.12.1
   Compiling crossbeam-epoch v0.9.13
   Compiling rand_core v0.6.4
   Compiling rustc-hash v1.1.0
   Compiling regex v1.7.0
   Compiling fastrand v1.8.0
   Compiling shlex v1.1.0
   Compiling async-trait v0.1.59
   Compiling rand_chacha v0.3.1
   Compiling remove_dir_all v0.5.3
   Compiling peeking_take_while v0.1.2
   Compiling protobuf v2.28.0
   Compiling lazycell v1.3.0
   Compiling axum-core v0.3.0
   Compiling rand v0.8.5
   Compiling cmake v0.1.49
   Compiling aho-corasick v0.7.20
   Compiling bytes v1.3.0
   Compiling prettyplease v0.1.21
   Compiling serde_json v1.0.89
   Compiling axum v0.6.1
   Compiling crossbeam-channel v0.5.6
   Compiling rayon-core v1.10.1
   Compiling semver v1.0.14
   Compiling fixedbitset v0.4.2
   Compiling hdrhistogram v7.5.2
   Compiling cexpr v0.6.0
   Compiling petgraph v0.6.2
   Compiling crossbeam-deque v0.8.2
   Compiling tempfile v3.3.0
   Compiling which v4.3.0
   Compiling num-integer v0.1.45
   Compiling multimap v0.8.3
   Compiling thiserror v1.0.37
   Compiling cpp_demangle v0.4.0
   Compiling heck v0.4.0
   Compiling findshlibs v0.10.2
   Compiling backtrace v0.3.66
   Compiling memmap2 v0.5.8
   Compiling symbolic-demangle v10.2.0
   Compiling clap v3.2.23
   Compiling rustc_version v0.4.0
   Compiling symbolic-common v10.2.0
   Compiling plotters v0.3.4
   Compiling time v0.1.45
   Compiling rayon v1.6.0
   Compiling atty v0.2.14
   Compiling object v0.29.0
   Compiling tracing-log v0.1.3
   Compiling sharded-slab v0.1.4
   Compiling chrono v0.4.23
   Compiling nix v0.24.2
   Compiling prometheus-parse v0.2.3
   Compiling protobuf-codegen v2.28.0
   Compiling protobuf-codegen-pure v2.28.0
   Compiling tracing-attributes v0.1.23
   Compiling tokio-macros v1.8.2
   Compiling futures-macro v0.3.25
   Compiling prost-derive v0.11.2
   Compiling pin-project-internal v1.0.12
   Compiling async-stream-impl v0.3.3
   Compiling foreign-types-macros v0.2.2
   Compiling thiserror-impl v1.0.37
   Compiling prometheus-client-derive-text-encode v0.3.0
   Compiling boring-sys v2.1.0
   Compiling pprof v0.11.0
   Compiling async-stream v0.3.3
   Compiling foreign-types v0.5.0
   Compiling prometheus-client v0.18.1
   Compiling tracing v0.1.37
   Compiling pin-project v1.0.12
   Compiling tracing-futures v0.2.5
   Compiling tracing-subscriber v0.3.16
   Compiling prost v0.11.3
   Compiling prost-types v0.11.2
   Compiling prost-build v0.11.3
   Compiling futures-executor v0.3.25
   Compiling futures v0.3.25
   Compiling tonic-build v0.8.4
   Compiling ztunnel v0.0.0 (/home/zkf/repos/kfreez/ztunnel)
   Compiling ciborium v0.2.0
   Compiling serde_yaml v0.9.14
   Compiling http v0.2.8
   Compiling tinytemplate v1.2.1
   Compiling criterion v0.4.0
   Compiling http-body v0.4.5
   Compiling tokio-util v0.7.4
   Compiling tokio-io-timeout v1.2.0
   Compiling tokio-stream v0.1.11
   Compiling drain v0.1.1
   Compiling realm_io v0.3.5
   Compiling h2 v0.3.15
   Compiling tower v0.4.13
   Compiling tower-http v0.3.4
   Compiling boring v2.1.0
   Compiling hyper v0.14.23
   Compiling tokio-boring v2.1.5
   Compiling hyper-timeout v0.4.1
   Compiling tls-listener v0.5.1
   Compiling hyper-boring v2.1.2
   Compiling tonic v0.8.3
   Compiling console-api v0.4.0
   Compiling console-subscriber v0.1.8
    Finished dev [unoptimized + debuginfo] target(s) in 40.41s
```
- test log with console enabled
```
zkf@pinn:~/repos/kfreez/ztunnel$ RUSTFLAGS="--cfg tokio_unstable" FAKE_CA="true" XDS_ADDRESS="" LOCAL_XDS_PATH=./examples/localhost.yaml cargo run --features console
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `out/rust/debug/ztunnel`
2022-12-13T08:24:54.692680Z  INFO ztunnel: running with config: Config {
    window_size: 4194304,
    connection_window_size: 4194304,
    frame_size: 1048576,
    socks5_addr: [::]:15080,
    admin_addr: [::]:15021,
    inbound_addr: [::]:15008,
    inbound_plaintext_addr: [::]:15006,
    outbound_addr: [::]:15001,
    local_node: None,
    ca_address: None,
    ca_root_cert: File(
        "./var/run/secrets/istio/root-cert.pem",
    ),
    xds_address: None,
    xds_root_cert: File(
        "./var/run/secrets/istio/root-cert.pem",
    ),
    local_xds_config: Some(
        File(
            "./examples/localhost.yaml",
        ),
    ),
    xds_on_demand: false,
    fake_ca: true,
    auth: Token(
        "./var/run/secrets/tokens/istio-token",
    ),
    termination_grace_period: 5s,
    num_worker_threads: 2,
    proxy_args: "",
}
2022-12-13T08:24:54.693721Z  INFO local_client: ztunnel::workload: inserted 2 local workloads
2022-12-13T08:24:54.693775Z  INFO ztunnel::admin: Readiness blocker complete, still awaiting 1 tasks task="workload manager" dur=8.031898ms
2022-12-13T08:24:54.693861Z  INFO ztunnel::proxy::inbound: listener established address=[::]:15008 component="inbound" transparent=false
2022-12-13T08:24:54.693912Z  INFO ztunnel::proxy::outbound: listener established address=[::]:15001 component="outbound" transparent=false
2022-12-13T08:24:54.693954Z  INFO ztunnel::proxy::socks5: listener established address=[::]:15080 component="socks5"
2022-12-13T08:24:54.693988Z  INFO ztunnel::admin: Readiness blocker complete, marking server ready task="proxy listeners" dur=8.248825ms
2022-12-13T08:24:54.694173Z  INFO ztunnel::admin: listener established address=[::]:15021 component="admin"
2022-12-13T08:24:54.695179Z  INFO ztunnel::proxy::inbound_passthrough: listener established address=[::]:15006 component="inbound plaintext" transparent=false
2022-12-13T08:25:11.406620Z  WARN ztunnel::admin: testing warn
2022-12-13T08:25:11.406742Z  INFO ztunnel::admin: testing info
2022-12-13T08:25:11.406834Z ERROR ztunnel::admin: testing error
2022-12-13T08:25:28.435810Z  WARN ztunnel::admin: testing warn
2022-12-13T08:25:28.435924Z  INFO ztunnel::admin: testing info
2022-12-13T08:25:28.435991Z ERROR ztunnel::admin: testing error
2022-12-13T08:25:28.436069Z DEBUG ztunnel::admin: testing debug
2022-12-13T08:25:28.436156Z DEBUG hyper::proto::h1::io: flushed 129 bytes
2022-12-13T08:25:44.909889Z DEBUG hyper::proto::h1::role: setting h1 header read timeout timer
2022-12-13T08:25:44.910253Z DEBUG hyper::proto::h1::io: parsed 6 headers
2022-12-13T08:25:44.910490Z DEBUG hyper::proto::h1::conn: incoming body is empty
2022-12-13T08:25:44.910591Z DEBUG ztunnel::telemetry: new directive is debug,debug,hyper::=info
2022-12-13T08:25:44.911031Z  WARN ztunnel::admin: testing warn
2022-12-13T08:25:44.911075Z  INFO ztunnel::admin: testing info
2022-12-13T08:25:44.911102Z ERROR ztunnel::admin: testing error
2022-12-13T08:25:44.911131Z DEBUG ztunnel::admin: testing debug
^C2022-12-13T08:25:57.993119Z  INFO ztunnel::signal::imp: received signal SIGINT, starting shutdown
2022-12-13T08:25:57.993532Z  INFO ztunnel::proxy::inbound: starting drain of inbound connections
2022-12-13T08:25:57.993565Z  INFO ztunnel::proxy::socks5: socks5 drained
2022-12-13T08:25:57.993579Z  INFO ztunnel::admin: starting drain of admin server
2022-12-13T08:25:57.993689Z  INFO ztunnel::proxy::outbound: outbound drained
2022-12-13T08:25:57.994127Z  INFO ztunnel::admin: admin server terminated
2022-12-13T08:25:57.994232Z  INFO ztunnel::app: Shutdown completed gracefully
```
another terminal send change log level POSTs to the ztunnel in console mode
```
zkf@pinn:~$  curl -X POST http://10.239.241.90:15021/logging
failed to get the log level

usage: POST /logging                                            (To list current level)
usage: POST /logging?level=<level>                              (To change global levels)
usage: POST /logging?level={mod1}:{level1},{mod2}:{level2}      (To change specific mods' logging level)

hint: loglevel: error|warn|info|debug|trace|off
hint: mod_name: the module name defined in the cargo.toml, i.e. ztunnel::proxy
$
zkf@pinn:~$ curl -X POST http://10.239.241.90:15021/logging
current log level is INFO
$ curl -X POST http://10.239.241.90:15021/logging?level=debug
current log level is DEBUG
$ curl -X POST http://10.239.241.90:15021/logging?level=debug,hyper::=info
current log level is HYPER::=INFO,DEBUG
``` 