### PR TITLE
e2e tests: cleanup IP usage

### DIFF
--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -22,8 +22,9 @@ use std::time::Duration;
 use hyper::{body, Body, Client, Method, Request, Response};
 use prometheus_parse::Scrape;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
+use tokio::net::{TcpSocket, TcpStream};
 
+use crate::test_helpers::TEST_WORKLOAD_SOURCE;
 use crate::*;
 
 use super::helpers::*;
@@ -124,11 +125,6 @@ impl TestApp {
     }
 
     pub async fn socks5_connect(&self, addr: SocketAddr) -> TcpStream {
-        // let addr = net::lookup_host(addr)
-        //     .await
-        //     .expect("must get localhost address")
-        //     .next()
-        //     .expect("must get at least one localhost address");
         // Always use IPv4 address. In theory, we can resolve `localhost` to pick to support any machine
         // However, we need to make sure the WorkloadStore knows about both families then.
         let socks_addr = with_ip(
@@ -136,7 +132,16 @@ impl TestApp {
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         );
 
-        let mut stream = TcpStream::connect(socks_addr).await.expect("must connect");
+        // Set source IP to TEST_WORKLOAD_SOURCE
+        let socket = TcpSocket::new_v4().unwrap();
+        socket
+            .bind(SocketAddr::from((
+                TEST_WORKLOAD_SOURCE.parse::<IpAddr>().unwrap(),
+                0,
+            )))
+            .unwrap();
+
+        let mut stream = socket.connect(socks_addr).await.expect("must connect");
         stream.set_nodelay(true).unwrap();
 
         let addr_type = if addr.ip().is_ipv4() { 0x01u8 } else { 0x04u8 };

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -15,12 +15,12 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 
-use bytes::{BufMut, Bytes};
-
 use crate::config;
 use crate::config::ConfigSource;
 use crate::workload::Protocol::{HBONE, TCP};
 use crate::workload::{LocalWorkload, Workload};
+use bytes::{BufMut, Bytes};
+use std::default::Default;
 
 pub mod app;
 pub mod ca;
@@ -46,16 +46,18 @@ pub fn test_config() -> config::Config {
     test_config_with_port(80)
 }
 
-const HBONE_IP: &str = "127.0.0.1";
-const TCP_IP: &str = "127.0.0.2";
-const TEST_VIP: &str = "127.10.0.1";
+// Define some test workloads. Intentionally do not use 127.0.0.1 to avoid accidentally using a workload
+pub const TEST_WORKLOAD_SOURCE: &str = "127.0.0.2";
+pub const TEST_WORKLOAD_HBONE: &str = "127.0.0.3";
+pub const TEST_WORKLOAD_TCP: &str = "127.0.0.4";
+pub const TEST_VIP: &str = "127.10.0.1";
 
 fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
     let mut b = bytes::BytesMut::new().writer();
     let res: Vec<LocalWorkload> = vec![
         LocalWorkload {
             workload: Workload {
-                workload_ip: HBONE_IP.parse()?,
+                workload_ip: TEST_WORKLOAD_HBONE.parse()?,
                 protocol: HBONE,
                 name: "local-hbone".to_string(),
                 namespace: "default".to_string(),
@@ -74,7 +76,7 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
         },
         LocalWorkload {
             workload: Workload {
-                workload_ip: TCP_IP.parse()?,
+                workload_ip: TEST_WORKLOAD_TCP.parse()?,
                 protocol: TCP,
                 name: "local-tcp".to_string(),
                 namespace: "default".to_string(),
@@ -90,6 +92,25 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
                 native_hbone: false,
             },
             vips: HashMap::from([(TEST_VIP.to_string(), HashMap::from([(80u16, echo_port)]))]),
+        },
+        LocalWorkload {
+            workload: Workload {
+                workload_ip: TEST_WORKLOAD_SOURCE.parse()?,
+                protocol: TCP,
+                name: "local-source".to_string(),
+                namespace: "default".to_string(),
+                service_account: "default".to_string(),
+                node: "local".to_string(),
+
+                waypoint_addresses: vec![],
+                gateway_address: None,
+                workload_name: "".to_string(),
+                workload_type: "".to_string(),
+                canonical_name: "".to_string(),
+                canonical_revision: "".to_string(),
+                native_hbone: false,
+            },
+            vips: Default::default(),
         },
     ];
     serde_yaml::to_writer(&mut b, &res)?;

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -104,7 +104,7 @@ async fn test_shutdown_drain() {
     });
     // we shouldn't be shutdown yet
     assert!(shutdown_rx.try_recv().is_err());
-    let dst = helpers::with_ip(echo_addr, "127.0.0.1".parse().unwrap());
+    let dst = helpers::with_ip(echo_addr, TEST_WORKLOAD_HBONE.parse().unwrap());
     let mut stream = ta.socks5_connect(dst).await;
     read_write_stream(&mut stream).await;
     // Since we are connected, the app shouldn't shutdown
@@ -146,7 +146,7 @@ async fn test_shutdown_forced_drain() {
     });
     // we shouldn't be shutdown yet
     assert!(shutdown_rx.try_recv().is_err());
-    let dst = helpers::with_ip(echo_addr, "127.0.0.1".parse().unwrap());
+    let dst = helpers::with_ip(echo_addr, TEST_WORKLOAD_HBONE.parse().unwrap());
     let mut stream = ta.socks5_connect(dst).await;
     const BODY: &[u8] = "hello world".as_bytes();
     stream.write_all(BODY).await.unwrap();
@@ -192,17 +192,17 @@ async fn run_request_test(target: &str) {
 
 #[tokio::test]
 async fn test_hbone_request() {
-    run_request_test("127.0.0.1").await;
+    run_request_test(TEST_WORKLOAD_HBONE).await;
 }
 
 #[tokio::test]
 async fn test_tcp_request() {
-    run_request_test("127.0.0.2").await;
+    run_request_test(TEST_WORKLOAD_TCP).await;
 }
 
 #[tokio::test]
 async fn test_vip_request() {
-    run_request_test("127.10.0.1:80").await;
+    run_request_test(&format!("{TEST_VIP}:80")).await;
 }
 
 #[tokio::test]
@@ -232,7 +232,7 @@ async fn test_tcp_metrics() {
     let echo_addr = echo.address();
     tokio::spawn(echo.run());
     testapp::with_app(test_config(), |app| async move {
-        let dst = helpers::with_ip(echo_addr, "127.0.0.2".parse().unwrap());
+        let dst = helpers::with_ip(echo_addr, TEST_WORKLOAD_TCP.parse().unwrap());
         let mut stream = app.socks5_connect(dst).await;
         read_write_stream(&mut stream).await;
 


### PR DESCRIPTION
* Use constants
* Avoid 127.0.0.1 implicitly being used, which can lead to us missing coverage
* Explicitly use a source IP that isn't 127.0.0.1 for above reason