### PR TITLE
(feat) Add `cargo deny` to check for CVEs & allowed licenses

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -21,6 +21,12 @@ lint: lint-scripts lint-yaml lint-markdown lint-licenses lint-copyright
 check:
 	cargo check
 
+cve-check:
+	cargo deny check advisories
+
+license-check:
+	cargo deny check licenses
+
 fix: fix-copyright-banner
 	cargo clippy --fix --allow-staged --allow-dirty
 	cargo fmt

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,27 @@
+[licenses]
+allow = ["Apache-2.0",
+"CC-BY-3.0",
+"ISC",
+"AFL-2.1",
+"AFL-3.0",
+"Artistic-1.0",
+"Artistic-2.0",
+"Apache-1.1",
+"BSD-1-Clause",
+"BSD-2-Clause",
+"BSD-3-Clause",
+"0BSD",
+"FTL",
+"LPL-1.02",
+"MS-PL",
+"MIT",
+"NCSA",
+"OpenSSL",
+"PHP-3.0",
+"TCP-wrappers",
+"W3C",
+"Xnet",
+"Zlib",
+"Unicode-DFS-2016"]
+unused-allowed-license = "allow"
+copyleft = "deny"


### PR DESCRIPTION
Creates two new targets (`cve-check` & `license-check`) that utilizes `cargo-deny`.
`cve-check` will check for any CVEs in all deps (currently there in one)
`license-check` uses the `deny.toml` to scan for allowed licenses 