### PR TITLE
config: correct admin and status ports

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -285,7 +285,7 @@ async fn handle_metrics(reg: Arc<Mutex<Registry>>, _req: Request<Body>) -> Respo
 
 //mirror envoy's behavior: https://www.envoyproxy.io/docs/envoy/latest/operations/admin#post--logging
 //NOTE: multiple query parameters is not supported, for example
-//curl -X POST http://127.0.0.1:15021/logging?"tap=debug&router=debug"
+//curl -X POST http://127.0.0.1:15000/logging?"tap=debug&router=debug"
 static HELP_STRING: &str = "
 usage: POST /logging\t\t\t\t\t\t(To list current level)
 usage: POST /logging?level=<level>\t\t\t\t(To change global levels)

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,8 +37,8 @@ const ZTUNNEL_WORKER_THREADS: &str = "ZTUNNEL_WORKER_THREADS";
 const PROXY_CONFIG: &str = "PROXY_CONFIG";
 
 const DEFAULT_WORKER_THREADS: u16 = 2;
-const DEFAULT_ADMIN_PORT: u16 = 15021;
-const DEFAULT_STATUS_PORT: u16 = 15020;
+const DEFAULT_ADMIN_PORT: u16 = 15000;
+const DEFAULT_STATUS_PORT: u16 = 15021;
 const DEFAULT_DRAIN_DURATION: Duration = Duration::from_secs(5);
 
 #[derive(serde::Serialize, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Fixes the ports used for admin and status endpoints. 65225bb incorrectly updated the port numbers.