### PR TITLE
build: bump tls-listener from 0.5.1 to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,9 +2029,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tls-listener"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d4ff21187d434ac7709bfc7441ca88f63681247e5ad99f0f08c8c91ddc103d"
+checksum = "97abcaa5d5850d3b469898d1e0939b57c3afb4475122e792cdd1c82b07f5de06"
 dependencies = [
  "futures-util",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_yaml = "0.9.13"
 socket2 = "0.4.7"
 byteorder = "1.3.4"
 thiserror = "1.0.38"
-tls-listener = { version  = "0.5.1", features = ["hyper-h2"] }
+tls-listener = { version  = "0.6.0", features = ["hyper-h2"] }
 tokio = {"version"= "1", features=["full"]}
 tokio-boring = { version = "2.1.5" }
 tokio-stream = "0.1.9"


### PR DESCRIPTION
The main change is to increase handshake timeout from 200ms to 10s, which may be good for real network world:
https://github.com/tmccombs/tls-listener/commit/b9e666d12d1185e34dc5b72d27040b65603a8956

https://github.com/tmccombs/tls-listener/releases/tag/v0.6.0 [Changed]
  Increased default handshake timeout to 10 seconds (technically a breaking change)