### PR TITLE
Bump tokio to 1.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "38a54aca0c15d014013256222ba0ebed095673f89345dd79119d912eb561b7a8"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2058,7 +2058,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
Resolving a [CVE](https://rustsec.org/advisories/RUSTSEC-2023-0001).

Benchmarked against the 1.22.0 baseline shows improvement in connection/tcp and throughput/direct (others are not affected).

Also tried benchmarking the 1.24.1 which is suppose to [bring much better performance improvements](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.24.0) but I saw similar improvements like 1.23.1 but regression in metrics/write.

Ran all with zero copy disabled.