### PR TITLE
implement L4 AuthorizationPolicy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,6 +2525,7 @@ dependencies = [
  "gperftools",
  "hyper",
  "hyper-boring",
+ "ipnet",
  "itertools",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +1932,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d6cf5a7dffb3f9dceec8e6b8ca528d9bd71d36c9f074defb548ce161f598c0"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
+dependencies = [
+ "cfg-if",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2544,6 +2590,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "socket2",
+ "test-case",
  "thiserror",
  "tls-listener",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ go-parse-duration = "0.1.1"
 prometheus-parse = "0.2.3"
 url = "2.2"
 itertools = "0.10.5"
+ipnet = { version = "2.7.0", features = ["serde"] }
 
 [build-dependencies]
 tonic-build = { version = "0.8", default-features=false, features = ["prost"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,4 +87,5 @@ incremental = true
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 matches = "0.1.9"
+test-case = "2.2.2"
 #debug = true

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -218,6 +218,7 @@ pub fn metrics(c: &mut Criterion) {
                     canonical_revision: Default::default(),
                     node: Default::default(),
                     native_hbone: Default::default(),
+                    authorization_policies: Default::default(),
                 },
                 destination: None,
                 destination_service: None,

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), anyhow::Error> {
     let proto_files = vec![
         "proto/xds.proto",
         "proto/workload.proto",
+        "proto/networkpolicy.proto",
         "proto/citadel.proto",
     ]
     .iter()
@@ -32,7 +33,7 @@ fn main() -> Result<(), anyhow::Error> {
     let config = {
         let mut c = prost_build::Config::new();
         c.disable_comments(Some("."));
-        c.bytes([".istio.workload.Workload"]);
+        c.bytes([".istio.workload.Workload", ".istio.workload.Address"]);
         c
     };
     tonic_build::configure()

--- a/examples/localhost.yaml
+++ b/examples/localhost.yaml
@@ -1,5 +1,6 @@
 # This shows an example local config for ztunnel that adds a workload for localhost.
 # This allows local testing by sending requests through the local ztunnel to other servers running on localhost.
+workloads:
 - name: local
   namespace: default
   serviceAccount: default
@@ -19,3 +20,11 @@
   vips:
     "127.10.0.1":
       80: 8080
+policies:
+  - action: Allow
+    groups:
+    - - - not_destination_ports:
+          - 9999
+    name: deny-9999
+    namespace: default
+    scope: Namespace

--- a/proto/google/protobuf/empty.proto
+++ b/proto/google/protobuf/empty.proto
@@ -1,0 +1,51 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option go_package = "google.golang.org/protobuf/types/known/emptypb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "EmptyProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
+
+// A generic empty message that you can re-use to avoid defining duplicated
+// empty messages in your APIs. A typical example is to use it as the request
+// or the response type of an API method. For instance:
+//
+//     service Foo {
+//       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+//     }
+//
+message Empty {}

--- a/proto/networkpolicy.proto
+++ b/proto/networkpolicy.proto
@@ -1,0 +1,107 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.workload;
+option go_package="pkg/workloadapi";
+
+import "google/protobuf/empty.proto";
+
+message RBAC {
+  string name = 1;
+  string namespace = 2;
+
+  // Determine the scope of this RBAC policy.
+  // If set to NAMESPACE, the 'namespace' field value will be used.
+  RBACScope scope = 3;
+  // The action to take if the request is matched with the rules.
+  // Default is ALLOW if not specified.
+  RBACPolicyAction action = 4;
+  // Set of RBAC policy groups each containing its rules.
+  // If at least one of the groups is matched the policy action will
+  // take place.
+  // Groups are OR-ed.
+  repeated RBACPolicyRulesGroup groups = 5;
+}
+
+message RBACPolicyRulesGroup {
+  // Rules are AND-ed
+  // This is a generic form of the authz policy's to, from and when
+  repeated RBACPolicyRules rules = 1;
+}
+
+message RBACPolicyRules {
+  // The logical behavior between the matches (if there are more than one)
+  //  MatchBehavior match_behavior = 1;
+  repeated RBACPolicyRuleMatch matches = 2;
+}
+
+message RBACPolicyRuleMatch {
+  // Values of specific type are ORed
+  // If multiple types are set, they are ANDed
+
+  repeated StringMatch namespaces = 1;
+  repeated StringMatch not_namespaces = 2;
+
+  repeated StringMatch principals = 3;
+  repeated StringMatch not_principals = 4;
+
+  repeated Address source_ips = 5;
+  repeated Address not_source_ips = 6;
+
+  repeated Address destination_ips = 7;
+  repeated Address not_destination_ips = 8;
+
+  repeated uint32 destination_ports = 9;
+  repeated uint32 not_destination_ports = 10;
+}
+
+message Address {
+  bytes address = 1;
+  uint32 length = 2;
+}
+
+message StringMatch {
+  oneof match_type {
+    // exact string match
+    string exact = 1;
+    // prefix-based match
+    string prefix = 2;
+
+    // suffix-based match
+    string suffix = 3;
+
+    google.protobuf.Empty presence = 4;
+  }
+}
+
+enum RBACScope {
+  // ALL means that the authorization policy will be applied to all workloads
+  // in the mesh (any namespace).
+  GLOBAL = 0;
+  // NAMESPACE means that the policy will only be applied to workloads in a
+  // specific namespace.
+  NAMESPACE = 1;
+  // WORKLOAD_SELECTOR means that the policy will only be applied to specific
+  // workloads that were selected by their labels.
+  WORKLOAD_SELECTOR = 2;
+}
+
+enum RBACPolicyAction {
+  // Allow the request if it matches with the rules.
+  ALLOW = 0;
+  // Deny the request if it matches with the rules.
+  DENY = 1;
+}

--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -67,8 +67,10 @@ message Workload {
   // The key is an IP address.
   map<string, PortList> virtual_ips = 15;
 
-  // RBAC rules for the workload.
-  Authorization rbac = 16;
+  // A list of authorization policies applicable to this workload.
+  // NOTE: this *only* includes Selector based policies. Namespace and global polices
+  // are returned out of band.
+  repeated string authorization_policies = 16;
 }
 
 enum WorkloadType {
@@ -76,32 +78,6 @@ enum WorkloadType {
   CRONJOB = 1;
   POD = 2;
   JOB = 3;
-}
-
-message Authorization {
-  // If true, mTLS will be required
-  bool enforceMTLS = 1;
-  // Allow policies
-  repeated Policy allow = 2;
-  // Deny policies
-  repeated Policy deny = 3;
-}
-
-message Policy {
-  repeated AuthRule rule = 1;
-  repeated AuthCondition when = 2;
-}
-
-message AuthRule {
-  bool invert = 1;
-  // Rules
-  string identity = 2;
-  string namespace = 3;
-}
-
-message AuthCondition {
-  bool invert = 1;
-  uint32 port = 2;
 }
 
 // PorList represents the ports for a service

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -35,4 +35,6 @@ pub enum Error {
     SanError(Identity),
     #[error("chain returned from CA is empty for: {0}")]
     EmptyResponse(Identity),
+    #[error("invalid spiffe identity: {0}")]
+    Spiffe(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod config;
 pub mod identity;
 pub mod metrics;
 pub mod proxy;
+pub mod rbac;
 pub mod readiness;
 pub mod signal;
 pub mod socket;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
 use std::time::Instant;
 
@@ -26,7 +28,8 @@ use crate::config::Config;
 use crate::identity::CertificateProvider;
 use crate::proxy::inbound::InboundConnect::Hbone;
 use crate::proxy::{TraceParent, TRACEPARENT_HEADER};
-use crate::socket::relay;
+use crate::rbac;
+use crate::socket::{relay, to_canonical};
 use crate::tls::TlsError;
 use crate::workload::WorkloadInformation;
 
@@ -73,8 +76,25 @@ impl Inbound {
 
     pub(super) async fn run(self) {
         let (tx, rx) = oneshot::channel();
-        let service =
-            make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(Self::serve_connect)) });
+        let service = make_service_fn(|socket: &tokio_boring::SslStream<TcpStream>| {
+            let dst = crate::socket::orig_dst_addr_or_default(socket.get_ref());
+            let conn = rbac::Connection {
+                src_identity: socket
+                    .ssl()
+                    .peer_certificate()
+                    .and_then(|x| crate::tls::boring::extract_sans(&x).first().cloned()),
+                src_ip: to_canonical(socket.get_ref().peer_addr().unwrap()).ip(),
+                dst,
+            };
+            let workloads = self.workloads.clone();
+            async move {
+                let conn = conn.clone();
+                let workloads = workloads.clone();
+                Ok::<_, hyper::Error>(service_fn(move |req| {
+                    Self::serve_connect(workloads.clone(), conn.clone(), req)
+                }))
+            }
+        });
 
         let acceptor = InboundCertProvider {
             workloads: self.workloads.clone(),
@@ -171,8 +191,16 @@ impl Inbound {
             .unwrap_or_else(TraceParent::new)
     }
 
-    #[instrument(name="inbound", skip_all, fields(id=%Self::extract_traceparent(&req)))]
-    async fn serve_connect(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    #[instrument(name="inbound", skip_all, fields(
+        id=%Self::extract_traceparent(&req),
+        peer_ip=%conn.src_ip,
+        peer_id=%OptionDisplay(&conn.src_identity)
+    ))]
+    async fn serve_connect(
+        workloads: WorkloadInformation,
+        conn: rbac::Connection,
+        req: Request<Body>,
+    ) -> Result<Response<Body>, hyper::Error> {
         match req.method() {
             &Method::CONNECT => {
                 let uri = req.uri();
@@ -187,6 +215,22 @@ impl Inbound {
                 }
 
                 let addr: SocketAddr = addr.unwrap();
+                if addr.ip() != conn.dst.ip() {
+                    info!("Sending 400, ip mismatch {addr} != {}", conn.dst);
+                    return Ok(Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(Body::empty())
+                        .unwrap());
+                }
+                // Orig has 15008, swap with the real port
+                let conn = rbac::Connection { dst: addr, ..conn };
+                if !workloads.assert_rbac(&conn).await {
+                    info!(%conn, "RBAC rejected");
+                    return Ok(Response::builder()
+                        .status(StatusCode::UNAUTHORIZED)
+                        .body(Body::empty())
+                        .unwrap());
+                }
                 let status_code = match Self::handle_inbound(InboundConnect::Hbone(req), addr)
                     .instrument(tracing::span::Span::current())
                     .await
@@ -208,6 +252,17 @@ impl Inbound {
                     .body(Body::empty())
                     .unwrap())
             }
+        }
+    }
+}
+
+struct OptionDisplay<'a, T>(&'a Option<T>);
+
+impl<'a, T: Display> Display for OptionDisplay<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            None => write!(f, "None"),
+            Some(i) => write!(f, "{}", i),
         }
     }
 }

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -88,8 +88,6 @@ impl Inbound {
             };
             let workloads = self.workloads.clone();
             async move {
-                let conn = conn.clone();
-                let workloads = workloads.clone();
                 Ok::<_, hyper::Error>(service_fn(move |req| {
                     Self::serve_connect(workloads.clone(), conn.clone(), req)
                 }))

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -1,0 +1,385 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::Into;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::net::{IpAddr, SocketAddr};
+
+use ipnet::IpNet;
+use tracing::{instrument, trace};
+
+use xds::istio::workload::Address as XdsAddress;
+use xds::istio::workload::Rbac as XdsRbac;
+use xds::istio::workload::StringMatch as XdsStringMatch;
+
+use crate::identity::Identity;
+use crate::workload::WorkloadError;
+use crate::workload::WorkloadError::EnumParse;
+use crate::xds::istio::workload::string_match::MatchType;
+use crate::xds::istio::workload::RbacPolicyRuleMatch;
+use crate::{workload, xds};
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Rbac {
+    pub name: String,
+    pub namespace: String,
+    pub scope: RbacScope,
+    pub action: RbacAction,
+    pub groups: Vec<Vec<Vec<RbacMatch>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Connection {
+    pub src_identity: Option<Identity>,
+    pub src_ip: IpAddr,
+    pub dst: SocketAddr,
+}
+
+struct OptionDisplay<'a, T>(&'a Option<T>);
+
+impl<'a, T: Display> Display for OptionDisplay<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            None => write!(f, "None"),
+            Some(i) => write!(f, "{}", i),
+        }
+    }
+}
+
+impl Display for Connection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}({})->{}",
+            self.src_ip,
+            OptionDisplay(&self.src_identity),
+            self.dst
+        )
+    }
+}
+
+impl Rbac {
+    pub fn to_key(&self) -> String {
+        format!("{}/{}", self.namespace, self.name)
+    }
+
+    #[instrument(level = "trace", skip_all, fields(policy=self.to_key()))]
+    pub fn matches(&self, conn: &Connection) -> bool {
+        let id = conn
+            .src_identity
+            .as_ref()
+            .map(|i| i.to_string())
+            .unwrap_or_default();
+        let ns = conn
+            .src_identity
+            .as_ref()
+            .map(|i| match i {
+                Identity::Spiffe { namespace, .. } => namespace.clone(),
+            })
+            .unwrap_or_default();
+        for rule in self.groups.iter() {
+            // If ANY rule matches, it is a match...
+            let mut rule_match = true;
+            for group in rule.iter() {
+                // We need ALL groups to match...
+                let mut group_match = true;
+                for mg in group.iter() {
+                    if mg.is_empty() {
+                        trace!(matches = false, "empty rule");
+                        group_match = false;
+                        break;
+                    }
+                    // We need ALL of these to match. Within each type, ANY must match
+                    let mut m = true;
+                    m &= Self::matches_internal(
+                        "destination_ip",
+                        &mg.destination_ips,
+                        &mg.not_destination_ips,
+                        |i| i.contains(&conn.dst.ip()),
+                    );
+                    m &= Self::matches_internal(
+                        "source_ips",
+                        &mg.source_ips,
+                        &mg.not_source_ips,
+                        |i| i.contains(&conn.src_ip),
+                    );
+                    m &= Self::matches_internal(
+                        "destination_ports",
+                        &mg.destination_ports,
+                        &mg.not_destination_ports,
+                        |p| *p == conn.dst.port(),
+                    );
+                    m &= Self::matches_internal(
+                        "principals",
+                        &mg.principals,
+                        &mg.not_principals,
+                        |p| p.matches(&id),
+                    );
+                    m &= Self::matches_internal(
+                        "namespaces",
+                        &mg.namespaces,
+                        &mg.not_namespaces,
+                        |p| p.matches(&ns),
+                    );
+
+                    group_match &= m;
+                }
+
+                rule_match &= group_match;
+            }
+            if rule_match {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[instrument(name= "match", level = "trace", skip_all, fields(%desc))]
+    fn matches_internal<T: fmt::Debug>(
+        desc: &'static str,
+        positive: &Vec<T>,
+        negative: &Vec<T>,
+        mut predicate: impl FnMut(&T) -> bool,
+    ) -> bool {
+        let pm = if positive.is_empty() {
+            trace!(matches = true, "type" = "positive", "no match declared");
+            true
+        } else {
+            let matches = positive.iter().any(&mut predicate);
+            trace!(%matches, "type"="positive", "{positive:?}");
+            matches
+        };
+        let nm = if negative.is_empty() {
+            trace!(matches = true, "type" = "negative", "no match declared");
+            true
+        } else {
+            let matches = negative.iter().any(&mut predicate);
+            trace!(%matches, "type"="negative", "{negative:?}");
+            matches
+        };
+        pm && nm
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RbacMatch {
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub namespaces: Vec<StringMatch>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub not_namespaces: Vec<StringMatch>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub principals: Vec<StringMatch>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub not_principals: Vec<StringMatch>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub source_ips: Vec<IpNet>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub not_source_ips: Vec<IpNet>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub destination_ips: Vec<IpNet>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub not_destination_ips: Vec<IpNet>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub destination_ports: Vec<u16>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub not_destination_ports: Vec<u16>,
+}
+
+impl RbacMatch {
+    fn is_empty(&self) -> bool {
+        self.namespaces.is_empty()
+            && self.not_namespaces.is_empty()
+            && self.principals.is_empty()
+            && self.not_principals.is_empty()
+            && self.source_ips.is_empty()
+            && self.not_source_ips.is_empty()
+            && self.destination_ips.is_empty()
+            && self.not_destination_ips.is_empty()
+            && self.destination_ports.is_empty()
+            && self.not_destination_ports.is_empty()
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+pub enum StringMatch {
+    Prefix(String),
+    Suffix(String),
+    Exact(String),
+    Presence(),
+}
+
+impl StringMatch {
+    pub fn matches(&self, check: &str) -> bool {
+        // Istio matches all assumes spiffe:// prefix. This includes prefix matches.
+        // A prefix match for "*foo" means "spiffe://*foo".
+        // So we strip it, and fail if it isn't present.
+        let Some(check) = check.strip_prefix("spiffe://") else {
+            return false
+        };
+        match self {
+            StringMatch::Prefix(pre) => check.starts_with(pre),
+            StringMatch::Suffix(suf) => check.ends_with(suf),
+            StringMatch::Exact(exact) => exact == check,
+            StringMatch::Presence() => !check.is_empty(),
+        }
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub enum RbacScope {
+    Global,
+    Namespace,
+    WorkloadSelector,
+}
+
+impl TryFrom<Option<xds::istio::workload::RbacScope>> for RbacScope {
+    type Error = WorkloadError;
+
+    fn try_from(value: Option<xds::istio::workload::RbacScope>) -> Result<Self, Self::Error> {
+        match value {
+            Some(xds::istio::workload::RbacScope::WorkloadSelector) => {
+                Ok(RbacScope::WorkloadSelector)
+            }
+            Some(xds::istio::workload::RbacScope::Namespace) => Ok(RbacScope::Namespace),
+            Some(xds::istio::workload::RbacScope::Global) => Ok(RbacScope::Global),
+            None => Err(EnumParse("unknown type".into())),
+        }
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub enum RbacAction {
+    Allow,
+    Deny,
+}
+
+impl TryFrom<Option<xds::istio::workload::RbacPolicyAction>> for RbacAction {
+    type Error = WorkloadError;
+
+    fn try_from(
+        value: Option<xds::istio::workload::RbacPolicyAction>,
+    ) -> Result<Self, Self::Error> {
+        match value {
+            Some(xds::istio::workload::RbacPolicyAction::Allow) => Ok(RbacAction::Allow),
+            Some(xds::istio::workload::RbacPolicyAction::Deny) => Ok(RbacAction::Deny),
+            None => Err(EnumParse("unknown type".into())),
+        }
+    }
+}
+
+impl TryFrom<&XdsRbac> for Rbac {
+    type Error = WorkloadError;
+
+    fn try_from(resource: &XdsRbac) -> Result<Self, Self::Error> {
+        let resource: XdsRbac = resource.to_owned();
+        let groups = resource
+            .groups
+            .into_iter()
+            .map(|g| {
+                g.rules
+                    .into_iter()
+                    .map(|r| {
+                        r.matches
+                            .into_iter()
+                            .map(|m| TryInto::<RbacMatch>::try_into(&m))
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Rbac {
+            name: resource.name,
+            namespace: resource.namespace,
+            scope: RbacScope::try_from(xds::istio::workload::RbacScope::from_i32(resource.scope))?,
+            action: RbacAction::try_from(xds::istio::workload::RbacPolicyAction::from_i32(
+                resource.action,
+            ))?,
+            groups,
+        })
+    }
+}
+
+impl TryFrom<&RbacPolicyRuleMatch> for RbacMatch {
+    type Error = WorkloadError;
+
+    fn try_from(resource: &RbacPolicyRuleMatch) -> Result<Self, Self::Error> {
+        Ok(RbacMatch {
+            namespaces: resource.namespaces.iter().filter_map(From::from).collect(),
+            not_namespaces: resource
+                .not_namespaces
+                .iter()
+                .filter_map(From::from)
+                .collect(),
+            principals: resource.principals.iter().filter_map(From::from).collect(),
+            not_principals: resource
+                .not_principals
+                .iter()
+                .filter_map(From::from)
+                .collect(),
+            source_ips: resource
+                .source_ips
+                .iter()
+                .filter_map(|a| a.try_into().ok())
+                .collect(),
+            not_source_ips: resource
+                .not_source_ips
+                .iter()
+                .filter_map(|a| a.try_into().ok())
+                .collect(),
+            destination_ips: resource
+                .destination_ips
+                .iter()
+                .filter_map(|a| a.try_into().ok())
+                .collect(),
+            not_destination_ips: resource
+                .not_destination_ips
+                .iter()
+                .filter_map(|a| a.try_into().ok())
+                .collect(),
+            destination_ports: resource
+                .destination_ports
+                .iter()
+                .map(|p| *p as u16)
+                .collect(),
+            not_destination_ports: resource
+                .not_destination_ports
+                .iter()
+                .map(|p| *p as u16)
+                .collect(),
+        })
+    }
+}
+
+impl TryFrom<&XdsAddress> for IpNet {
+    type Error = WorkloadError;
+    fn try_from(resource: &XdsAddress) -> Result<Self, Self::Error> {
+        Ok(IpNet::new(
+            workload::byte_to_ip(&resource.address)?,
+            resource.length as u8,
+        )?)
+    }
+}
+
+impl From<&XdsStringMatch> for Option<StringMatch> {
+    fn from(resource: &XdsStringMatch) -> Self {
+        resource.match_type.as_ref().map(|m| match m {
+            MatchType::Exact(s) => StringMatch::Exact(s.clone()),
+            MatchType::Prefix(s) => StringMatch::Prefix(s.clone()),
+            MatchType::Suffix(s) => StringMatch::Suffix(s.clone()),
+            MatchType::Presence(_) => StringMatch::Presence(),
+        })
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 use once_cell::sync::Lazy;
 use once_cell::sync::OnceCell;
 use thiserror::Error;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 use tracing_subscriber::{filter, filter::EnvFilter, fmt, prelude::*, reload, Layer, Registry};
 
 pub static APPLICATION_START_TIME: Lazy<Instant> = Lazy::new(Instant::now);
@@ -79,7 +79,7 @@ pub fn set_level(reset: bool, level: &str) -> Result<(), Error> {
 
         //create the new EnvFilter based on the new directives
         let new_filter = EnvFilter::builder().parse(new_directive)?;
-        error!("new log filter is {new_filter}");
+        info!("new log filter is {new_filter}");
 
         //set the new filter
         Ok(handle.modify(|layer| {

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -18,7 +18,7 @@ use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use crate::config;
 use crate::config::ConfigSource;
 use crate::workload::Protocol::{HBONE, TCP};
-use crate::workload::{LocalWorkload, Workload};
+use crate::workload::{LocalConfig, LocalWorkload, Workload};
 use bytes::{BufMut, Bytes};
 use std::default::Default;
 
@@ -70,6 +70,7 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
                 node: "local".to_string(),
 
                 waypoint_addresses: vec![],
+                authorization_policies: vec![],
                 gateway_address: None,
                 workload_name: "".to_string(),
                 workload_type: "".to_string(),
@@ -89,6 +90,7 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
                 node: "local".to_string(),
 
                 waypoint_addresses: vec![],
+                authorization_policies: vec![],
                 gateway_address: None,
                 workload_name: "".to_string(),
                 workload_type: "".to_string(),
@@ -108,6 +110,7 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
                 node: "local".to_string(),
 
                 waypoint_addresses: vec![],
+                authorization_policies: vec![],
                 gateway_address: None,
                 workload_name: "".to_string(),
                 workload_type: "".to_string(),
@@ -118,6 +121,10 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
             vips: Default::default(),
         },
     ];
-    serde_yaml::to_writer(&mut b, &res)?;
+    let lc = LocalConfig {
+        workloads: res,
+        policies: vec![],
+    };
+    serde_yaml::to_writer(&mut b, &lc)?;
     Ok(b.into_inner().freeze())
 }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -20,18 +20,21 @@ use std::sync::{Arc, Mutex};
 use std::{fmt, net};
 
 use rand::prelude::IteratorRandom;
-
 use thiserror::Error;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, trace};
+
+use xds::istio::workload::Rbac as XdsRbac;
 
 use xds::istio::workload::Workload as XdsWorkload;
 
 use crate::config::ConfigSource;
 use crate::identity::Identity;
 use crate::metrics::Metrics;
-use crate::workload::WorkloadError::ProtocolParse;
+use crate::workload::WorkloadError::EnumParse;
+
+use crate::rbac::{Rbac, RbacScope};
 use crate::xds::{AdsClient, Demander, RejectedConfig, XdsUpdate};
-use crate::{config, readiness, xds};
+use crate::{config, rbac, readiness, xds};
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum Protocol {
@@ -52,7 +55,7 @@ impl TryFrom<Option<xds::istio::workload::Protocol>> for Protocol {
         match value {
             Some(xds::istio::workload::Protocol::Http) => Ok(Protocol::HBONE),
             Some(xds::istio::workload::Protocol::Direct) => Ok(Protocol::TCP),
-            None => Err(ProtocolParse("unknown type".into())),
+            None => Err(EnumParse("unknown type".into())),
         }
     }
 }
@@ -89,6 +92,9 @@ pub struct Workload {
 
     #[serde(default)]
     pub native_hbone: bool,
+
+    #[serde(default)]
+    pub authorization_policies: Vec<String>,
 }
 
 impl Workload {
@@ -146,7 +152,7 @@ impl fmt::Display for Upstream {
     }
 }
 
-fn byte_to_ip(b: &bytes::Bytes) -> Result<IpAddr, WorkloadError> {
+pub fn byte_to_ip(b: &bytes::Bytes) -> Result<IpAddr, WorkloadError> {
     match b.len() {
         0 => Err(WorkloadError::ByteAddressParse(0)),
         4 => {
@@ -199,6 +205,7 @@ impl TryFrom<&XdsWorkload> for Workload {
             canonical_revision: resource.canonical_revision,
 
             native_hbone: resource.native_hbone,
+            authorization_policies: resource.authorization_policies,
         })
     }
 }
@@ -225,6 +232,26 @@ impl xds::Handler<XdsWorkload> for Arc<Mutex<WorkloadStore>> {
     }
 }
 
+impl xds::Handler<XdsRbac> for Arc<Mutex<WorkloadStore>> {
+    fn handle(&self, updates: Vec<XdsUpdate<XdsRbac>>) -> Result<(), Vec<RejectedConfig>> {
+        let mut wli = self.lock().unwrap();
+        let handle = |res: XdsUpdate<XdsRbac>| {
+            match res {
+                XdsUpdate::Update(w) => {
+                    info!("handling RBAC update {}", w.name);
+                    wli.insert_xds_rbac(w.resource)?;
+                }
+                XdsUpdate::Remove(name) => {
+                    info!("handling RBAC delete {}", name);
+                    wli.remove_rbac(name);
+                }
+            }
+            Ok(())
+        };
+        xds::handle_single_resource(updates, handle)
+    }
+}
+
 impl WorkloadManager {
     pub async fn new(
         config: config::Config,
@@ -233,11 +260,14 @@ impl WorkloadManager {
     ) -> anyhow::Result<WorkloadManager> {
         let workloads: Arc<Mutex<WorkloadStore>> = Arc::new(Mutex::new(WorkloadStore::default()));
         let xds_workloads = workloads.clone();
+        let xds_rbac = workloads.clone();
         let xds_client = if config.xds_address.is_some() {
             Some(
                 xds::Config::new(config.clone())
                     .with_workload_handler(xds_workloads)
+                    .with_rbac_handler(xds_rbac)
                     .watch(xds::WORKLOAD_TYPE.into())
+                    .watch(xds::RBAC_TYPE.into())
                     .build(metrics, awaiting_ready.subtask("ads client")),
             )
         } else {
@@ -287,18 +317,26 @@ pub struct LocalWorkload {
     pub vips: HashMap<String, HashMap<u16, u16>>,
 }
 
+#[derive(Default, Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalConfig {
+    pub workloads: Vec<LocalWorkload>,
+    pub policies: Vec<Rbac>,
+}
+
 impl LocalClient {
     #[instrument(skip_all, name = "local_client")]
     async fn run(self) -> Result<(), anyhow::Error> {
         // Currently, we just load the file once. In the future, we could dynamically reload.
         let data = self.cfg.read_to_string().await?;
-        let r: Vec<LocalWorkload> = serde_yaml::from_str(&data)?;
+        let r: LocalConfig = serde_yaml::from_str(&data)?;
         let mut wli = self.workloads.lock().unwrap();
-        let l = r.len();
-        for wl in r {
+        let workloads = r.workloads.len();
+        let policies = r.policies.len();
+        for wl in r.workloads {
             let wip = wl.workload.workload_ip;
             debug!("inserting local workloads {wip}");
-            wli.insert(wl.workload);
+            wli.insert_workload(wl.workload);
             for (vip, ports) in wl.vips {
                 let ip = vip.parse::<IpAddr>()?;
                 for (service_port, target_port) in ports {
@@ -311,7 +349,10 @@ impl LocalClient {
                 }
             }
         }
-        info!("inserted {} local workloads", l);
+        for rbac in r.policies {
+            wli.insert_rbac(rbac);
+        }
+        info!(%workloads, %policies, "local config initialized");
         Ok(())
     }
 }
@@ -329,6 +370,67 @@ pub struct WorkloadInformation {
 }
 
 impl WorkloadInformation {
+    pub async fn assert_rbac(&self, conn: &rbac::Connection) -> bool {
+        let Some(wl) = self.fetch_workload(&conn.dst.ip()).await else {
+            debug!("destination workload not found");
+            return false;
+        };
+
+        if wl.waypoint_addresses.contains(&conn.src_ip) && conn.src_identity == Some(wl.identity())
+        {
+            debug!("request from waypoint, skipping policy");
+            return true;
+        }
+        let wli = self.info.lock().unwrap();
+
+        // We can get policies from namespace, global, and workload...
+        let ns = wli
+            .policies_by_namespace
+            .get(&wl.namespace)
+            .into_iter()
+            .flatten();
+        let global = wli.policies_by_namespace.get("").into_iter().flatten();
+        let workload = wl.authorization_policies.iter();
+
+        // Aggregate all of them based on type
+        let (allow, deny): (Vec<_>, Vec<_>) = ns
+            .chain(global)
+            .chain(workload)
+            .filter_map(|k| wli.policies.get(k))
+            .partition(|p| p.action == rbac::RbacAction::Allow);
+
+        trace!(
+            allow = allow.len(),
+            deny = deny.len(),
+            "checking connection"
+        );
+
+        // Allow and deny logic follows https://istio.io/latest/docs/reference/config/security/authorization-policy/
+
+        // "If there are any DENY policies that match the request, deny the request."
+        for pol in deny.iter() {
+            if pol.matches(conn) {
+                debug!("deny policy match");
+                return false;
+            }
+        }
+        // "If there are no ALLOW policies for the workload, allow the request."
+        if allow.is_empty() {
+            debug!("no allow policies, allow");
+            return true;
+        }
+        // "If any of the ALLOW policies match the request, allow the request."
+        for pol in allow.iter() {
+            if pol.matches(conn) {
+                debug!("allow policy match");
+                return true;
+            }
+        }
+        // "Deny the request."
+        debug!("no allow policies matched");
+        false
+    }
+
     // only support workload
     pub async fn fetch_workload(&self, addr: &IpAddr) -> Option<Workload> {
         // Wait for it on-demand, *if* needed
@@ -389,11 +491,16 @@ impl WorkloadInformation {
 #[derive(serde::Serialize, Default, Debug)]
 pub struct WorkloadStore {
     workloads: HashMap<IpAddr, Workload>,
-    // workload_to_vip maintains a mapping of workload IP to VIP. This is used only to handle removals.
+    /// workload_to_vip maintains a mapping of workload IP to VIP. This is used only to handle removals.
     workload_to_vip: HashMap<IpAddr, HashSet<(SocketAddr, u16)>>,
-    // vips maintains a mapping of socket address with service port to workload ip and socket address
-    // with target ports in hashset.
+    /// vips maintains a mapping of socket address with service port to workload ip and socket address
+    /// with target ports in hashset.
     vips: HashMap<SocketAddr, HashSet<(IpAddr, u16)>>,
+
+    /// policies maintains a mapping of ns/name to policy.
+    policies: HashMap<String, rbac::Rbac>,
+    // policies_by_namespace maintains a mapping of namespace (or "" for global) to policy names
+    policies_by_namespace: HashMap<String, HashSet<String>>,
 }
 
 impl WorkloadStore {
@@ -409,7 +516,7 @@ impl WorkloadStore {
     fn insert_xds_workload(&mut self, w: XdsWorkload) -> anyhow::Result<()> {
         let workload = Workload::try_from(&w)?;
         let wip = workload.workload_ip;
-        self.insert(workload);
+        self.insert_workload(workload);
         for (vip, pl) in &w.virtual_ips {
             let ip = vip.parse::<IpAddr>()?;
             for port in &pl.ports {
@@ -427,7 +534,52 @@ impl WorkloadStore {
         Ok(())
     }
 
-    fn insert(&mut self, w: Workload) {
+    fn insert_xds_rbac(&mut self, r: XdsRbac) -> anyhow::Result<()> {
+        let rbac = rbac::Rbac::try_from(&r)?;
+        trace!("insert policy {}", serde_json::to_string(&rbac)?);
+        self.insert_rbac(rbac);
+        Ok(())
+    }
+
+    fn insert_rbac(&mut self, rbac: Rbac) {
+        let key = rbac.to_key();
+        match rbac.scope {
+            RbacScope::Global => {
+                self.policies_by_namespace
+                    .entry("".to_string())
+                    .or_default()
+                    .insert(key.clone());
+            }
+            RbacScope::Namespace => {
+                self.policies_by_namespace
+                    .entry(rbac.namespace.clone())
+                    .or_default()
+                    .insert(key.clone());
+            }
+            RbacScope::WorkloadSelector => {}
+        }
+        self.policies.insert(key, rbac);
+    }
+
+    fn remove_rbac(&mut self, name: String) {
+        let Some(rbac) = self.policies.remove(&name) else {
+            return;
+        };
+        if let Some(key) = match rbac.scope {
+            RbacScope::Global => Some("".to_string()),
+            RbacScope::Namespace => Some(rbac.namespace),
+            RbacScope::WorkloadSelector => None,
+        } {
+            if let Some(pl) = self.policies_by_namespace.get_mut(&key) {
+                pl.remove(&name);
+                if pl.is_empty() {
+                    self.policies_by_namespace.remove(&key);
+                }
+            }
+        }
+    }
+
+    fn insert_workload(&mut self, w: Workload) {
         let wip = w.workload_ip;
         self.workloads.insert(wip, w);
     }
@@ -511,8 +663,10 @@ pub enum WorkloadError {
     AddressParse(#[from] net::AddrParseError),
     #[error("failed to parse address, had {0} bytes")]
     ByteAddressParse(usize),
-    #[error("unknown protocol {0}")]
-    ProtocolParse(String),
+    #[error("invalid cidr: {0}")]
+    PrefixParse(#[from] ipnet::PrefixLenError),
+    #[error("unknown enum: {0}")]
+    EnumParse(String),
 }
 
 #[cfg(test)]
@@ -620,6 +774,7 @@ mod tests {
             canonical_revision: "".to_string(),
             node: "".to_string(),
 
+            authorization_policies: Default::default(),
             native_hbone: false,
         };
         let mut wi = WorkloadStore::default();

--- a/src/xds/types.rs
+++ b/src/xds/types.rs
@@ -38,4 +38,4 @@ pub mod istio {
 }
 
 pub const WORKLOAD_TYPE: &str = "type.googleapis.com/istio.workload.Workload";
-pub const RBAC_TYPE: &str = "type.googleapis.com/istio.workload.Authorization";
+pub const RBAC_TYPE: &str = "type.googleapis.com/istio.workload.RBAC";


### PR DESCRIPTION
This commit introduces the first iteration of L4 AuthorizationPolicy
support.

* Policies are read over XDS and converted to a new internal type. These
  are indexed by namespace
* Inbound requests check against applicable policies and send 401 in the
  HBONE response when they fail to match
* Current matching algorithm is fairly efficient (TODO: benchmarks), but
  not optimized (one could imagine a trie like implementation; today it
is a linear search).

Fixes https://github.com/istio/ztunnel/issues/259
Fixes https://github.com/istio/ztunnel/issues/205
Fixes https://github.com/istio/ztunnel/issues/29