### PR TITLE
tests: use network namespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
  "findshlibs",
  "libc",
  "log",
- "nix 0.24.2",
+ "nix 0.24.3",
  "once_cell",
  "parking_lot",
  "protobuf",
@@ -1825,7 +1825,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix 0.24.2",
+ "nix 0.24.3",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
@@ -1159,6 +1159,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -1204,6 +1213,95 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5dee5ed749373c298237fe694eb0a51887f4cc1a27370c8464bac4382348f1a"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25af9cf0dc55498b7bd94a1508af7a78706aa0ab715a73c5169273e03c84845e"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "netns-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23541694f1d7d18cd1a0da3a1352a6ea48b01cbb4a8e7a6e547963823fd5276e"
+dependencies = [
+ "nix 0.23.2",
+ "thiserror",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
 
 [[package]]
 name = "nix"
@@ -1322,6 +1420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1525,7 @@ dependencies = [
  "findshlibs",
  "libc",
  "log",
- "nix",
+ "nix 0.24.2",
  "once_cell",
  "parking_lot",
  "protobuf",
@@ -1709,6 +1813,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f1cfa18f8cebe685373a2697915d7e0db3b4554918bba118385e0f71f258a7"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-route",
+ "netlink-proto",
+ "nix 0.24.2",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2575,6 +2694,7 @@ dependencies = [
  "libc",
  "log",
  "matches",
+ "netns-rs",
  "once_cell",
  "pprof",
  "prometheus-client",
@@ -2584,6 +2704,7 @@ dependencies = [
  "prost-types",
  "rand",
  "realm_io",
+ "rtnetlink",
  "rustc_version",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ prometheus-parse = "0.2.3"
 url = "2.2"
 itertools = "0.10.5"
 ipnet = { version = "2.7.0", features = ["serde"] }
+netns-rs = "0.1.0"
 
 [build-dependencies]
 tonic-build = { version = "0.8", default-features=false, features = ["prost"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,5 +87,7 @@ incremental = true
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 matches = "0.1.9"
+netns-rs = "0.1.0"
+rtnetlink = "0.11.0"
 test-case = "2.2.2"
 #debug = true

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -3,6 +3,10 @@ include common/Makefile.common.mk
 test:
 	cargo test --benches --tests --bins
 
+test-root: export CARGO_TARGET_$(shell rustc -vV | sed -n 's|host: ||p' | tr [:lower:] [:upper:]| tr - _)_RUNNER = sudo -E
+test-root:
+	cargo test --benches --tests --bins
+
 build:
 	cargo build
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -1,7 +1,7 @@
 include common/Makefile.common.mk
 
 test:
-	cargo test --benches --tests --bins
+	RUST_LOG=debug cargo test --benches --tests --bins
 
 test-root: export CARGO_TARGET_$(shell rustc -vV | sed -n 's|host: ||p' | tr [:lower:] [:upper:]| tr - _)_RUNNER = sudo -E
 test-root:

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -1,7 +1,7 @@
 include common/Makefile.common.mk
 
 test:
-	RUST_LOG=debug cargo test --benches --tests --bins
+	RUST_LOG=debug cargo test --benches --tests --bins  -- --test-threads=1 --nocapture
 
 test-root: export CARGO_TARGET_$(shell rustc -vV | sed -n 's|host: ||p' | tr [:lower:] [:upper:]| tr - _)_RUNNER = sudo -E
 test-root:

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -1,7 +1,7 @@
 include common/Makefile.common.mk
 
 test:
-	RUST_LOG=debug cargo test --benches --tests --bins  -- --test-threads=1 --nocapture
+	cargo test --benches --tests --bins
 
 test-root: export CARGO_TARGET_$(shell rustc -vV | sed -n 's|host: ||p' | tr [:lower:] [:upper:]| tr - _)_RUNNER = sudo -E
 test-root:

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -76,7 +76,7 @@ fn initialize_environment(mode: Mode) -> (Arc<Mutex<TestEnv>>, Runtime) {
             cert_manager,
         };
         ta.ready().await;
-        let echo = tcp::TestServer::new(mode).await;
+        let echo = tcp::TestServer::new(mode, 0).await;
         let echo_addr = helpers::with_ip(echo.address(), TEST_WORKLOAD_SOURCE.parse().unwrap());
         let t = tokio::spawn(async move {
             let _ = tokio::join!(app.wait_termination(), echo.run());

--- a/scripts/node-redirect.sh
+++ b/scripts/node-redirect.sh
@@ -2,16 +2,14 @@
 
 set -ex
 
-# TODO: use a loop instead of ipset maybe
-ipset create ztunnel-pods-ips hash:ip
-ipset add ztunnel-pods-ips 10.0.1.1
-ipset add ztunnel-pods-ips 10.0.2.1
-ipset add ztunnel-pods-ips 10.0.3.1
-
-
 HOST_IP="10.0.0.1"
-ZTUNNEL_INTERFACE=veth3
-ZTUNNEL_IP="10.0.3.1"
+
+ZTUNNEL_IP="${1:?ztunnel IP}"
+ZTUNNEL_INTERFACE="${2:?ztunnel interface}"
+ipset create ztunnel-pods-ips hash:ip
+for i in `seq 1 ${3:?ip count}`; do
+  ipset add ztunnel-pods-ips 10.0."${i}".1
+done
 
 # Setup interfaces
 ip link add name istioin type geneve id 1000 remote "${ZTUNNEL_IP}"
@@ -21,8 +19,6 @@ ip link set istioin up
 ip link add name istioout type geneve id 1001 remote "${ZTUNNEL_IP}"
 ip addr add 192.168.127.1/30 dev istioout
 ip link set istioout up
-
-
 
 iptables-legacy -t nat -N ztunnel-PREROUTING
 iptables-legacy -t nat -I PREROUTING -j ztunnel-PREROUTING
@@ -49,23 +45,16 @@ iptables-legacy -t mangle -A ztunnel-INPUT -m mark --mark 0x210/0x210 -j CONNMAR
 iptables-legacy -t mangle -A ztunnel-OUTPUT --source "${HOST_IP}" -j MARK --set-mark 0x220
 iptables-legacy -t nat -A ztunnel-PREROUTING -m mark --mark 0x100/0x100 -j ACCEPT
 iptables-legacy -t nat -A ztunnel-POSTROUTING -m mark --mark 0x100/0x100 -j ACCEPT
-iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt pre!"
 iptables-legacy -t mangle -A ztunnel-PREROUTING -p udp -m udp --dport 6081 -j RETURN
 iptables-legacy -t mangle -A ztunnel-PREROUTING -m connmark --mark 0x220/0x220 -j MARK --set-mark 0x200/0x200
-iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 1!"
 iptables-legacy -t mangle -A ztunnel-PREROUTING -m mark --mark 0x200/0x200 -j RETURN
 iptables-legacy -t mangle -A ztunnel-PREROUTING ! -i "${ZTUNNEL_INTERFACE}" -m connmark --mark 0x210/0x210 -j MARK --set-mark 0x040/0x040
-iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 2!"
 iptables-legacy -t mangle -A ztunnel-PREROUTING -m mark --mark 0x040/0x040 -j RETURN
 iptables-legacy -t mangle -A ztunnel-PREROUTING -i "${ZTUNNEL_INTERFACE}" ! --source "${ZTUNNEL_IP}" -j MARK --set-mark 0x210/0x210
-iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 3!"
 iptables-legacy -t mangle -A ztunnel-PREROUTING -m mark --mark 0x200/0x200 -j RETURN
-iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 3.5!"
 iptables-legacy -t mangle -A ztunnel-PREROUTING -i "${ZTUNNEL_INTERFACE}" -j MARK --set-mark 0x220/0x220
 iptables-legacy -t mangle -A ztunnel-PREROUTING -p udp -j MARK --set-mark 0x220/0x220
-iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 4!"
 iptables-legacy -t mangle -A ztunnel-PREROUTING -m mark --mark 0x200/0x200 -j RETURN
-iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "check set!"
 iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -m set --match-set ztunnel-pods-ips src -j MARK --set-mark 0x100/0x100
 ip route add table 101 "${ZTUNNEL_IP}" dev "${ZTUNNEL_INTERFACE}" scope link
 ip route add table 101 0.0.0.0/0 via 192.168.127.2 dev istioout
@@ -76,19 +65,3 @@ ip rule add priority 100 fwmark 0x200/0x200 goto 32766
 ip rule add priority 101 fwmark 0x100/0x100 lookup 101
 ip rule add priority 102 fwmark 0x040/0x040 lookup 102
 ip rule add priority 103 table 100
-
-# TODO: remove
-#iptables-legacy -t mangle -I PREROUTING -j LOG --log-prefix "mangle pre [$POD_NAME] "
-#iptables-legacy -t mangle -I POSTROUTING -j LOG --log-prefix "mangle post [$POD_NAME] "
-#iptables-legacy -t mangle -I INPUT -j LOG --log-prefix "mangle inp [$POD_NAME] "
-#iptables-legacy -t mangle -I OUTPUT -j LOG --log-prefix "mangle out [$POD_NAME] "
-#iptables-legacy -t mangle -I FORWARD -j LOG --log-prefix "mangle fw [$POD_NAME] "
-#iptables-legacy -t nat -I POSTROUTING -j LOG --log-prefix "nat post [$POD_NAME] "
-#iptables-legacy -t nat -I INPUT -j LOG --log-prefix "nat inp [$POD_NAME] "
-#iptables-legacy -t nat -I OUTPUT -j LOG --log-prefix "nat out [$POD_NAME] "
-#iptables-legacy -t nat -I PREROUTING -j LOG --log-prefix "nat pre [$POD_NAME] "
-#iptables-legacy -t raw -I PREROUTING -j LOG --log-prefix "raw pre [$POD_NAME] "
-#iptables-legacy -t raw -I OUTPUT -j LOG --log-prefix "raw out [$POD_NAME] "
-#iptables-legacy -t filter -I FORWARD -j LOG --log-prefix "filt fw [$POD_NAME] "
-#iptables-legacy -t filter -I OUTPUT -j LOG --log-prefix "filt out [$POD_NAME] "
-#iptables-legacy -t filter -I INPUT -j LOG --log-prefix "filt inp [$POD_NAME] "

--- a/scripts/node-redirect.sh
+++ b/scripts/node-redirect.sh
@@ -6,9 +6,10 @@ set -ex
 HOST_IP="10.0.0.1"
 ZTUNNEL_IP="${1:?ztunnel IP}"
 ZTUNNEL_INTERFACE="${2:?ztunnel interface}"
+shift; shift;
 ipset create ztunnel-pods-ips hash:ip
-for i in `seq 1 ${3:?ip count}`; do
-  ipset add ztunnel-pods-ips 10.0."${i}".1
+for ip in $@; do
+  ipset add ztunnel-pods-ips "${ip}"
 done
 
 # Setup interfaces
@@ -81,3 +82,19 @@ ip rule add priority 100 fwmark 0x200/0x200 goto 32766
 ip rule add priority 101 fwmark 0x100/0x100 lookup 101
 ip rule add priority 102 fwmark 0x040/0x040 lookup 102
 ip rule add priority 103 table 100
+
+#IPTABLES=iptables-legacy
+#$IPTABLES -t mangle -I PREROUTING -j LOG --log-prefix "mangle pre [node] "
+#$IPTABLES -t mangle -I POSTROUTING -j LOG --log-prefix "mangle post [node] "
+#$IPTABLES -t mangle -I INPUT -j LOG --log-prefix "mangle inp [node] "
+#$IPTABLES -t mangle -I OUTPUT -j LOG --log-prefix "mangle out [node] "
+#$IPTABLES -t mangle -I FORWARD -j LOG --log-prefix "mangle fw [node] "
+#$IPTABLES -t nat -I POSTROUTING -j LOG --log-prefix "nat post [node] "
+#$IPTABLES -t nat -I INPUT -j LOG --log-prefix "nat inp [node] "
+#$IPTABLES -t nat -I OUTPUT -j LOG --log-prefix "nat out [node] "
+#$IPTABLES -t nat -I PREROUTING -j LOG --log-prefix "nat pre [node] "
+#$IPTABLES -t raw -I PREROUTING -j LOG --log-prefix "raw pre [node] "
+#$IPTABLES -t raw -I OUTPUT -j LOG --log-prefix "raw out [node] "
+#$IPTABLES -t filter -I FORWARD -j LOG --log-prefix "filt fw [node] "
+#$IPTABLES -t filter -I OUTPUT -j LOG --log-prefix "filt out [node] "
+#$IPTABLES -t filter -I INPUT -j LOG --log-prefix "filt inp [node] "

--- a/scripts/node-redirect.sh
+++ b/scripts/node-redirect.sh
@@ -8,7 +8,7 @@ ZTUNNEL_IP="${1:?ztunnel IP}"
 ZTUNNEL_INTERFACE="${2:?ztunnel interface}"
 shift; shift;
 ipset create ztunnel-pods-ips hash:ip
-for ip in $@; do
+for ip in "$@"; do
   ipset add ztunnel-pods-ips "${ip}"
 done
 

--- a/scripts/node-redirect.sh
+++ b/scripts/node-redirect.sh
@@ -21,7 +21,7 @@ ip link add name istioout type geneve id 1001 remote "${ZTUNNEL_IP}"
 ip addr add 192.168.127.1/30 dev istioout
 ip link set istioout up
 
-cat <<EOF | iptables-restore
+cat <<EOF | iptables-restore -w
 *mangle
 :PREROUTING ACCEPT
 :INPUT ACCEPT

--- a/scripts/node-redirect.sh
+++ b/scripts/node-redirect.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -ex
+
+# TODO: use a loop instead of ipset maybe
+ipset create ztunnel-pods-ips hash:ip
+ipset add ztunnel-pods-ips 10.0.1.1
+ipset add ztunnel-pods-ips 10.0.2.1
+ipset add ztunnel-pods-ips 10.0.3.1
+
+
+HOST_IP="10.0.0.1"
+ZTUNNEL_INTERFACE=veth3
+ZTUNNEL_IP="10.0.3.1"
+
+# Setup interfaces
+ip link add name istioin type geneve id 1000 remote "${ZTUNNEL_IP}"
+ip addr add 192.168.126.1/30 dev istioin
+ip link set istioin up
+
+ip link add name istioout type geneve id 1001 remote "${ZTUNNEL_IP}"
+ip addr add 192.168.127.1/30 dev istioout
+ip link set istioout up
+
+
+
+iptables-legacy -t nat -N ztunnel-PREROUTING
+iptables-legacy -t nat -I PREROUTING -j ztunnel-PREROUTING
+iptables-legacy -t nat -N ztunnel-POSTROUTING
+iptables-legacy -t nat -I POSTROUTING -j ztunnel-POSTROUTING
+iptables-legacy -t mangle -N ztunnel-PREROUTING
+iptables-legacy -t mangle -I PREROUTING -j ztunnel-PREROUTING
+iptables-legacy -t mangle -N ztunnel-POSTROUTING
+iptables-legacy -t mangle -I POSTROUTING -j ztunnel-POSTROUTING
+iptables-legacy -t mangle -N ztunnel-OUTPUT
+iptables-legacy -t mangle -I OUTPUT -j ztunnel-OUTPUT
+iptables-legacy -t mangle -N ztunnel-INPUT
+iptables-legacy -t mangle -I INPUT -j ztunnel-INPUT
+iptables-legacy -t mangle -N ztunnel-FORWARD
+iptables-legacy -t mangle -I FORWARD -j ztunnel-FORWARD
+iptables-legacy -t mangle -A ztunnel-PREROUTING -i istioin -j MARK --set-mark 0x200/0x200
+iptables-legacy -t mangle -A ztunnel-PREROUTING -i istioin -j RETURN
+iptables-legacy -t mangle -A ztunnel-PREROUTING -i istioout -j MARK --set-mark 0x200/0x200
+iptables-legacy -t mangle -A ztunnel-PREROUTING -i istioout -j RETURN
+iptables-legacy -t mangle -A ztunnel-FORWARD -m mark --mark 0x220/0x220 -j CONNMARK --save-mark --nfmask 0x220 --ctmask 0x220
+iptables-legacy -t mangle -A ztunnel-INPUT -m mark --mark 0x220/0x220 -j CONNMARK --save-mark --nfmask 0x220 --ctmask 0x220
+iptables-legacy -t mangle -A ztunnel-FORWARD -m mark --mark 0x210/0x210 -j CONNMARK --save-mark --nfmask 0x210 --ctmask 0x210
+iptables-legacy -t mangle -A ztunnel-INPUT -m mark --mark 0x210/0x210 -j CONNMARK --save-mark --nfmask 0x210 --ctmask 0x210
+iptables-legacy -t mangle -A ztunnel-OUTPUT --source "${HOST_IP}" -j MARK --set-mark 0x220
+iptables-legacy -t nat -A ztunnel-PREROUTING -m mark --mark 0x100/0x100 -j ACCEPT
+iptables-legacy -t nat -A ztunnel-POSTROUTING -m mark --mark 0x100/0x100 -j ACCEPT
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt pre!"
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p udp -m udp --dport 6081 -j RETURN
+iptables-legacy -t mangle -A ztunnel-PREROUTING -m connmark --mark 0x220/0x220 -j MARK --set-mark 0x200/0x200
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 1!"
+iptables-legacy -t mangle -A ztunnel-PREROUTING -m mark --mark 0x200/0x200 -j RETURN
+iptables-legacy -t mangle -A ztunnel-PREROUTING ! -i "${ZTUNNEL_INTERFACE}" -m connmark --mark 0x210/0x210 -j MARK --set-mark 0x040/0x040
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 2!"
+iptables-legacy -t mangle -A ztunnel-PREROUTING -m mark --mark 0x040/0x040 -j RETURN
+iptables-legacy -t mangle -A ztunnel-PREROUTING -i "${ZTUNNEL_INTERFACE}" ! --source "${ZTUNNEL_IP}" -j MARK --set-mark 0x210/0x210
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 3!"
+iptables-legacy -t mangle -A ztunnel-PREROUTING -m mark --mark 0x200/0x200 -j RETURN
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 3.5!"
+iptables-legacy -t mangle -A ztunnel-PREROUTING -i "${ZTUNNEL_INTERFACE}" -j MARK --set-mark 0x220/0x220
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p udp -j MARK --set-mark 0x220/0x220
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "zt mark 4!"
+iptables-legacy -t mangle -A ztunnel-PREROUTING -m mark --mark 0x200/0x200 -j RETURN
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -j LOG --log-prefix "check set!"
+iptables-legacy -t mangle -A ztunnel-PREROUTING -p tcp -m set --match-set ztunnel-pods-ips src -j MARK --set-mark 0x100/0x100
+ip route add table 101 "${ZTUNNEL_IP}" dev "${ZTUNNEL_INTERFACE}" scope link
+ip route add table 101 0.0.0.0/0 via 192.168.127.2 dev istioout
+ip route add table 102 "${ZTUNNEL_IP}" dev "${ZTUNNEL_INTERFACE}" scope link
+ip route add table 102 0.0.0.0/0 via "${ZTUNNEL_IP}" dev "${ZTUNNEL_INTERFACE}" onlink
+ip route add table 100 "${ZTUNNEL_IP}" dev "${ZTUNNEL_INTERFACE}" scope link
+ip rule add priority 100 fwmark 0x200/0x200 goto 32766
+ip rule add priority 101 fwmark 0x100/0x100 lookup 101
+ip rule add priority 102 fwmark 0x040/0x040 lookup 102
+ip rule add priority 103 table 100
+
+# TODO: remove
+#iptables-legacy -t mangle -I PREROUTING -j LOG --log-prefix "mangle pre [$POD_NAME] "
+#iptables-legacy -t mangle -I POSTROUTING -j LOG --log-prefix "mangle post [$POD_NAME] "
+#iptables-legacy -t mangle -I INPUT -j LOG --log-prefix "mangle inp [$POD_NAME] "
+#iptables-legacy -t mangle -I OUTPUT -j LOG --log-prefix "mangle out [$POD_NAME] "
+#iptables-legacy -t mangle -I FORWARD -j LOG --log-prefix "mangle fw [$POD_NAME] "
+#iptables-legacy -t nat -I POSTROUTING -j LOG --log-prefix "nat post [$POD_NAME] "
+#iptables-legacy -t nat -I INPUT -j LOG --log-prefix "nat inp [$POD_NAME] "
+#iptables-legacy -t nat -I OUTPUT -j LOG --log-prefix "nat out [$POD_NAME] "
+#iptables-legacy -t nat -I PREROUTING -j LOG --log-prefix "nat pre [$POD_NAME] "
+#iptables-legacy -t raw -I PREROUTING -j LOG --log-prefix "raw pre [$POD_NAME] "
+#iptables-legacy -t raw -I OUTPUT -j LOG --log-prefix "raw out [$POD_NAME] "
+#iptables-legacy -t filter -I FORWARD -j LOG --log-prefix "filt fw [$POD_NAME] "
+#iptables-legacy -t filter -I OUTPUT -j LOG --log-prefix "filt out [$POD_NAME] "
+#iptables-legacy -t filter -I INPUT -j LOG --log-prefix "filt inp [$POD_NAME] "

--- a/scripts/node-redirect.sh
+++ b/scripts/node-redirect.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+# This script sets up redirection in the host network namespace for namespaced tests (tests/README.md)
 set -ex
+
 HOST_IP="10.0.0.1"
 ZTUNNEL_IP="${1:?ztunnel IP}"
 ZTUNNEL_INTERFACE="${2:?ztunnel interface}"

--- a/scripts/ztunnel-redirect.sh
+++ b/scripts/ztunnel-redirect.sh
@@ -125,3 +125,18 @@ $IPTABLES -t nat -A OUTPUT -p tcp --dport 15008 -m set '!' --match-set waypoint-
 echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
 echo 0 > /proc/sys/net/ipv4/conf/default/rp_filter
 echo 0 > /proc/sys/net/ipv4/conf/eth0/rp_filter
+
+#$IPTABLES -t mangle -I PREROUTING -j LOG --log-prefix "mangle pre [zt] "
+#$IPTABLES -t mangle -I POSTROUTING -j LOG --log-prefix "mangle post [zt] "
+#$IPTABLES -t mangle -I INPUT -j LOG --log-prefix "mangle inp [zt] "
+#$IPTABLES -t mangle -I OUTPUT -j LOG --log-prefix "mangle out [zt] "
+#$IPTABLES -t mangle -I FORWARD -j LOG --log-prefix "mangle fw [zt] "
+#$IPTABLES -t nat -I POSTROUTING -j LOG --log-prefix "nat post [zt] "
+#$IPTABLES -t nat -I INPUT -j LOG --log-prefix "nat inp [zt] "
+#$IPTABLES -t nat -I OUTPUT -j LOG --log-prefix "nat out [zt] "
+#$IPTABLES -t nat -I PREROUTING -j LOG --log-prefix "nat pre [zt] "
+#$IPTABLES -t raw -I PREROUTING -j LOG --log-prefix "raw pre [zt] "
+#$IPTABLES -t raw -I OUTPUT -j LOG --log-prefix "raw out [zt] "
+#$IPTABLES -t filter -I FORWARD -j LOG --log-prefix "filt fw [zt] "
+#$IPTABLES -t filter -I OUTPUT -j LOG --log-prefix "filt out [zt] "
+#$IPTABLES -t filter -I INPUT -j LOG --log-prefix "filt inp [zt] "

--- a/scripts/ztunnel-redirect.sh
+++ b/scripts/ztunnel-redirect.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -ex
+
+INSTANCE_IP="${1:?INSTANCE_IP}"
+
+# START https://github.com/solo-io/istio-sidecarless/blob/master/redirect-worker.sh#L198-L205
+PROXY_OUTBOUND_MARK=0x401/0xfff
+PROXY_INBOUND_MARK=0x402/0xfff
+PROXY_ORG_SRC_MARK=0x4d2/0xfff
+# tproxy mark, it's only used here.
+MARK=0x400/0xfff
+ORG_SRC_RET_MARK=0x4d3/0xfff
+# END https://github.com/solo-io/istio-sidecarless/blob/master/redirect-worker.sh#L198-L205
+
+# Below is from config.sh but used in redirect-worker.sh as well
+POD_OUTBOUND=15001
+POD_INBOUND=15008
+POD_INBOUND_PLAINTEXT=15006
+
+# socket mark setup
+OUTBOUND_MASK="0x100"
+OUTBOUND_MARK="0x100/$OUTBOUND_MASK"
+
+SKIP_MASK="0x200"
+SKIP_MARK="0x200/$SKIP_MASK"
+
+# note!! this includes the skip mark bit, so match on skip mark will match this as well.
+CONNSKIP_MASK="0x220"
+CONNSKIP_MARK="0x220/$CONNSKIP_MASK"
+
+# note!! this includes the skip mark bit, so match on skip mark will match this as well.
+PROXY_MASK="0x210"
+PROXY_MARK="0x210/$PROXY_MASK"
+
+PROXY_RET_MASK="0x040"
+PROXY_RET_MARK="0x040/$PROXY_RET_MASK"
+
+INBOUND_TUN=istioin
+OUTBOUND_TUN=istioout
+
+# TODO: look into why link local (169.254.x.x) address didn't work
+# they don't respond to ARP.
+INBOUND_TUN_IP=192.168.126.1
+ZTUNNEL_INBOUND_TUN_IP=192.168.126.2
+OUTBOUND_TUN_IP=192.168.127.1
+ZTUNNEL_OUTBOUND_TUN_IP=192.168.127.2
+TUN_PREFIX=30
+
+# a route table number number we can use to send traffic to envoy (should be unused).
+INBOUND_ROUTE_TABLE=100
+INBOUND_ROUTE_TABLE2=103
+OUTBOUND_ROUTE_TABLE=101
+# needed for original src.
+PROXY_ROUTE_TABLE=102
+
+# START https://github.com/solo-io/istio-sidecarless/blob/master/redirect-worker.sh#L185-L196
+set +e # Only for delete, we don't care if this fails
+ip link del p$INBOUND_TUN
+ip link del p$OUTBOUND_TUN
+set -e
+HOST_IP=$(ip route | grep default | awk '{print $3}')
+
+ip link add name p$INBOUND_TUN type geneve id 1000 remote $HOST_IP
+ip addr add $ZTUNNEL_INBOUND_TUN_IP/$TUN_PREFIX dev p$INBOUND_TUN
+
+ip link add name p$OUTBOUND_TUN type geneve id 1001 remote $HOST_IP
+ip addr add $ZTUNNEL_OUTBOUND_TUN_IP/$TUN_PREFIX dev p$OUTBOUND_TUN
+
+ip link set p$INBOUND_TUN up
+ip link set p$OUTBOUND_TUN up
+
+echo 0 > /proc/sys/net/ipv4/conf/p$INBOUND_TUN/rp_filter
+echo 0 > /proc/sys/net/ipv4/conf/p$OUTBOUND_TUN/rp_filter
+# END https://github.com/solo-io/istio-sidecarless/blob/master/redirect-worker.sh#L185-L196
+
+# START https://github.com/solo-io/istio-sidecarless/blob/master/redirect-worker.sh#L206-L238
+set +e # Only for delete, we don't care if this fails
+ip rule del priority 20000
+ip rule del priority 20001
+ip rule del priority 20002
+ip rule del priority 20003
+
+ip route flush table 100
+ip route flush table 101
+ip route flush table 102
+set -e
+
+ip rule add priority 20000 fwmark $MARK lookup 100
+ip rule add priority 20001 fwmark $PROXY_OUTBOUND_MARK lookup 101
+ip rule add priority 20002 fwmark $PROXY_INBOUND_MARK lookup 102
+ip rule add priority 20003 fwmark $ORG_SRC_RET_MARK lookup 100
+ip route add local 0.0.0.0/0 dev lo table 100
+
+ip route add table 101 $HOST_IP dev eth0 scope link
+ip route add table 101 0.0.0.0/0 via $OUTBOUND_TUN_IP dev p$OUTBOUND_TUN
+
+ip route add table 102 $HOST_IP dev eth0 scope link
+ip route add table 102 0.0.0.0/0 via $INBOUND_TUN_IP dev p$INBOUND_TUN
+
+set +e
+num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "${num_legacy_lines}" -ge 10 ]; then
+  mode=legacy
+else
+  num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l)
+  if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+    mode=legacy
+  else
+    mode=nft
+  fi
+fi
+IPTABLES=iptables-legacy
+if [ "${mode}" = "nft" ]; then
+  IPTABLES=iptables-nft
+fi
+set -e
+
+$IPTABLES -t mangle -F PREROUTING
+$IPTABLES -t nat -F OUTPUT
+
+$IPTABLES-save | grep -v LOG | $IPTABLES-restore
+$IPTABLES -t mangle -I PREROUTING -j LOG --log-prefix "mangle pre zt "
+$IPTABLES -t mangle -I POSTROUTING -j LOG --log-prefix "mangle post zt "
+$IPTABLES -t mangle -I INPUT -j LOG --log-prefix "mangle inp zt "
+$IPTABLES -t mangle -I OUTPUT -j LOG --log-prefix "mangle out zt "
+$IPTABLES -t mangle -I FORWARD -j LOG --log-prefix "mangle fw zt "
+$IPTABLES -t nat -I POSTROUTING -j LOG --log-prefix "nat post zt "
+$IPTABLES -t nat -I INPUT -j LOG --log-prefix "nat inp zt "
+$IPTABLES -t nat -I OUTPUT -j LOG --log-prefix "nat out zt "
+$IPTABLES -t nat -I PREROUTING -j LOG --log-prefix "nat pre zt "
+$IPTABLES -t raw -I PREROUTING -j LOG --log-prefix "raw pre zt "
+$IPTABLES -t raw -I OUTPUT -j LOG --log-prefix "raw out zt "
+$IPTABLES -t filter -I FORWARD -j LOG --log-prefix "filt fw zt "
+$IPTABLES -t filter -I OUTPUT -j LOG --log-prefix "filt out zt "
+$IPTABLES -t filter -I INPUT -j LOG --log-prefix "filt inp zt "
+
+$IPTABLES -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -m tcp --dport=$POD_INBOUND -j TPROXY --tproxy-mark $MARK --on-port $POD_INBOUND --on-ip 127.0.0.1
+$IPTABLES -t mangle -A PREROUTING -p tcp -i p$OUTBOUND_TUN -j TPROXY --tproxy-mark $MARK --on-port $POD_OUTBOUND --on-ip 127.0.0.1
+$IPTABLES -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -j TPROXY --tproxy-mark $MARK --on-port $POD_INBOUND_PLAINTEXT --on-ip 127.0.0.1
+
+$IPTABLES -t mangle -A PREROUTING -p tcp -i eth0 ! --dst $INSTANCE_IP -j MARK --set-mark $ORG_SRC_RET_MARK
+# END https://github.com/solo-io/istio-sidecarless/blob/master/redirect-worker.sh#L206-L238
+# With normal linux routing we need to disable the rp_filter
+# as we get packets from a tunnel that doesn't have default routes.
+echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
+echo 0 > /proc/sys/net/ipv4/conf/default/rp_filter
+echo 0 > /proc/sys/net/ipv4/conf/eth0/rp_filter

--- a/scripts/ztunnel-redirect.sh
+++ b/scripts/ztunnel-redirect.sh
@@ -101,14 +101,14 @@ if [ "${mode}" = "nft" ]; then
 fi
 set -e
 
-$IPTABLES -t mangle -F PREROUTING
-$IPTABLES -t nat -F OUTPUT
+$IPTABLES -w -t mangle -F PREROUTING
+$IPTABLES -w -t nat -F OUTPUT
 
-$IPTABLES -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -m tcp --dport=$POD_INBOUND -j TPROXY --tproxy-mark $MARK --on-port $POD_INBOUND --on-ip 127.0.0.1
-$IPTABLES -t mangle -A PREROUTING -p tcp -i p$OUTBOUND_TUN -j TPROXY --tproxy-mark $MARK --on-port $POD_OUTBOUND --on-ip 127.0.0.1
-$IPTABLES -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -j TPROXY --tproxy-mark $MARK --on-port $POD_INBOUND_PLAINTEXT --on-ip 127.0.0.1
+$IPTABLES -w -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -m tcp --dport=$POD_INBOUND -j TPROXY --tproxy-mark $MARK --on-port $POD_INBOUND --on-ip 127.0.0.1
+$IPTABLES -w -t mangle -A PREROUTING -p tcp -i p$OUTBOUND_TUN -j TPROXY --tproxy-mark $MARK --on-port $POD_OUTBOUND --on-ip 127.0.0.1
+$IPTABLES -w -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -j TPROXY --tproxy-mark $MARK --on-port $POD_INBOUND_PLAINTEXT --on-ip 127.0.0.1
 
-$IPTABLES -t mangle -A PREROUTING -p tcp -i eth0 ! --dst $INSTANCE_IP -j MARK --set-mark $ORG_SRC_RET_MARK
+$IPTABLES -w -t mangle -A PREROUTING -p tcp -i eth0 ! --dst $INSTANCE_IP -j MARK --set-mark $ORG_SRC_RET_MARK
 
 # Huge hack. Currently, we only support single "node" test setup. This means we cannot test
 # Cross-ztunnel requests. Instead, loop these back to ourselves.
@@ -118,7 +118,7 @@ ipset create waypoint-pods-ips hash:ip
 for waypoint in $@; do
   ipset add waypoint-pods-ips "${waypoint}"
 done
-$IPTABLES -t nat -A OUTPUT -p tcp --dport 15008 -m set '!' --match-set waypoint-pods-ips dst -j REDIRECT --to-port $POD_INBOUND
+$IPTABLES -w -t nat -A OUTPUT -p tcp --dport 15008 -m set '!' --match-set waypoint-pods-ips dst -j REDIRECT --to-port $POD_INBOUND
 
 # With normal linux routing we need to disable the rp_filter
 # as we get packets from a tunnel that doesn't have default routes.

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -216,7 +216,6 @@ impl Inbound {
         enable_original_source: bool,
         req: Request<Body>,
     ) -> Result<Response<Body>, hyper::Error> {
-        warn!("serve");
         match req.method() {
             &Method::CONNECT => {
                 let uri = req.uri();

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -82,6 +82,7 @@ impl Inbound {
                 dst,
             };
             let workloads = self.workloads.clone();
+            debug!(%conn, "accepted connection");
             let enable_original_source = self.cfg.enable_original_source;
             async move {
                 Ok::<_, hyper::Error>(service_fn(move |req| {
@@ -215,6 +216,7 @@ impl Inbound {
         enable_original_source: bool,
         req: Request<Body>,
     ) -> Result<Response<Body>, hyper::Error> {
+        warn!("serve");
         match req.method() {
             &Method::CONNECT => {
                 let uri = req.uri();

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -81,6 +81,7 @@ impl InboundPassthrough {
         mut inbound: TcpStream,
     ) -> Result<(), Error> {
         let orig = socket::orig_dst_addr_or_default(&inbound);
+        info!(%source, destination=%orig, component="inbound plaintext", "accepted connection");
         let Some(upstream) = pi.workloads.fetch_workload(&orig.ip()).await else {
             return Err(Error::UnknownDestination(orig.ip()))
         };
@@ -110,7 +111,6 @@ impl InboundPassthrough {
             info!(%conn, "RBAC rejected");
             return Ok(());
         }
-        info!(%source, destination=%orig, component="inbound plaintext", "accepted connection");
         let orig_src = if pi.cfg.enable_original_source {
             super::get_original_src_from_stream(&inbound)
         } else {

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -20,7 +20,7 @@ use boring::ssl::ConnectConfiguration;
 use drain::Watch;
 use hyper::StatusCode;
 use tokio::net::{TcpListener, TcpStream};
-use tracing::{debug, error, info, info_span, trace_span, warn, Instrument, trace};
+use tracing::{debug, error, info, info_span, trace, trace_span, warn, Instrument};
 
 use crate::metrics::traffic::Reporter;
 use crate::metrics::{traffic, Recorder};
@@ -338,7 +338,12 @@ impl OutboundConnection {
             && self.pi.cfg.local_node == Some(us.workload.node.clone())
             && us.workload.protocol == Protocol::HBONE
         {
-            trace!(workload_node=us.workload.node, local_node=self.pi.cfg.local_node, "select {:?}", RequestType::DirectLocal);
+            trace!(
+                workload_node = us.workload.node,
+                local_node = self.pi.cfg.local_node,
+                "select {:?}",
+                RequestType::DirectLocal
+            );
             return Ok(Request {
                 protocol: Protocol::HBONE,
                 source: source_workload,

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -20,7 +20,7 @@ use boring::ssl::ConnectConfiguration;
 use drain::Watch;
 use hyper::StatusCode;
 use tokio::net::{TcpListener, TcpStream};
-use tracing::{debug, error, info, info_span, trace_span, warn, Instrument};
+use tracing::{debug, error, info, info_span, trace_span, warn, Instrument, trace};
 
 use crate::metrics::traffic::Reporter;
 use crate::metrics::{traffic, Recorder};
@@ -338,6 +338,7 @@ impl OutboundConnection {
             && self.pi.cfg.local_node == Some(us.workload.node.clone())
             && us.workload.protocol == Protocol::HBONE
         {
+            trace!(workload_node=us.workload.node, local_node=self.pi.cfg.local_node, "select {:?}", RequestType::DirectLocal);
             return Ok(Request {
                 protocol: Protocol::HBONE,
                 source: source_workload,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -25,6 +25,7 @@ use std::default::Default;
 pub mod app;
 pub mod ca;
 pub mod helpers;
+pub mod netns;
 pub mod tcp;
 
 pub fn test_config_with_waypoint(addr: IpAddr) -> config::Config {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -27,6 +27,14 @@ pub mod ca;
 pub mod helpers;
 pub mod tcp;
 
+pub fn test_config_with_waypoint(addr: IpAddr) -> config::Config {
+    config::Config {
+        local_xds_config: Some(ConfigSource::Static(
+            local_xds_config(80, Some(addr)).unwrap(),
+        )),
+        ..test_config()
+    }
+}
 pub fn test_config_with_port(port: u16) -> config::Config {
     config::Config {
         xds_address: None,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -24,6 +24,7 @@ use std::default::Default;
 
 pub mod app;
 pub mod ca;
+pub mod components;
 pub mod helpers;
 pub mod netns;
 pub mod tcp;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -27,14 +27,6 @@ pub mod ca;
 pub mod helpers;
 pub mod tcp;
 
-pub fn test_config_with_waypoint(addr: IpAddr) -> config::Config {
-    config::Config {
-        local_xds_config: Some(ConfigSource::Static(
-            local_xds_config(80, Some(addr)).unwrap(),
-        )),
-        ..test_config()
-    }
-}
 pub fn test_config_with_port(port: u16) -> config::Config {
     config::Config {
         xds_address: None,

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -45,7 +45,6 @@ where
     Fut: Future<Output = FO>,
 {
     initialize_telemetry();
-    telemetry::set_level(false, "ztunnel=trace");
     let cert_manager = MockCaClient::new(Duration::from_secs(10));
     let app = app::build_with_cert(cfg, cert_manager.clone())
         .await

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -86,7 +86,7 @@ impl TestApp {
             .method(Method::GET)
             .uri(format!(
                 "http://localhost:{}/healthz/ready",
-                self.readiness_address
+                self.readiness_address.port()
             ))
             .body(Body::default())
             .unwrap();

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -23,12 +23,10 @@ use hyper::{body, Body, Client, Method, Request, Response};
 use prometheus_parse::Scrape;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpSocket, TcpStream};
-use tracing::info;
 
 use crate::identity::mock::MockCaClient;
 use crate::identity::SecretManager;
-use crate::config::Config;
-use crate::test_helpers::{netns, TEST_WORKLOAD_SOURCE};
+use crate::test_helpers::TEST_WORKLOAD_SOURCE;
 use crate::*;
 
 use super::helpers::*;
@@ -185,42 +183,6 @@ impl TestApp {
         stream.read_exact(&mut resp).await.unwrap();
 
         stream
-    }
-}
-
-pub struct Ztunnel {
-    cfg: Config,
-}
-
-impl Ztunnel {
-    pub fn new() -> Self {
-        Self {
-            cfg: Config {
-                xds_address: None,
-                fake_ca: true,
-                local_xds_config: None,
-                local_node: Some("local".to_string()),
-                ..config::parse_config().unwrap()
-            },
-        }
-    }
-
-    pub async fn run_in_namespace(self, ready: netns::Ready) -> anyhow::Result<()> {
-        info!("Running ztunnel");
-        let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(10));
-        let app = app::build_with_cert(self.cfg, cert_manager).await.unwrap();
-
-        let ta = TestApp {
-            admin_address: app.admin_address,
-            proxy_addresses: app.proxy_addresses,
-            readiness_address: app.readiness_address,
-        };
-        info!("initialized");
-        ta.ready().await;
-        info!("ready");
-        ready.set_ready();
-
-        app.wait_termination().await
     }
 }
 

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -45,6 +45,7 @@ where
     Fut: Future<Output = FO>,
 {
     initialize_telemetry();
+    telemetry::set_level(false, "ztunnel=trace");
     let cert_manager = MockCaClient::new(Duration::from_secs(10));
     let app = app::build_with_cert(cfg, cert_manager.clone())
         .await

--- a/src/test_helpers/components.rs
+++ b/src/test_helpers/components.rs
@@ -1,0 +1,147 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+use std::net::IpAddr;
+use std::time::Duration;
+
+use bytes::BufMut;
+use tracing::info;
+
+use crate::config::ConfigSource;
+use crate::test_helpers::app::TestApp;
+use crate::test_helpers::netns::{Namespace, Resolver};
+use crate::test_helpers::*;
+use crate::workload::{LocalConfig, LocalWorkload, Workload};
+use crate::{config, identity};
+
+pub struct TestWorkloadBuilder<'a> {
+    w: LocalWorkload,
+    manager: &'a mut WorkloadManager,
+}
+
+impl<'a> TestWorkloadBuilder<'a> {
+    pub fn new(name: &str, manager: &'a mut WorkloadManager) -> TestWorkloadBuilder<'a> {
+        TestWorkloadBuilder {
+            w: LocalWorkload {
+                workload: Workload {
+                    name: name.to_string(),
+                    namespace: "default".to_string(),
+                    service_account: "default".to_string(),
+                    node: "not-local".to_string(),
+                    ..test_default_workload()
+                },
+                vips: Default::default(),
+            },
+            manager,
+        }
+    }
+
+    pub fn hbone(mut self) -> Self {
+        self.w.workload.protocol = HBONE;
+        self
+    }
+
+    pub fn vip(mut self, ip: &str, server_port: u16, target_port: u16) -> Self {
+        self.w.vips.entry(ip.to_string()).or_default().insert(server_port, target_port);
+        self
+    }
+
+    pub fn on_local_node(mut self) -> Self {
+        self.w.workload.node = "local".to_string();
+        self
+    }
+
+    pub fn register(mut self) -> anyhow::Result<Namespace> {
+        let network_namespace = self.manager.namespaces.child(&self.w.workload.name)?;
+        self.w.workload.workload_ip = network_namespace.ip();
+        self.manager.workloads.push(self.w);
+        Ok(network_namespace)
+    }
+}
+
+pub struct WorkloadManager {
+    namespaces: netns::NamespaceManager,
+    name: String,
+    /// workloads that we have constructed
+    workloads: Vec<LocalWorkload>,
+}
+
+impl WorkloadManager {
+    pub fn new(name: &str) -> anyhow::Result<Self> {
+        Ok(Self {
+            namespaces: netns::NamespaceManager::new(name)?,
+            name: name.to_string(),
+            workloads: vec![],
+        })
+    }
+
+    pub fn deploy_ztunnel(&mut self) -> anyhow::Result<()> {
+        let ns = TestWorkloadBuilder::new("ztunnel", self).register()?;
+        let ip = ns.ip();
+        let veth = ns.interface();
+        let count = self.namespaces.count();
+        let lc = LocalConfig {
+            workloads: self.workloads.clone(),
+            policies: vec![],
+        };
+        let mut b = bytes::BytesMut::new().writer();
+        serde_yaml::to_writer(&mut b, &lc)?;
+
+        let cfg = crate::config::Config {
+            xds_address: None,
+            fake_ca: true,
+            local_xds_config: Some(ConfigSource::Static(b.into_inner().freeze())),
+            local_node: Some("local".to_string()),
+            ..config::parse_config().unwrap()
+        };
+        // Setup the ztunnel...
+        ns.run_ready(move |ready| async move {
+            helpers::run_command(&format!("scripts/ztunnel-redirect.sh {ip}"))?;
+            let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(10));
+            let app = crate::app::build_with_cert(cfg, cert_manager.clone())
+                .await
+                .unwrap();
+
+            let ta = TestApp {
+                admin_address: app.admin_address,
+                proxy_addresses: app.proxy_addresses,
+                readiness_address: app.readiness_address,
+                cert_manager,
+            };
+            ta.ready().await;
+            info!("ready");
+            ready.set_ready();
+
+            app.wait_termination().await
+        })?;
+        // Setup the node...
+        self.namespaces.run_in_root_namespace(|| {
+            helpers::run_command(&format!("scripts/node-redirect.sh {ip} {veth} {count}"))
+        })?;
+        Ok(())
+    }
+
+    pub fn workload_builder(&mut self, name: &str) -> TestWorkloadBuilder {
+        TestWorkloadBuilder::new(name, self)
+    }
+
+    pub fn resolver(&self) -> Resolver {
+        self.namespaces.resolver()
+    }
+    pub fn resolve(&self, name: &str) -> Option<IpAddr> {
+        self.namespaces.resolve(name)
+    }
+}
+// TODO: all threads must terminate... somehow.

--- a/src/test_helpers/components.rs
+++ b/src/test_helpers/components.rs
@@ -26,74 +26,10 @@ use crate::test_helpers::*;
 use crate::workload::{LocalConfig, LocalWorkload, Workload};
 use crate::{config, identity, proxy};
 
-pub struct TestWorkloadBuilder<'a> {
-    w: LocalWorkload,
-    captured: bool,
-    manager: &'a mut WorkloadManager,
-}
-
-impl<'a> TestWorkloadBuilder<'a> {
-    pub fn new(name: &str, manager: &'a mut WorkloadManager) -> TestWorkloadBuilder<'a> {
-        TestWorkloadBuilder {
-            captured: true, // workload has redirection enabled
-            w: LocalWorkload {
-                workload: Workload {
-                    name: name.to_string(),
-                    namespace: "default".to_string(),
-                    service_account: "default".to_string(),
-                    node: "not-local".to_string(),
-                    ..test_default_workload()
-                },
-                vips: Default::default(),
-            },
-            manager,
-        }
-    }
-
-    pub fn hbone(mut self) -> Self {
-        self.w.workload.protocol = HBONE;
-        self
-    }
-
-    pub fn waypoint(mut self, waypoint: IpAddr) -> Self {
-        self.w.workload.waypoint_addresses.push(waypoint);
-        self
-    }
-
-    pub fn vip(mut self, ip: &str, server_port: u16, target_port: u16) -> Self {
-        self.w
-            .vips
-            .entry(ip.to_string())
-            .or_default()
-            .insert(server_port, target_port);
-        self
-    }
-
-    pub fn on_local_node(mut self) -> Self {
-        self.w.workload.node = "local".to_string();
-        self
-    }
-
-    pub fn uncaptured(mut self) -> Self {
-        self.captured = false;
-        self
-    }
-
-    pub fn register(mut self) -> anyhow::Result<Namespace> {
-        let network_namespace = self.manager.namespaces.child(&self.w.workload.name)?;
-        self.w.workload.workload_ip = network_namespace.ip();
-        info!(
-            "registered {}/{} at {}",
-            self.w.workload.namespace, self.w.workload.name, self.w.workload.workload_ip
-        );
-        self.manager.workloads.push(self.w);
-        if self.captured {
-            self.manager.captured_workloads.push(network_namespace.ip());
-        }
-        Ok(network_namespace)
-    }
-}
-
+/// WorkloadManager provides an interface to deploy "workloads" as part of a test. Each workload
+/// runs in its own isolated network namespace, simulating a real environment. Redirection in the "host network"
+/// namespace is configured, which can redirect traffic to a ztunnel.
+/// Note: at this time, only a single "node" (and therefor, ztunnel), is supported.
 pub struct WorkloadManager {
     namespaces: netns::NamespaceManager,
     /// workloads that we have constructed
@@ -103,6 +39,7 @@ pub struct WorkloadManager {
 }
 
 impl WorkloadManager {
+    /// new instantiates a manager with the given name. Using a unique name between tests is critical.
     pub fn new(name: &str) -> anyhow::Result<Self> {
         Ok(Self {
             namespaces: netns::NamespaceManager::new(name)?,
@@ -112,6 +49,10 @@ impl WorkloadManager {
         })
     }
 
+    /// deploy_ztunnel runs a ztunnel instance and configures redirection on the "node".
+    ///
+    /// Warning: currently, workloads are not dynamically update; they are snapshotted at the time
+    /// deploy_ztunnel is called. As such, you must ensure this is called after all other workloads are created.
     pub fn deploy_ztunnel(&mut self) -> anyhow::Result<TestApp> {
         let ns = TestWorkloadBuilder::new("ztunnel", self).register()?;
         let ip = ns.ip();
@@ -168,10 +109,13 @@ impl WorkloadManager {
         Ok(rx.recv()?)
     }
 
+    /// workload_builder allows creating a new workload. It will run in its own network namespace.
     pub fn workload_builder(&mut self, name: &str) -> TestWorkloadBuilder {
         TestWorkloadBuilder::new(name, self)
     }
 
+    /// register_waypoint builds a new waypoint. This must be used for waypoints, rather than workload_builder,
+    /// or the redirection will not work properly
     pub fn register_waypoint(&mut self, name: &str) -> anyhow::Result<Namespace> {
         let ns = TestWorkloadBuilder::new(name, self).hbone().register()?;
         self.waypoints.push(ns.ip());
@@ -182,8 +126,82 @@ impl WorkloadManager {
         self.namespaces.resolver()
     }
 
+    /// resolve acts as a "DNS lookup", converting a workload name to an IP address.
     pub fn resolve(&self, name: &str) -> Option<IpAddr> {
         self.namespaces.resolve(name)
     }
 }
-// TODO: all threads must terminate... somehow.
+
+pub struct TestWorkloadBuilder<'a> {
+    w: LocalWorkload,
+    captured: bool,
+    manager: &'a mut WorkloadManager,
+}
+
+impl<'a> TestWorkloadBuilder<'a> {
+    pub fn new(name: &str, manager: &'a mut WorkloadManager) -> TestWorkloadBuilder<'a> {
+        TestWorkloadBuilder {
+            captured: true, // workload has redirection enabled
+            w: LocalWorkload {
+                workload: Workload {
+                    name: name.to_string(),
+                    namespace: "default".to_string(),
+                    service_account: "default".to_string(),
+                    node: "not-local".to_string(),
+                    ..test_default_workload()
+                },
+                vips: Default::default(),
+            },
+            manager,
+        }
+    }
+
+    /// Set the workload to use HBONE
+    pub fn hbone(mut self) -> Self {
+        self.w.workload.protocol = HBONE;
+        self
+    }
+
+    /// Append a waypoint to the workload
+    pub fn waypoint(mut self, waypoint: IpAddr) -> Self {
+        self.w.workload.waypoint_addresses.push(waypoint);
+        self
+    }
+
+    /// Append a VIP to the workload
+    pub fn vip(mut self, ip: &str, server_port: u16, target_port: u16) -> Self {
+        self.w
+            .vips
+            .entry(ip.to_string())
+            .or_default()
+            .insert(server_port, target_port);
+        self
+    }
+
+    /// Configure the workload to run on the "same node" as the ztunnel
+    pub fn on_local_node(mut self) -> Self {
+        self.w.workload.node = "local".to_string();
+        self
+    }
+
+    /// Opt out of redirection
+    pub fn uncaptured(mut self) -> Self {
+        self.captured = false;
+        self
+    }
+
+    /// Finish building the workload.
+    pub fn register(mut self) -> anyhow::Result<Namespace> {
+        let network_namespace = self.manager.namespaces.child(&self.w.workload.name)?;
+        self.w.workload.workload_ip = network_namespace.ip();
+        info!(
+            "registered {}/{} at {}",
+            self.w.workload.namespace, self.w.workload.name, self.w.workload.workload_ip
+        );
+        self.manager.workloads.push(self.w);
+        if self.captured {
+            self.manager.captured_workloads.push(network_namespace.ip());
+        }
+        Ok(network_namespace)
+    }
+}

--- a/src/test_helpers/components.rs
+++ b/src/test_helpers/components.rs
@@ -24,16 +24,18 @@ use crate::test_helpers::app::TestApp;
 use crate::test_helpers::netns::{Namespace, Resolver};
 use crate::test_helpers::*;
 use crate::workload::{LocalConfig, LocalWorkload, Workload};
-use crate::{config, identity};
+use crate::{config, identity, proxy};
 
 pub struct TestWorkloadBuilder<'a> {
     w: LocalWorkload,
+    captured: bool,
     manager: &'a mut WorkloadManager,
 }
 
 impl<'a> TestWorkloadBuilder<'a> {
     pub fn new(name: &str, manager: &'a mut WorkloadManager) -> TestWorkloadBuilder<'a> {
         TestWorkloadBuilder {
+            captured: true, // workload has redirection enabled
             w: LocalWorkload {
                 workload: Workload {
                     name: name.to_string(),
@@ -72,10 +74,22 @@ impl<'a> TestWorkloadBuilder<'a> {
         self
     }
 
+    pub fn uncaptured(mut self) -> Self {
+        self.captured = false;
+        self
+    }
+
     pub fn register(mut self) -> anyhow::Result<Namespace> {
         let network_namespace = self.manager.namespaces.child(&self.w.workload.name)?;
         self.w.workload.workload_ip = network_namespace.ip();
+        info!(
+            "registered {}/{} at {}",
+            self.w.workload.namespace, self.w.workload.name, self.w.workload.workload_ip
+        );
         self.manager.workloads.push(self.w);
+        if self.captured {
+            self.manager.captured_workloads.push(network_namespace.ip());
+        }
         Ok(network_namespace)
     }
 }
@@ -84,6 +98,7 @@ pub struct WorkloadManager {
     namespaces: netns::NamespaceManager,
     /// workloads that we have constructed
     workloads: Vec<LocalWorkload>,
+    captured_workloads: Vec<IpAddr>,
     waypoints: Vec<IpAddr>,
 }
 
@@ -92,15 +107,16 @@ impl WorkloadManager {
         Ok(Self {
             namespaces: netns::NamespaceManager::new(name)?,
             workloads: vec![],
+            captured_workloads: vec![],
             waypoints: vec![],
         })
     }
 
-    pub fn deploy_ztunnel(&mut self) -> anyhow::Result<()> {
+    pub fn deploy_ztunnel(&mut self) -> anyhow::Result<TestApp> {
         let ns = TestWorkloadBuilder::new("ztunnel", self).register()?;
         let ip = ns.ip();
         let veth = ns.interface();
-        let count = self.namespaces.count();
+        let _count = self.namespaces.count();
         let lc = LocalConfig {
             workloads: self.workloads.clone(),
             policies: vec![],
@@ -116,31 +132,40 @@ impl WorkloadManager {
             ..config::parse_config().unwrap()
         };
         let waypoints = self.waypoints.iter().map(|i| i.to_string()).join(" ");
+        let (tx, rx) = std::sync::mpsc::sync_channel(0);
         // Setup the ztunnel...
         ns.run_ready(move |ready| async move {
             helpers::run_command(&format!("scripts/ztunnel-redirect.sh {ip} {waypoints}"))?;
             let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(10));
-            let app = crate::app::build_with_cert(cfg, cert_manager.clone())
-                .await
-                .unwrap();
+            let app = crate::app::build_with_cert(cfg, cert_manager.clone()).await?;
 
             let ta = TestApp {
-                admin_address: app.admin_address,
-                proxy_addresses: app.proxy_addresses,
-                readiness_address: app.readiness_address,
+                admin_address: helpers::with_ip(app.admin_address, ip),
+                proxy_addresses: proxy::Addresses {
+                    outbound: helpers::with_ip(app.proxy_addresses.outbound, ip),
+                    inbound: helpers::with_ip(app.proxy_addresses.inbound, ip),
+                    socks5: helpers::with_ip(app.proxy_addresses.socks5, ip),
+                },
+                readiness_address: helpers::with_ip(app.readiness_address, ip),
                 cert_manager,
             };
             ta.ready().await;
             info!("ready");
             ready.set_ready();
+            tx.send(ta)?;
 
             app.wait_termination().await
         })?;
         // Setup the node...
+        let captured = self
+            .captured_workloads
+            .iter()
+            .map(|i| i.to_string())
+            .join(" ");
         self.namespaces.run_in_root_namespace(|| {
-            helpers::run_command(&format!("scripts/node-redirect.sh {ip} {veth} {count}"))
+            helpers::run_command(&format!("scripts/node-redirect.sh {ip} {veth} {captured}"))
         })?;
-        Ok(())
+        Ok(rx.recv()?)
     }
 
     pub fn workload_builder(&mut self, name: &str) -> TestWorkloadBuilder {
@@ -156,6 +181,7 @@ impl WorkloadManager {
     pub fn resolver(&self) -> Resolver {
         self.namespaces.resolver()
     }
+
     pub fn resolve(&self, name: &str) -> Option<IpAddr> {
         self.namespaces.resolve(name)
     }

--- a/src/test_helpers/helpers.rs
+++ b/src/test_helpers/helpers.rs
@@ -16,6 +16,7 @@ use crate::telemetry;
 use once_cell::sync::Lazy;
 use std::net::{IpAddr, SocketAddr};
 use std::process::Command;
+use std::time::Instant;
 use tracing::debug;
 
 // Ensure that the `tracing` stack is only initialised once using `once_cell`
@@ -30,20 +31,24 @@ pub fn with_ip(s: SocketAddr, ip: IpAddr) -> SocketAddr {
 }
 
 pub fn run_command(cmd: &str) -> anyhow::Result<()> {
+    let now = Instant::now();
     debug!("running command {cmd}");
     let output = Command::new("sh").arg("-c").arg(cmd).output()?;
     debug!(
-            "complete! code={}, stdout={}, stderr={}",
+        "command complete in {:?}; code={}, stdout={}, stderr={}",
+        now.elapsed(),
+        output.status,
+        std::str::from_utf8(&output.stdout)?,
+        std::str::from_utf8(&output.stderr)?
+    );
+    if !output.status.success() {
+        anyhow::bail!(
+            "command {} exited with code={}, stdout={}, stderr={}",
+            cmd.chars().take(50).collect::<String>(),
             output.status,
             std::str::from_utf8(&output.stdout)?,
             std::str::from_utf8(&output.stderr)?
         );
-    if !output.status.success() {
-        anyhow::bail!("command {} exited with code={}, stdout={}, stderr={}",
-            cmd.chars().take(50).collect::<String>(),
-            output.status,
-            std::str::from_utf8(&output.stdout)?,
-            std::str::from_utf8(&output.stderr)?);
     }
     Ok(())
 }

--- a/src/test_helpers/helpers.rs
+++ b/src/test_helpers/helpers.rs
@@ -15,6 +15,8 @@
 use crate::telemetry;
 use once_cell::sync::Lazy;
 use std::net::{IpAddr, SocketAddr};
+use std::process::Command;
+use tracing::debug;
 
 // Ensure that the `tracing` stack is only initialised once using `once_cell`
 static TRACING: Lazy<()> = Lazy::new(telemetry::setup_logging);
@@ -25,4 +27,23 @@ pub fn initialize_telemetry() {
 
 pub fn with_ip(s: SocketAddr, ip: IpAddr) -> SocketAddr {
     SocketAddr::new(ip, s.port())
+}
+
+pub fn run_command(cmd: &str) -> anyhow::Result<()> {
+    debug!("running command {cmd}");
+    let output = Command::new("sh").arg("-c").arg(cmd).output()?;
+    debug!(
+            "complete! code={}, stdout={}, stderr={}",
+            output.status,
+            std::str::from_utf8(&output.stdout)?,
+            std::str::from_utf8(&output.stderr)?
+        );
+    if !output.status.success() {
+        anyhow::bail!("command {} exited with code={}, stdout={}, stderr={}",
+            cmd.chars().take(50).collect::<String>(),
+            output.status,
+            std::str::from_utf8(&output.stdout)?,
+            std::str::from_utf8(&output.stderr)?);
+    }
+    Ok(())
 }

--- a/src/test_helpers/netns.rs
+++ b/src/test_helpers/netns.rs
@@ -225,6 +225,7 @@ ip -n {net} route add default via 10.0.0.1
 ip -n {net} route add 10.0.0.1 dev eth0 scope link src {ip}
 ip -n {net} route del 10.0.0.0/16 # remove auto-kernel route
 ip -n {net} route add 10.0.0.0/16 via 10.0.0.1 src {ip}
+ip netns exec {prefix} sysctl -w net.ipv4.conf.all.rp_filter=0
 ip netns exec {prefix} sysctl -w net.ipv4.conf.{veth}.rp_filter=0
 "
         ))?;

--- a/src/test_helpers/netns.rs
+++ b/src/test_helpers/netns.rs
@@ -1,0 +1,200 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::future::Future;
+use std::io::Write;
+use std::net::IpAddr;
+use std::process::Command;
+use std::sync::mpsc::SyncSender;
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::{sync, thread};
+
+use netns_rs::NetNs;
+use tokio::runtime::{Handle, RuntimeFlavor};
+use tracing::{debug, info, warn, Instrument};
+
+pub struct NamespaceManager {
+    prefix: String,
+    namespaces: Arc<Mutex<HashMap<String, u8>>>,
+}
+
+#[derive(Debug)]
+pub struct Namespace {
+    id: u8,
+    name: String,
+    namespace_name: String,
+    netns: NetNs,
+}
+
+pub struct Ready(SyncSender<()>);
+
+impl Ready {
+    // This is the same as drop(ready) but more explicit
+    pub fn set_ready(self) {}
+}
+
+impl Namespace {
+    pub fn ip(&self) -> IpAddr {
+        id_to_ip(self.id)
+    }
+
+    pub fn run<F, Fut>(self, f: F) -> anyhow::Result<JoinHandle<anyhow::Result<()>>>
+        where
+            F: FnOnce(IpAddr) -> Fut + Send + 'static,
+            Fut: Future<Output = anyhow::Result<()>> {
+        self.run_ready(|ip, ready| async move {
+            ready.set_ready();
+            f(ip).await
+        })
+    }
+
+    pub fn run_ready<F, Fut>(self, f: F) -> anyhow::Result<JoinHandle<anyhow::Result<()>>>
+    where
+        F: FnOnce(IpAddr, Ready) -> Fut + Send + 'static,
+        Fut: Future<Output = anyhow::Result<()>>,
+    {
+        let name = self.name.clone();
+        let (tx, rx) = sync::mpsc::sync_channel::<()>(0);
+        // Change network namespaces changes the entire thread, so we want to run each network in its own thread
+        let j = thread::spawn(move || {
+            self.netns
+                .run(|_n| {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .unwrap();
+                    rt.block_on(
+                        f(id_to_ip(self.id), Ready(tx))
+                            .instrument(tracing::info_span!("run", namespace = self.name)),
+                    )
+                })
+                .unwrap()
+        });
+        debug!(namespace=name, "awaiting ready");
+        // Await readiness
+        let _ = rx.recv();
+        debug!(namespace=name, "ready");
+        Ok(j)
+    }
+}
+
+fn drop_namespace(name: &str) {
+    debug!("dropping namespace {name}");
+    match NetNs::get(name) {
+        // We do not store exclusive NetNs since they are not Clone, so just fetch it...
+        Ok(ns) => {
+            if let Err(e) = ns.remove() {
+                warn!("failed to remove namespace {name}: {e}");
+            }
+        }
+        Err(e) => warn!("failed to find namespace {name}: {e}"),
+    }
+}
+
+fn id_to_ip(i: u8) -> IpAddr {
+    IpAddr::from([10, 0, i, 1])
+}
+
+impl Drop for NamespaceManager {
+    fn drop(&mut self) {
+        // Drop the root namespace
+        drop_namespace(&self.prefix);
+        for (name, _) in self.namespaces.lock().unwrap().iter() {
+            drop_namespace( &format!("{}_inner_{name}", self.prefix));
+        }
+    }
+}
+
+impl NamespaceManager {
+    pub fn run<F, O>(prefix: &str, f: F) -> anyhow::Result<O>
+    where
+    F: FnOnce(Self) -> O,
+    {
+        if let Ok(h) = Handle::try_current() {
+            assert_eq!(
+                h.runtime_flavor(),
+                RuntimeFlavor::CurrentThread,
+                "Namespaces require single threaded"
+            );
+        }
+        let _ = NetNs::new(prefix)?;
+        Ok(Self {
+            prefix: prefix.to_string(),
+            namespaces: Default::default(),
+            // namespaces: vec![netns_rs::NetNs::new(prefix)?],
+        })
+    }
+
+    pub fn resolve(&self, name: &str) -> Option<IpAddr> {
+        self.namespaces
+            .lock()
+            .unwrap()
+            .get(name)
+            .map(|i| id_to_ip(*i))
+    }
+
+    pub fn child(&self, name: &str) -> anyhow::Result<Namespace> {
+        let mut namespaces = self.namespaces.lock().unwrap();
+        // Namespaces are never removed, so its safe (for now) to use the size
+        let id = namespaces.len() as u8;
+        assert!(id <= 255, "only 255 networks allowed");
+        let prefix = &self.prefix;
+        let veth = format!("veth{id}");
+        let net = format!("{}_inner_{name}", prefix);
+        let netns = NetNs::new(&net)?;
+        let ns = Namespace {
+            id,
+            netns,
+            name: name.to_string(),
+            namespace_name: net.clone(),
+        };
+        let ip = ns.ip();
+        Self::run(&format!(
+            "
+ip -n {prefix} link add {veth} type veth peer name eth0 netns {net}
+ip -n {prefix} link set dev {veth} up
+ip -n {prefix} addr add 10.0.0.1 dev {veth}
+ip -n {prefix} route add {ip} dev {veth} scope host
+
+ip -n {net} link set dev lo up
+ip -n {net} link set dev eth0 up
+ip -n {net} addr add {ip}/16 dev eth0
+ip -n {net} route add default via 10.0.0.1
+ip -n {net} route add 10.0.0.1 dev eth0 scope link src {ip}
+ip -n {net} route del 10.0.0.0/16 # remove auto-kernel route
+ip -n {net} route add 10.0.0.0/16 via 10.0.0.1 src {ip}
+"
+        ))?;
+        namespaces.insert(name.to_string(), id);
+        Ok(ns)
+    }
+
+    fn run(cmd: &str) -> anyhow::Result<()> {
+        debug!("running command {cmd}");
+        let output = Command::new("sh").arg("-c").arg(cmd).output()?;
+        debug!(
+            "complete! code={}, stdout={}, stderr={}",
+            output.status,
+            std::str::from_utf8(&output.stdout)?,
+            std::str::from_utf8(&output.stdout)?
+        );
+        println!("status: {}", output.status);
+        std::io::stdout().write_all(&output.stdout).unwrap();
+        std::io::stderr().write_all(&output.stderr).unwrap();
+        Ok(())
+    }
+}

--- a/src/test_helpers/netns.rs
+++ b/src/test_helpers/netns.rs
@@ -225,6 +225,7 @@ ip -n {net} route add default via 10.0.0.1
 ip -n {net} route add 10.0.0.1 dev eth0 scope link src {ip}
 ip -n {net} route del 10.0.0.0/16 # remove auto-kernel route
 ip -n {net} route add 10.0.0.0/16 via 10.0.0.1 src {ip}
+ip netns exec {prefix} sysctl -w net.ipv4.conf.{veth}.rp_filter=0
 "
         ))?;
         namespaces.insert(name.to_string(), id);

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::convert::Infallible;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::net::{IpAddr, Ipv6Addr};
 use std::time::Duration;
 use std::{cmp, io};
@@ -90,7 +90,7 @@ static BUFFER_SIZE: usize = 2 * 1024 * 1024;
 
 impl TestServer {
     pub async fn new(mode: Mode, port: u16) -> TestServer {
-        let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port);
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
         let listener = TcpListener::bind(addr).await.unwrap();
         TestServer { listener, mode }
     }

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -22,7 +22,7 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Response, Server};
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use rand::Rng;
+
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::Instant;
 use tracing::{debug, error, info};

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::convert::Infallible;
+use std::net::IpAddr;
 use std::net::{Ipv4Addr, SocketAddr};
-use std::net::{IpAddr, Ipv6Addr};
 use std::time::Duration;
 use std::{cmp, io};
 

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -20,6 +20,7 @@ use std::{cmp, io};
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Response, Server};
+use rand::Rng;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use rand::Rng;
 use tokio::net::{TcpListener, TcpStream};
@@ -141,6 +142,8 @@ where
     }
 }
 
+/// HboneTestServer is like TestServer but listens over HBONE. Unlike the plain TCP test server, it will
+/// always write "waypoint/n" to allow tests to assert they reached the HBONE server.
 pub struct HboneTestServer {
     listener: TcpListener,
     mode: Mode,
@@ -148,9 +151,19 @@ pub struct HboneTestServer {
 
 impl HboneTestServer {
     pub async fn new(mode: Mode) -> Self {
-        let addr = SocketAddr::new("127.0.0.9".parse().unwrap(), 15008);
-        let listener = TcpListener::bind(addr).await.unwrap();
-        Self { listener, mode }
+        // Waypoints are assumed to always run on 15008, but we need to have a unique ip:port
+        // Linux doesn't offer a way to pick a random free ip, so we iterate until we find an open one
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            // lo has 127.0.0.1/8, so we will generate 2 u8's. That is enough to give us 65k
+            let attempt = SocketAddr::new(IpAddr::from([127, 137, rng.gen(), rng.gen()]), 15008);
+            let Ok(listener) = TcpListener::bind(attempt).await else {
+                // Try again...
+                continue
+            };
+            return Self { listener, mode };
+        }
+        panic!("failed to find a free IP after 1000 attempts");
     }
 
     pub fn address(&self) -> SocketAddr {
@@ -175,14 +188,16 @@ impl HboneTestServer {
         Server::builder(incoming)
             .http2_only(true)
             .serve(make_service_fn(|_| async move {
-                let mode = mode.clone();
+                let mode = mode;
                 Ok::<_, Infallible>(service_fn(move |req| async move {
                     info!("waypoint: received request");
-                    let mode = mode.clone();
+                    let mode = mode;
                     tokio::task::spawn(async move {
                         match hyper::upgrade::on(req).await {
-                            Ok(mut upgraded) => {
+                            Ok(upgraded) => {
                                 let (mut ri, mut wi) = tokio::io::split(upgraded);
+                                // Signal we are the waypoint so tests can validate this
+                                wi.write_all(b"waypoint\n").await.unwrap();
                                 handle_stream(mode, &mut ri, &mut wi).await;
                             }
                             Err(e) => error!("No upgrade {e}"),

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -20,8 +20,8 @@ use std::{cmp, io};
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Response, Server};
-use rand::Rng;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use rand::Rng;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::Instant;
 use tracing::{debug, error, info};
@@ -141,8 +141,6 @@ where
     }
 }
 
-/// HboneTestServer is like TestServer but listens over HBONE. Unlike the plain TCP test server, it will
-/// always write "waypoint/n" to allow tests to assert they reached the HBONE server.
 pub struct HboneTestServer {
     listener: TcpListener,
     mode: Mode,
@@ -150,19 +148,9 @@ pub struct HboneTestServer {
 
 impl HboneTestServer {
     pub async fn new(mode: Mode) -> Self {
-        // Waypoints are assumed to always run on 15008, but we need to have a unique ip:port
-        // Linux doesn't offer a way to pick a random free ip, so we iterate until we find an open one
-        let mut rng = rand::thread_rng();
-        for _ in 0..1000 {
-            // lo has 127.0.0.1/8, so we will generate 2 u8's. That is enough to give us 65k
-            let attempt = SocketAddr::new(IpAddr::from([127, 137, rng.gen(), rng.gen()]), 15008);
-            let Ok(listener) = TcpListener::bind(attempt).await else {
-                // Try again...
-                continue
-            };
-            return Self { listener, mode };
-        }
-        panic!("failed to find a free IP after 1000 attempts");
+        let addr = SocketAddr::new("127.0.0.9".parse().unwrap(), 15008);
+        let listener = TcpListener::bind(addr).await.unwrap();
+        Self { listener, mode }
     }
 
     pub fn address(&self) -> SocketAddr {
@@ -187,16 +175,14 @@ impl HboneTestServer {
         Server::builder(incoming)
             .http2_only(true)
             .serve(make_service_fn(|_| async move {
-                let mode = mode;
+                let mode = mode.clone();
                 Ok::<_, Infallible>(service_fn(move |req| async move {
                     info!("waypoint: received request");
-                    let mode = mode;
+                    let mode = mode.clone();
                     tokio::task::spawn(async move {
                         match hyper::upgrade::on(req).await {
-                            Ok(upgraded) => {
+                            Ok(mut upgraded) => {
                                 let (mut ri, mut wi) = tokio::io::split(upgraded);
-                                // Signal we are the waypoint so tests can validate this
-                                wi.write_all(b"waypoint\n").await.unwrap();
                                 handle_stream(mode, &mut ri, &mut wi).await;
                             }
                             Err(e) => error!("No upgrade {e}"),

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -89,8 +89,8 @@ pub struct TestServer {
 static BUFFER_SIZE: usize = 2 * 1024 * 1024;
 
 impl TestServer {
-    pub async fn new(mode: Mode) -> TestServer {
-        let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0);
+    pub async fn new(mode: Mode, port: u16) -> TestServer {
+        let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port);
         let listener = TcpListener::bind(addr).await.unwrap();
         TestServer { listener, mode }
     }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -356,7 +356,7 @@ impl LocalClient {
         let policies = r.policies.len();
         for wl in r.workloads {
             let wip = wl.workload.workload_ip;
-            debug!("inserting local workloads {wip}");
+            debug!("inserting local workloads {wip} ({}/{})", &wl.workload.namespace, &wl.workload.name);
             wli.insert_workload(wl.workload);
             for (vip, ports) in wl.vips {
                 let ip = vip.parse::<IpAddr>()?;

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -715,6 +715,7 @@ mod tests {
 
     use crate::test_helpers;
     use bytes::Bytes;
+    use crate::test_helpers;
 
     use crate::xds::istio::workload::Port as XdsPort;
     use crate::xds::istio::workload::PortList as XdsPortList;

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -715,7 +715,6 @@ mod tests {
 
     use crate::test_helpers;
     use bytes::Bytes;
-    use crate::test_helpers;
 
     use crate::xds::istio::workload::Port as XdsPort;
     use crate::xds::istio::workload::PortList as XdsPortList;

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -350,13 +350,17 @@ impl LocalClient {
     async fn run(self) -> Result<(), anyhow::Error> {
         // Currently, we just load the file once. In the future, we could dynamically reload.
         let data = self.cfg.read_to_string().await?;
+        trace!("local config: {data}");
         let r: LocalConfig = serde_yaml::from_str(&data)?;
         let mut wli = self.workloads.lock().unwrap();
         let workloads = r.workloads.len();
         let policies = r.policies.len();
         for wl in r.workloads {
             let wip = wl.workload.workload_ip;
-            debug!("inserting local workloads {wip} ({}/{})", &wl.workload.namespace, &wl.workload.name);
+            debug!(
+                "inserting local workloads {wip} ({}/{})",
+                &wl.workload.namespace, &wl.workload.name
+            );
             wli.insert_workload(wl.workload);
             for (vip, ports) in wl.vips {
                 let ip = vip.parse::<IpAddr>()?;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,39 @@
+# Integration tests
+
+This folder contains integration tests for ztunnel.
+
+## Direct tests
+
+These are tests in `direct.rs`, which simply run a ztunnel in process and make assertions.
+This is the preferred option for most tests, if possible.
+
+Helpers are available to use a fake CA and local XDS config, to avoid reliance on components outside of `ztunnel`.
+
+For more advanced testing, see [Namespaced](#namespaced).
+
+## Namespaced
+
+Many scenarios in ztunnel are reliant on being deployed in an environment with redirection in place.
+In order to support these, the tests in `namespaced.rs` come with a framework to run components in different network namespaces.
+This simulates a single node in Kubernetes.
+
+Tests can run "workloads" in a namespace, such as:
+
+```rust
+manager
+    .workload_builder("client")
+    .on_local_node()
+    .register()?
+    .run(|| { ... commands run here are in a network namespace ...})
+```
+
+For more information, see the docs under `WorkloadManager`.
+
+Running these tests requires root. To run tests under sudo, `make test-root` can be used.
+When not running as root, the tests are skipped. 
+Warning: rust doesn't allow reporting a test was skipped, so it just appears to pass; in CI we enforce it always runs as root to avoid missing tests.
+
+## Kubernetes
+
+Tests run in a full Kubernetes environment are handled in [`istio/istio`](https://github.com/istio/istio).
+This repo only runs a standalone `ztunnel` tests.

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,12 @@ Running these tests requires root. To run tests under sudo, `make test-root` can
 When not running as root, the tests are skipped. 
 Warning: rust doesn't allow reporting a test was skipped, so it just appears to pass; in CI we enforce it always runs as root to avoid missing tests.
 
+If namespaces get in a broken state, they can be cleaned up with:
+
+```shell
+ip -j netns ls | jq -r '.[].name' | grep '^test_' | xargs -n1 sudo ip netns del
+```
+
 ## Kubernetes
 
 Tests run in a full Kubernetes environment are handled in [`istio/istio`](https://github.com/istio/istio).

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,7 +30,7 @@ manager
 For more information, see the docs under `WorkloadManager`.
 
 Running these tests requires root. To run tests under sudo, `make test-root` can be used.
-When not running as root, the tests are skipped. 
+When not running as root, the tests are skipped.
 Warning: rust doesn't allow reporting a test was skipped, so it just appears to pass; in CI we enforce it always runs as root to avoid missing tests.
 
 If namespaces get in a broken state, they can be cleaned up with:

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -160,7 +160,7 @@ async fn test_waypoint_bypass() -> anyhow::Result<()> {
         .on_local_node()
         .register()?;
     let client = manager.workload_builder("client").register()?;
-    let mut app = manager.deploy_ztunnel()?;
+    let app = manager.deploy_ztunnel()?;
 
     let srv = resolve_target(manager.resolver(), "server");
     client
@@ -211,7 +211,7 @@ async fn test_hbone_ip_mismatch() -> anyhow::Result<()> {
     let mut manager = setup_netns_test!();
     let _ = manager.workload_builder("server").register()?;
     let client = manager.workload_builder("client").register()?;
-    let mut app = manager.deploy_ztunnel()?;
+    let app = manager.deploy_ztunnel()?;
 
     let srv = resolve_target(manager.resolver(), "server");
     client

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -1,0 +1,244 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::{IpAddr, SocketAddr};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use tokio::net::TcpStream;
+
+use tracing::info;
+
+use ztunnel::test_helpers::components::WorkloadManager;
+use ztunnel::test_helpers::helpers::initialize_telemetry;
+use ztunnel::test_helpers::netns::{Namespace, Resolver};
+
+use ztunnel::test_helpers::*;
+
+macro_rules! function {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        &name[..name.len() - 3]
+    }};
+}
+
+/// setup_netns_test prepares a test using network namespaces. This checks we have root,
+/// and automatically setups up a namespace based on the test name (to avoid conflicts).
+macro_rules! setup_netns_test {
+    () => {{
+        if unsafe { libc::getuid() } != 0 {
+            if std::env::var("CI").is_ok() {
+                panic!("CI tests should run as root to have full coverage");
+            }
+            eprintln!("This test requires root; skipping");
+            return Ok(());
+        }
+        initialize_telemetry();
+        let f = function!()
+            .strip_prefix(module_path!())
+            .unwrap()
+            .strip_prefix("::")
+            .unwrap()
+            .strip_suffix("::{{closure}}")
+            .unwrap();
+        WorkloadManager::new(f)?
+    }};
+}
+
+const TEST_VIP: &str = "10.10.0.1";
+
+const SERVER_PORT: u16 = 8080;
+
+#[tokio::test]
+async fn test_vip_request() -> anyhow::Result<()> {
+    let mut manager = setup_netns_test!();
+    let server1 = manager
+        .workload_builder("server1")
+        .vip(TEST_VIP, 80, SERVER_PORT)
+        .register()?;
+    let server2 = manager
+        .workload_builder("server2")
+        .hbone()
+        .vip(TEST_VIP, 80, SERVER_PORT)
+        .register()?;
+    let client = manager
+        .workload_builder("client")
+        .on_local_node()
+        .register()?;
+    manager.deploy_ztunnel()?;
+
+    run_tcp_server(server1)?;
+    run_tcp_server(server2)?;
+    run_tcp_client(client, manager.resolver(), &format!("{TEST_VIP}:80"))?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_tcp_request() -> anyhow::Result<()> {
+    let mut manager = setup_netns_test!();
+    let server = manager.workload_builder("server").register()?;
+    client_server_test(manager, server)
+}
+
+#[tokio::test]
+async fn test_tcp_local_request() -> anyhow::Result<()> {
+    let mut manager = setup_netns_test!();
+    let server = manager
+        .workload_builder("server")
+        .on_local_node()
+        .register()?;
+    client_server_test(manager, server)
+}
+
+#[tokio::test]
+async fn test_hbone_request() -> anyhow::Result<()> {
+    let mut manager = setup_netns_test!();
+    let server = manager.workload_builder("server").hbone().register()?;
+    client_server_test(manager, server)
+}
+
+#[tokio::test]
+async fn test_hbone_local_request() -> anyhow::Result<()> {
+    let mut manager = setup_netns_test!();
+    let server = manager
+        .workload_builder("server")
+        .hbone()
+        .on_local_node()
+        .register()?;
+    client_server_test(manager, server)
+}
+
+#[tokio::test]
+async fn test_waypoint() -> anyhow::Result<()> {
+    let mut manager = setup_netns_test!();
+    let waypoint = manager.register_waypoint("waypoint")?;
+    let ip = waypoint.ip();
+    run_hbone_server(waypoint)?;
+    let server = manager
+        .workload_builder("server")
+        .hbone()
+        .waypoint(ip)
+        .on_local_node()
+        .register()?;
+    let client = manager
+        .workload_builder("client")
+        .on_local_node()
+        .register()?;
+    manager.deploy_ztunnel()?;
+
+    run_tcp_server(server)?;
+    run_tcp_to_hbone_client(client, manager.resolver(), "server")?;
+    Ok(())
+}
+
+fn resolve_target(resolver: Resolver, target: &str) -> SocketAddr {
+    // We accept a ip:port, ip, or name (which is resolved).
+    target.parse::<SocketAddr>().unwrap_or_else(|_| {
+        let ip = target
+            .parse::<IpAddr>()
+            .unwrap_or_else(|_| resolver.resolve(target).unwrap());
+        SocketAddr::new(ip, SERVER_PORT)
+    })
+}
+
+/// run_tcp_client runs a simple client that reads and writes some data, asserting it flows end to end
+fn run_tcp_client(client: Namespace, resolver: Resolver, target: &str) -> anyhow::Result<()> {
+    let srv = resolve_target(resolver, target);
+    client
+        .run(move || async move {
+            info!("Running client to {srv}");
+            let mut stream = TcpStream::connect(srv).await.unwrap();
+            read_write_stream(&mut stream).await;
+            Ok(())
+        })?
+        .join()
+        .unwrap()
+}
+
+/// run_tcp_client runs a simple client that reads and writes some data, asserting it flows end to end
+fn run_tcp_to_hbone_client(
+    client: Namespace,
+    resolver: Resolver,
+    target: &str,
+) -> anyhow::Result<()> {
+    let srv = resolve_target(resolver, target);
+    client
+        .run(move || async move {
+            info!("Running client to {srv}");
+            let mut stream = TcpStream::connect(srv).await.unwrap();
+            hbone_read_write_stream(&mut stream).await;
+            Ok(())
+        })?
+        .join()
+        .unwrap()
+}
+
+/// run_tcp_server deploys a simple echo server in the provided namespace
+fn run_tcp_server(server: Namespace) -> anyhow::Result<()> {
+    server.run_ready(|ready| async move {
+        let echo = tcp::TestServer::new(tcp::Mode::ReadWrite, SERVER_PORT).await;
+        info!("Running echo server");
+        ready.set_ready();
+        echo.run().await;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+/// run_hbone_server deploys a simple echo server, deployed over HBONE, in the provided namespace
+fn run_hbone_server(server: Namespace) -> anyhow::Result<()> {
+    server.run_ready(|ready| async move {
+        let echo = tcp::HboneTestServer::new(tcp::Mode::ReadWrite).await;
+        info!("Running echo server");
+        ready.set_ready();
+        echo.run().await;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+/// client_server_test runs a simple test sending a single request from the client and asserting it is received.
+fn client_server_test(mut manager: WorkloadManager, server: Namespace) -> anyhow::Result<()> {
+    let client = manager
+        .workload_builder("client")
+        .on_local_node()
+        .register()?;
+    manager.deploy_ztunnel()?;
+
+    run_tcp_server(server)?;
+    run_tcp_client(client, manager.resolver(), "server")?;
+    Ok(())
+}
+// TODO: dedupe
+async fn read_write_stream(stream: &mut TcpStream) -> usize {
+    const BODY: &[u8] = b"hello world";
+    stream.write_all(BODY).await.unwrap();
+    let mut buf: [u8; BODY.len()] = [0; BODY.len()];
+    stream.read_exact(&mut buf).await.unwrap();
+    assert_eq!(BODY, buf);
+    BODY.len()
+}
+
+async fn hbone_read_write_stream(stream: &mut TcpStream) {
+    const BODY: &[u8] = b"hello world";
+    const WAYPOINT_MESSAGE: &[u8] = b"waypoint\n";
+    stream.write_all(BODY).await.unwrap();
+    let mut buf = [0; BODY.len() + WAYPOINT_MESSAGE.len()];
+    stream.read_exact(&mut buf).await.unwrap();
+    assert_eq!([WAYPOINT_MESSAGE, BODY].concat(), buf);
+}

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -273,7 +273,7 @@ async fn test_inbound_waypoint_bypass() {
     let cfg = config::Config {
         ..test_config_with_waypoint(TEST_WORKLOAD_WAYPOINT.parse().unwrap())
     };
-    testapp::with_app(cfg, |mut app| async move {
+    testapp::with_app(cfg, |app| async move {
         let mut builder = hyper::client::conn::Builder::new();
         let builder = builder.http2_only(true);
 

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -26,6 +26,7 @@ use tokio::net::TcpStream;
 use tokio::time;
 use tokio::time::timeout;
 use tracing::{error, trace};
+use ztunnel::config;
 
 use ztunnel::identity::mock::MockCaClient;
 use ztunnel::identity::CertificateProvider;
@@ -33,6 +34,7 @@ use ztunnel::test_helpers::app as testapp;
 use ztunnel::test_helpers::app::TestApp;
 use ztunnel::test_helpers::tcp::HboneTestServer;
 use ztunnel::test_helpers::*;
+use ztunnel::test_helpers::tcp::HboneTestServer;
 use ztunnel::{config, identity};
 
 #[tokio::test]
@@ -259,59 +261,11 @@ async fn test_vip_request_local() {
 
 #[tokio::test]
 async fn test_waypoint() {
-    // Port doesn't matter, we will only go to the fake waypoint.
-    run_waypoint_test(&format!("{TEST_WORKLOAD_WAYPOINT}:1234"), "").await;
-    // Also test when client and server are on the same node; we still need to go through the waypoint.
-    run_waypoint_test(&format!("{TEST_WORKLOAD_WAYPOINT}:1234"), "local").await;
+    let waypoint = HboneTestServer::new(tcp::Mode::ReadWrite).await;
+    tokio::spawn(waypoint.run());
+    run_request_test(TEST_WORKLOAD_WAYPOINT, "").await;
 }
 
-// TODO: this test doesn't work since sending direct inbound requests still requires redirection support to terminate the TLS
-// Find a way to simulate this and re-enable
-#[tokio::test]
-#[ignore]
-async fn test_inbound_waypoint_bypass() {
-    let cfg = config::Config {
-        ..test_config_with_waypoint(TEST_WORKLOAD_WAYPOINT.parse().unwrap())
-    };
-    testapp::with_app(cfg, |app| async move {
-        let mut builder = hyper::client::conn::Builder::new();
-        let builder = builder.http2_only(true);
-
-        let request = hyper::Request::builder()
-            .uri(format!("https://{TEST_WORKLOAD_WAYPOINT}:12345"))
-            .method(Method::CONNECT)
-            .version(hyper::Version::HTTP_2)
-            .body(Body::empty())
-            .unwrap();
-
-        let id = &identity::Identity::default();
-        let cert = app.cert_manager.fetch_certificate(id).await.unwrap();
-        let mut connector = cert
-            .connector(None)
-            .unwrap()
-            .configure()
-            .expect("configure");
-        connector.set_verify_hostname(false);
-        connector.set_use_server_name_indication(false);
-        let tcp_stream = TcpStream::connect(app.proxy_addresses.inbound)
-            .await
-            .unwrap();
-        let tls_stream = tokio_boring::connect(connector, "", tcp_stream)
-            .await
-            .unwrap();
-        let (mut request_sender, connection) = builder.handshake(tls_stream).await.unwrap();
-        // spawn a task to poll the connection and drive the HTTP state
-        tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                error!("Error in HBONE connection handshake: {:?}", e);
-            }
-        });
-
-        let response = request_sender.send_request(request).await.unwrap();
-        assert_eq!(response.status(), hyper::StatusCode::UNAUTHORIZED);
-    })
-    .await;
-}
 
 #[tokio::test]
 async fn test_stats_exist() {

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -48,6 +48,9 @@ use ztunnel::{config, identity};
 macro_rules! require_root {
     () => {
         if unsafe { libc::getuid() } != 0 {
+            if std::env::var("CI").is_ok() {
+                panic!("CI tests should run as root to have full coverage");
+            }
             eprintln!("This test requires root; skipping");
             return Ok(())
         }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -595,7 +595,7 @@ async fn test_netns() -> anyhow::Result<()> {
     // }
     server.run_ready(|ip, ready| async move {
         let echo = tcp::TestServer::new(tcp::Mode::ReadWrite, 8080).await;
-        info!("Running echo at {ip}:8080");
+        info!("Running echo at {ip}:8080, {}", echo.address());
         ready.set_ready();
         Ok(echo.run().await)
     })?;
@@ -608,9 +608,11 @@ async fn test_netns() -> anyhow::Result<()> {
     namespaces
         .child("client")?
         .run(move |_ip| async move {
-            info!("Running client");
+            let srv = SocketAddr::new(namespaces.resolve("server").unwrap(), 8080);
+            info!("Running client to {srv}");
+            // tokio::time::sleep(Duration::from_secs(30)).await;
             let mut stream =
-                TcpStream::connect(SocketAddr::new(namespaces.resolve("server").unwrap(), 8080))
+                TcpStream::connect(srv)
                     .await
                     .unwrap();
             info!("connected");


### PR DESCRIPTION
Fixes https://github.com/istio/ztunnel/issues/250

This PR introduces using network namespaces to deploy ""workloads"", which run in their own network namespace. For example, a test could deploy a client, ztunnel, and server. Redirection is configured to simulate a real k8s environment. This allows us to test a LOT more realistically than we do today, at the cost of requiring root (and complexity) 