### PR TITLE
local node e2e tests

### DIFF
--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -27,7 +27,7 @@ pub mod ca;
 pub mod helpers;
 pub mod tcp;
 
-pub fn test_config_with_port(port: u16) -> config::Config {
+pub fn test_config_with_port_and_node(port: u16, node: Option<String>) -> config::Config {
     config::Config {
         xds_address: None,
         fake_ca: true,
@@ -38,8 +38,13 @@ pub fn test_config_with_port(port: u16) -> config::Config {
         readiness_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+        local_node: node,
         ..config::parse_config().unwrap()
     }
+}
+
+pub fn test_config_with_port(port: u16) -> config::Config {
+    test_config_with_port_and_node(port, None)
 }
 
 pub fn test_config() -> config::Config {

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -20,6 +20,7 @@ use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
 use hyper::{Body, Client, Method, Request};
+use log::{info};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
@@ -188,6 +189,12 @@ async fn run_request_test(target: &str) {
         read_write_stream(&mut stream).await;
     })
     .await;
+    testapp::with_app(test_config_with_port_and_node(echo_addr.port(), Some(String::from("local"))), |app| async move {
+        let dst = SocketAddr::from_str(target)
+            .unwrap_or_else(|_| helpers::with_ip(echo_addr, target.parse().unwrap()));
+        let mut stream = app.socks5_connect(dst).await;
+        read_write_stream(&mut stream).await;
+    }).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
affects:
```
test_hbone_request
test_tcp_request
test_vip_request
```
Tests are run with (1) `local_node` set to `None` and (2) with `local_node` set to `Some("local")`.