### PR TITLE
Implement inbound passthrough hairpin

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -204,22 +204,7 @@ pub fn metrics(c: &mut Criterion) {
         b.iter(|| {
             metrics.record(&ConnectionOpen {
                 reporter: Default::default(),
-                source: Workload {
-                    workload_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    waypoint_addresses: Default::default(),
-                    gateway_address: Default::default(),
-                    protocol: Default::default(),
-                    name: Default::default(),
-                    namespace: Default::default(),
-                    service_account: Default::default(),
-                    workload_name: Default::default(),
-                    workload_type: Default::default(),
-                    canonical_name: Default::default(),
-                    canonical_revision: Default::default(),
-                    node: Default::default(),
-                    native_hbone: Default::default(),
-                    authorization_policies: Default::default(),
-                },
+                source: test_helpers::test_default_workload(),
                 destination: None,
                 destination_service: None,
                 connection_security_policy: Default::default(),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -201,7 +201,7 @@ impl OutboundConnection {
                 let id = &req.source.identity();
                 let cert = self.pi.cert_manager.fetch_certificate(id).await?;
                 let connector = cert
-                    .connector(&req.destination_workload.map(|w| w.identity()))?
+                    .connector(req.destination_workload.map(|w| w.identity()).as_ref())?
                     .configure()
                     .expect("configure");
                 let tcp_stream = TcpStream::connect(req.gateway).await?;
@@ -379,7 +379,7 @@ enum RequestType {
     Passthrough,
 }
 
-async fn connect_tls(
+pub async fn connect_tls(
     mut connector: ConnectConfiguration,
     stream: TcpStream,
 ) -> Result<tokio_boring::SslStream<TcpStream>, tokio_boring::HandshakeError<TcpStream>> {

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
+
 use std::time::Instant;
 
 use boring::ssl::ConnectConfiguration;
@@ -22,38 +22,25 @@ use hyper::StatusCode;
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, error, info, info_span, trace_span, warn, Instrument};
 
-use crate::config::Config;
-use crate::identity::CertificateProvider;
 use crate::metrics::traffic::Reporter;
-use crate::metrics::{traffic, Metrics, Recorder};
+use crate::metrics::{traffic, Recorder};
 use crate::proxy::inbound::{Inbound, InboundConnect};
-use crate::proxy::{util, Error, TraceParent, BAGGAGE_HEADER, TRACEPARENT_HEADER};
+use crate::proxy::{util, Error, ProxyInputs, TraceParent, BAGGAGE_HEADER, TRACEPARENT_HEADER};
 use crate::socket::relay;
-use crate::workload::{Protocol, Workload, WorkloadInformation};
+use crate::workload::{Protocol, Workload};
 use crate::{rbac, socket};
 
 pub struct Outbound {
-    cfg: Config,
-    cert_manager: Box<dyn CertificateProvider>,
-    workloads: WorkloadInformation,
-    listener: TcpListener,
+    pi: ProxyInputs,
     drain: Watch,
-    metrics: Arc<Metrics>,
-    hbone_port: u16,
+    listener: TcpListener,
 }
 
 impl Outbound {
-    pub async fn new(
-        cfg: Config,
-        cert_manager: Box<dyn CertificateProvider>,
-        workloads: WorkloadInformation,
-        hbone_port: u16,
-        metrics: Arc<Metrics>,
-        drain: Watch,
-    ) -> Result<Outbound, Error> {
-        let listener: TcpListener = TcpListener::bind(cfg.outbound_addr)
+    pub(super) async fn new(pi: ProxyInputs, drain: Watch) -> Result<Outbound, Error> {
+        let listener: TcpListener = TcpListener::bind(pi.cfg.outbound_addr)
             .await
-            .map_err(|e| Error::Bind(cfg.outbound_addr, e))?;
+            .map_err(|e| Error::Bind(pi.cfg.outbound_addr, e))?;
 
         let transparent = socket::set_transparent(&listener).is_ok();
 
@@ -64,12 +51,8 @@ impl Outbound {
             "listener established",
         );
         Ok(Outbound {
-            cfg,
-            cert_manager,
-            workloads,
+            pi,
             listener,
-            hbone_port,
-            metrics,
             drain,
         })
     }
@@ -86,13 +69,8 @@ impl Outbound {
                 let start_outbound_instant = Instant::now();
                 match socket {
                     Ok((stream, _remote)) => {
-                        let cfg = self.cfg.clone();
                         let mut oc = OutboundConnection {
-                            cert_manager: self.cert_manager.clone(),
-                            workloads: self.workloads.clone(),
-                            cfg,
-                            hbone_port: self.hbone_port,
-                            metrics: self.metrics.clone(),
+                            pi: self.pi.clone(),
                             id: TraceParent::new(),
                         };
                         let span = info_span!("outbound", id=%oc.id);
@@ -129,14 +107,9 @@ impl Outbound {
     }
 }
 
-pub struct OutboundConnection {
-    pub cert_manager: Box<dyn CertificateProvider>,
-    pub workloads: WorkloadInformation,
-    // TODO: Config may be excessively large, maybe we store a scoped OutboundConfig intended for cloning.
-    pub cfg: Config,
-    pub hbone_port: u16,
-    pub metrics: Arc<Metrics>,
-    pub id: TraceParent,
+pub(super) struct OutboundConnection {
+    pub(super) pi: ProxyInputs,
+    pub(super) id: TraceParent,
 }
 
 impl OutboundConnection {
@@ -177,6 +150,7 @@ impl OutboundConnection {
 
         // _connection_close will record once dropped
         let _connection_close = self
+            .pi
             .metrics
             .record_defer::<_, traffic::ConnectionClose>(&connection_metrics);
         if req.request_type == RequestType::DirectLocal && can_fastpath {
@@ -190,7 +164,7 @@ impl OutboundConnection {
                 src_ip: remote_addr,
                 dst: req.destination,
             };
-            if !self.workloads.assert_rbac(&conn).await {
+            if !self.pi.workloads.assert_rbac(&conn).await {
                 info!(%conn, "RBAC rejected");
                 return Err(Error::HttpStatus(StatusCode::UNAUTHORIZED));
             }
@@ -211,9 +185,9 @@ impl OutboundConnection {
                 let mut builder = hyper::client::conn::Builder::new();
                 let builder = builder
                     .http2_only(true)
-                    .http2_initial_stream_window_size(self.cfg.window_size)
-                    .http2_max_frame_size(self.cfg.frame_size)
-                    .http2_initial_connection_window_size(self.cfg.connection_window_size);
+                    .http2_initial_stream_window_size(self.pi.cfg.window_size)
+                    .http2_max_frame_size(self.pi.cfg.frame_size)
+                    .http2_initial_connection_window_size(self.pi.cfg.connection_window_size);
 
                 let request = hyper::Request::builder()
                     .uri(&req.destination.to_string())
@@ -225,7 +199,7 @@ impl OutboundConnection {
                     .unwrap();
 
                 let id = &req.source.identity();
-                let cert = self.cert_manager.fetch_certificate(id).await?;
+                let cert = self.pi.cert_manager.fetch_certificate(id).await?;
                 let connector = cert
                     .connector(&req.destination_workload.map(|w| w.identity()))?
                     .configure()
@@ -264,11 +238,11 @@ impl OutboundConnection {
                 // Create a TCP connection to upstream
                 let mut outbound = TcpStream::connect(req.gateway).await?;
                 // Proxying data between downstrean and upstream
-                match relay(&mut stream, &mut outbound, self.cfg.zero_copy_enabled).await {
+                match relay(&mut stream, &mut outbound, self.pi.cfg.zero_copy_enabled).await {
                     // Connection closed with count of bytes transferred between streams
                     Ok(Some((sent, recv))) => {
-                        self.metrics.record_count(&sent_bytes, sent);
-                        self.metrics.record_count(&received_bytes, recv);
+                        self.pi.metrics.record_count(&sent_bytes, sent);
+                        self.pi.metrics.record_count(&received_bytes, recv);
                         Ok(())
                     }
                     Ok(None) => Ok(()),
@@ -283,13 +257,17 @@ impl OutboundConnection {
         downstream: IpAddr,
         target: SocketAddr,
     ) -> Result<Request, Error> {
-        let source_workload = match self.workloads.fetch_workload(&downstream).await {
+        let source_workload = match self.pi.workloads.fetch_workload(&downstream).await {
             Some(wl) => wl,
             None => return Err(Error::UnknownSource(downstream)),
         };
 
         // TODO: we want a single lock for source and upstream probably...?
-        let us = self.workloads.find_upstream(target, self.hbone_port).await;
+        let us = self
+            .pi
+            .workloads
+            .find_upstream(target, self.pi.hbone_port)
+            .await;
         if us.is_none() {
             // For case no upstream found, passthrough it
             return Ok(Request {
@@ -324,7 +302,7 @@ impl OutboundConnection {
         }
         // For case source client and upstream server are on the same node
         if !us.workload.node.is_empty()
-            && self.cfg.local_node == Some(us.workload.node.clone())
+            && self.pi.cfg.local_node == Some(us.workload.node.clone())
             && us.workload.protocol == Protocol::HBONE
         {
             return Ok(Request {
@@ -417,6 +395,8 @@ mod tests {
 
     use bytes::Bytes;
 
+    use crate::config::Config;
+    use crate::workload::WorkloadInformation;
     use crate::xds::istio::workload::Protocol as XdsProtocol;
     use crate::xds::istio::workload::Workload as XdsWorkload;
     use crate::{identity, workload};
@@ -447,11 +427,13 @@ mod tests {
             demand: None,
         };
         let outbound = OutboundConnection {
-            cert_manager: Box::new(identity::mock::MockCaClient::new(Duration::from_secs(10))),
-            workloads: wi,
-            hbone_port: 15008,
-            cfg,
-            metrics: Arc::new(Default::default()),
+            pi: ProxyInputs {
+                cert_manager: Box::new(identity::mock::MockCaClient::new(Duration::from_secs(10))),
+                workloads: wi,
+                hbone_port: 15008,
+                cfg,
+                metrics: Arc::new(Default::default()),
+            },
             id: TraceParent::new(),
         };
 

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -90,6 +90,10 @@ impl Authorization {
                 Identity::Spiffe { namespace, .. } => namespace.clone(),
             })
             .unwrap_or_default();
+        if self.groups.is_empty() {
+            trace!(matches = false, "empty groups");
+            return false;
+        }
         for rule in self.groups.iter() {
             // If ANY rule matches, it is a match...
             let mut rule_match = true;
@@ -138,6 +142,11 @@ impl Authorization {
                     group_match &= m;
                 }
 
+                if group.is_empty() {
+                    trace!(matches = true, "empty group");
+                } else {
+                    trace!(matches = group_match, "group");
+                }
                 rule_match &= group_match;
             }
             if rule_match {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -46,7 +46,6 @@ pub fn test_config_with_port(port: u16) -> config::Config {
         readiness_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
-        local_node: node,
         zero_copy_enabled: true,
         ..config::parse_config().unwrap()
     }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use crate::config;
 use crate::config::ConfigSource;
@@ -27,7 +27,7 @@ pub mod ca;
 pub mod helpers;
 pub mod tcp;
 
-pub fn test_config_with_port_and_node(port: u16, node: Option<String>) -> config::Config {
+pub fn test_config_with_port(port: u16) -> config::Config {
     config::Config {
         xds_address: None,
         fake_ca: true,
@@ -44,10 +44,6 @@ pub fn test_config_with_port_and_node(port: u16, node: Option<String>) -> config
     }
 }
 
-pub fn test_config_with_port(port: u16) -> config::Config {
-    test_config_with_port_and_node(port, None)
-}
-
 pub fn test_config() -> config::Config {
     test_config_with_port(80)
 }
@@ -56,7 +52,28 @@ pub fn test_config() -> config::Config {
 pub const TEST_WORKLOAD_SOURCE: &str = "127.0.0.2";
 pub const TEST_WORKLOAD_HBONE: &str = "127.0.0.3";
 pub const TEST_WORKLOAD_TCP: &str = "127.0.0.4";
+pub const TEST_WORKLOAD_WAYPOINT: &str = "127.0.0.4";
 pub const TEST_VIP: &str = "127.10.0.1";
+
+pub fn test_default_workload() -> Workload {
+    Workload {
+        workload_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        waypoint_addresses: Vec::new(),
+        gateway_address: None,
+        protocol: Default::default(),
+        name: "".to_string(),
+        namespace: "".to_string(),
+        service_account: "default".to_string(),
+        workload_name: "".to_string(),
+        workload_type: "deployment".to_string(),
+        canonical_name: "".to_string(),
+        canonical_revision: "".to_string(),
+        node: "".to_string(),
+
+        authorization_policies: Vec::new(),
+        native_hbone: false,
+    }
+}
 
 fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
     let mut b = bytes::BytesMut::new().writer();
@@ -69,15 +86,7 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
                 namespace: "default".to_string(),
                 service_account: "default".to_string(),
                 node: "local".to_string(),
-
-                waypoint_addresses: vec![],
-                authorization_policies: vec![],
-                gateway_address: None,
-                workload_name: "".to_string(),
-                workload_type: "".to_string(),
-                canonical_name: "".to_string(),
-                canonical_revision: "".to_string(),
-                native_hbone: false,
+                ..test_default_workload()
             },
             vips: HashMap::from([(TEST_VIP.to_string(), HashMap::from([(80u16, echo_port)]))]),
         },
@@ -89,15 +98,7 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
                 namespace: "default".to_string(),
                 service_account: "default".to_string(),
                 node: "local".to_string(),
-
-                waypoint_addresses: vec![],
-                authorization_policies: vec![],
-                gateway_address: None,
-                workload_name: "".to_string(),
-                workload_type: "".to_string(),
-                canonical_name: "".to_string(),
-                canonical_revision: "".to_string(),
-                native_hbone: false,
+                ..test_default_workload()
             },
             vips: HashMap::from([(TEST_VIP.to_string(), HashMap::from([(80u16, echo_port)]))]),
         },
@@ -109,15 +110,20 @@ fn local_xds_config(echo_port: u16) -> anyhow::Result<Bytes> {
                 namespace: "default".to_string(),
                 service_account: "default".to_string(),
                 node: "local".to_string(),
-
-                waypoint_addresses: vec![],
-                authorization_policies: vec![],
-                gateway_address: None,
-                workload_name: "".to_string(),
-                workload_type: "".to_string(),
-                canonical_name: "".to_string(),
-                canonical_revision: "".to_string(),
-                native_hbone: false,
+                ..test_default_workload()
+            },
+            vips: Default::default(),
+        },
+        LocalWorkload {
+            workload: Workload {
+                workload_ip: TEST_WORKLOAD_WAYPOINT.parse()?,
+                protocol: HBONE,
+                name: "local-waypoint".to_string(),
+                namespace: "default".to_string(),
+                service_account: "default".to_string(),
+                node: "local".to_string(),
+                waypoint_addresses: vec!["127.0.0.9".parse().unwrap()],
+                ..test_default_workload()
             },
             vips: Default::default(),
         },

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -24,16 +24,19 @@ use prometheus_parse::Scrape;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpSocket, TcpStream};
 
+use crate::identity::mock::MockCaClient;
+use crate::identity::SecretManager;
 use crate::test_helpers::TEST_WORKLOAD_SOURCE;
 use crate::*;
 
 use super::helpers::*;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct TestApp {
     pub admin_address: SocketAddr,
     pub readiness_address: SocketAddr,
     pub proxy_addresses: proxy::Addresses,
+    pub cert_manager: SecretManager<MockCaClient>,
 }
 
 pub async fn with_app<F, Fut, FO>(cfg: config::Config, f: F)
@@ -42,15 +45,17 @@ where
     Fut: Future<Output = FO>,
 {
     initialize_telemetry();
-    telemetry::set_level(false, "ztunnel=trace");
-    let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(10));
-    let app = app::build_with_cert(cfg, cert_manager).await.unwrap();
+    let cert_manager = MockCaClient::new(Duration::from_secs(10));
+    let app = app::build_with_cert(cfg, cert_manager.clone())
+        .await
+        .unwrap();
     let shutdown = app.shutdown.trigger().clone();
 
     let ta = TestApp {
         admin_address: app.admin_address,
         proxy_addresses: app.proxy_addresses,
         readiness_address: app.readiness_address,
+        cert_manager,
     };
     let run_and_shutdown = async {
         ta.ready().await;

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -42,6 +42,7 @@ where
     Fut: Future<Output = FO>,
 {
     initialize_telemetry();
+    telemetry::set_level(false, "ztunnel=trace");
     let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(10));
     let app = app::build_with_cert(cfg, cert_manager).await.unwrap();
     let shutdown = app.shutdown.trigger().clone();

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -250,7 +250,7 @@ impl Certs {
         Ok(conn.build())
     }
 
-    pub fn connector(&self, dest_id: &Option<Identity>) -> Result<ssl::SslConnector, Error> {
+    pub fn connector(&self, dest_id: Option<&Identity>) -> Result<ssl::SslConnector, Error> {
         let mut conn = ssl::SslConnector::builder(ssl::SslMethod::tls_client())?;
         self.setup_ctx(&mut conn)?;
 

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -677,8 +677,8 @@ pub enum WorkloadError {
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
-    use bytes::Bytes;
     use crate::test_helpers;
+    use bytes::Bytes;
 
     use crate::xds::istio::workload::Port as XdsPort;
     use crate::xds::istio::workload::PortList as XdsPortList;

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -678,6 +678,7 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use bytes::Bytes;
+    use crate::test_helpers;
 
     use crate::xds::istio::workload::Port as XdsPort;
     use crate::xds::istio::workload::PortList as XdsPortList;
@@ -764,23 +765,6 @@ mod tests {
 
     #[test]
     fn workload_information() {
-        let default = Workload {
-            workload_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            waypoint_addresses: Vec::new(),
-            gateway_address: None,
-            protocol: Default::default(),
-            name: "".to_string(),
-            namespace: "".to_string(),
-            service_account: "default".to_string(),
-            workload_name: "".to_string(),
-            workload_type: "deployment".to_string(),
-            canonical_name: "".to_string(),
-            canonical_revision: "".to_string(),
-            node: "".to_string(),
-
-            authorization_policies: Default::default(),
-            native_hbone: false,
-        };
         let mut wi = WorkloadStore::default();
         assert_eq!((wi.workloads.len()), 0);
         assert_eq!((wi.vips.len()), 0);
@@ -801,7 +785,7 @@ mod tests {
             Some(&Workload {
                 workload_ip: ip1,
                 name: "some name".to_string(),
-                ..default.clone()
+                ..test_helpers::test_default_workload()
             })
         );
 
@@ -811,7 +795,7 @@ mod tests {
             Some(&Workload {
                 workload_ip: ip1,
                 name: "some name".to_string(),
-                ..default.clone()
+                ..test_helpers::test_default_workload()
             })
         );
 
@@ -821,7 +805,7 @@ mod tests {
             Some(&Workload {
                 workload_ip: ip1,
                 name: "some name".to_string(),
-                ..default
+                ..test_helpers::test_default_workload()
             })
         );
 

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -410,8 +410,10 @@ impl WorkloadInformation {
         // "If there are any DENY policies that match the request, deny the request."
         for pol in deny.iter() {
             if pol.matches(conn) {
-                debug!("deny policy match");
+                debug!(policy = pol.to_key(), "deny policy match");
                 return false;
+            } else {
+                trace!(policy = pol.to_key(), "deny policy does not match");
             }
         }
         // "If there are no ALLOW policies for the workload, allow the request."
@@ -422,8 +424,10 @@ impl WorkloadInformation {
         // "If any of the ALLOW policies match the request, allow the request."
         for pol in allow.iter() {
             if pol.matches(conn) {
-                debug!("allow policy match");
+                debug!(policy = pol.to_key(), "allow policy match");
                 return true;
+            } else {
+                trace!(policy = pol.to_key(), "allow policy does not match");
             }
         }
         // "Deny the request."

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -273,7 +273,7 @@ async fn test_inbound_waypoint_bypass() {
     let cfg = config::Config {
         ..test_config_with_waypoint(TEST_WORKLOAD_WAYPOINT.parse().unwrap())
     };
-    testapp::with_app(cfg, |mut app| async move {
+    testapp::with_app(cfg, |app| async move {
         let mut builder = hyper::client::conn::Builder::new();
         let builder = builder.http2_only(true);
 


### PR DESCRIPTION
For https://github.com/istio/ztunnel/issues/73

This is a pretty large change:
* Outbound is refactored to take in a ProxyInputs instead of ~5 fields. This is useful since we use this now from all the proxy types (outbound, socks5, inbound), since any of those can result in outbound requests now.
* Add a few debugging logs that were useful when testing this.
* Add new testing for "waypoints"
* The core logic: new handling for inbound and inbound passthrough
  * Both must be sending to known destinations, no arbitrary passtrhough
  * Inbound passthrough CAN be sent directly... but if the dest has a waypoint, we hairpin it. This is to support non-mesh clients
  * Inbound HBONE must send to the waypoint first, if there is one. We could hairpin this in the future, if we want, but for now we are stricter.