### PR TITLE
readiness: fix never getting ready

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -70,7 +70,7 @@ pub async fn build_with_cert(
         drain_rx.clone(),
     )
     .await?;
-    std::mem::forget(proxy_task);
+    drop(proxy_task);
 
     // spawn admin task and xds client task
     admin.spawn(drain_rx_admin);

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -115,12 +115,15 @@ impl TestApp {
     }
 
     pub async fn ready(&self) {
-        for _ in 0..100 {
-            if self.readiness_request().await.is_ok() {
+        let mut last_err: anyhow::Result<()> = Ok(());
+        for _ in 0..200 {
+            last_err = self.readiness_request().await;
+            if last_err.is_ok() {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
+        panic!("failed to get ready (last: {last_err:?})");
     }
 
     pub async fn socks5_connect(&self, addr: SocketAddr) -> TcpStream {


### PR DESCRIPTION
This was broken *intentionally* as part of local debugging.. but accidentally committed due to lack of proper test coverage. We tested readiness, but didn't actually fail if it didn't become ready.

This fixes the mistake and ensures tests cover it.

closes https://github.com/istio/ztunnel/issues/287