### PR TITLE
orig src: cleanups from initial impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console-api"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +743,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +796,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -894,6 +946,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64",
+ "futures-lite",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1079,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
@@ -1397,6 +1475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,13 +1795,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1727,7 +1834,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1736,7 +1852,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1916,6 +2041,29 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -2293,7 +2441,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2454,6 +2602,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2475,6 +2624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2649,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2687,6 +2848,7 @@ dependencies = [
  "futures",
  "go-parse-duration",
  "gperftools",
+ "http-types",
  "hyper",
  "hyper-boring",
  "ipnet",
@@ -2702,7 +2864,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "rand",
+ "rand 0.8.5",
  "realm_io",
  "rtnetlink",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ prometheus-parse = "0.2.3"
 url = "2.2"
 itertools = "0.10.5"
 ipnet = { version = "2.7.0", features = ["serde"] }
+http-types = { version = "2.12.0", default-features = false }
 netns-rs = "0.1.0"
 
 [build-dependencies]

--- a/scripts/ztunnel-redirect.sh
+++ b/scripts/ztunnel-redirect.sh
@@ -84,16 +84,6 @@ $IPTABLES -w -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -j TPROXY --tproxy-
 
 $IPTABLES -w -t mangle -A PREROUTING -p tcp -i eth0 ! --dst $INSTANCE_IP -j MARK --set-mark $ORG_SRC_RET_MARK
 
-# Huge hack. Currently, we only support single "node" test setup. This means we cannot test
-# Cross-ztunnel requests. Instead, loop these back to ourselves.
-# TODO: setup multiple ztunnels and actually communicate between them; then this can be removed.
-# We send HBONE to waypoints, so let those through...
-ipset create waypoint-pods-ips hash:ip
-for waypoint in "$@"; do
-  ipset add waypoint-pods-ips "${waypoint}"
-done
-$IPTABLES -w -t nat -A OUTPUT -p tcp --dport 15008 -m set '!' --match-set waypoint-pods-ips dst -j REDIRECT --to-port $POD_INBOUND
-
 # With normal linux routing we need to disable the rp_filter
 # as we get packets from a tunnel that doesn't have default routes.
 echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,14 +34,13 @@ const CA_ADDRESS: &str = "CA_ADDRESS";
 const TERMINATION_GRACE_PERIOD: &str = "TERMINATION_GRACE_PERIOD";
 const FAKE_CA: &str = "FAKE_CA";
 const ZTUNNEL_WORKER_THREADS: &str = "ZTUNNEL_WORKER_THREADS";
-const ENABLE_ORIG_SRC: &str = "ISTIO_ENABLE_ORIG_SRC";
+const ENABLE_ORIG_SRC: &str = "ENABLE_ORIG_SRC";
 const PROXY_CONFIG: &str = "PROXY_CONFIG";
 
 const DEFAULT_WORKER_THREADS: u16 = 2;
 const DEFAULT_ADMIN_PORT: u16 = 15000;
 const DEFAULT_STATUS_PORT: u16 = 15021;
 const DEFAULT_DRAIN_DURATION: Duration = Duration::from_secs(5);
-const ENABLE_ORIG_SRC_DEFAULT: bool = false;
 
 #[derive(serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum RootCert {
@@ -108,7 +107,7 @@ pub struct Config {
     pub num_worker_threads: usize,
 
     // If true, then use original source proxying
-    pub enable_original_source: bool,
+    pub enable_original_source: Option<bool>,
 
     // CLI args passed to ztunnel at runtime
     pub proxy_args: String,
@@ -236,7 +235,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
                 .expect("concurrency cannot be negative"),
         )?,
 
-        enable_original_source: parse_default(ENABLE_ORIG_SRC, ENABLE_ORIG_SRC_DEFAULT)?,
+        enable_original_source: parse(ENABLE_ORIG_SRC)?,
         proxy_args: parse_args(),
         zero_copy_enabled: true,
     })

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -22,7 +22,7 @@ use drain::Watch;
 use hyper::{header, Body, Request};
 use rand::Rng;
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
-use tracing::{error, trace, warn};
+use tracing::{error, trace, warn, Instrument};
 
 use inbound::Inbound;
 
@@ -88,10 +88,10 @@ impl Proxy {
 
     pub async fn run(self) {
         let tasks = vec![
-            tokio::spawn(self.inbound_passthrough.run()),
-            tokio::spawn(self.inbound.run()),
-            tokio::spawn(self.outbound.run()),
-            tokio::spawn(self.socks5.run()),
+            tokio::spawn(self.inbound_passthrough.run().in_current_span()),
+            tokio::spawn(self.inbound.run().in_current_span()),
+            tokio::spawn(self.outbound.run().in_current_span()),
+            tokio::spawn(self.socks5.run().in_current_span()),
         ];
 
         futures::future::join_all(tasks).await;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -175,7 +175,7 @@ impl Inbound {
                             },
                         }
                     })
-                    .instrument(tracing::span::Span::current()),
+                    .in_current_span(),
                 );
                 // Send back our 200. We do this regardless of if our spawned task copies the data;
                 // we need to respond with headers immediately once connection is established for the
@@ -267,7 +267,7 @@ impl Inbound {
                     orig_src
                 };
                 let status_code = match Self::handle_inbound(Hbone(req), orig_src, addr)
-                    .instrument(tracing::span::Span::current())
+                    .in_current_span()
                     .await
                 {
                     Ok(_) => StatusCode::OK,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -26,7 +26,7 @@ use tracing::{debug, error, info, instrument, trace, trace_span, warn, Instrumen
 
 use crate::config::Config;
 use crate::identity::CertificateProvider;
-use crate::proxy::inbound::InboundConnect::{DirectPath, Hbone};
+use crate::proxy::inbound::InboundConnect::Hbone;
 use crate::proxy::{ProxyInputs, TraceParent, TRACEPARENT_HEADER};
 use crate::rbac;
 use crate::socket::{relay, to_canonical};
@@ -44,12 +44,13 @@ pub(super) struct Inbound {
 }
 
 impl Inbound {
-    pub(super) async fn new(pi: ProxyInputs, drain: Watch) -> Result<Inbound, Error> {
+    pub(super) async fn new(mut pi: ProxyInputs, drain: Watch) -> Result<Inbound, Error> {
         let listener: TcpListener = TcpListener::bind(pi.cfg.inbound_addr)
             .await
             .map_err(|e| Error::Bind(pi.cfg.inbound_addr, e))?;
-        let transparent = crate::socket::set_transparent(&listener).is_ok();
-
+        let transparent = super::maybe_set_transparent(&pi, &listener)?;
+        // Override with our explicitly configured setting
+        pi.cfg.enable_original_source = Some(transparent);
         info!(
             address=%listener.local_addr().unwrap(),
             component="inbound",
@@ -89,7 +90,7 @@ impl Inbound {
                     Self::serve_connect(
                         workloads.clone(),
                         conn.clone(),
-                        enable_original_source,
+                        enable_original_source.unwrap_or_default(),
                         req,
                     )
                 }))
@@ -134,24 +135,11 @@ impl Inbound {
     /// handle_inbound serves an inbound connection with a target address `addr`.
     pub(super) async fn handle_inbound(
         request_type: InboundConnect,
-        origin_src: Option<IpAddr>,
+        orig_src: Option<IpAddr>,
         addr: SocketAddr,
     ) -> Result<(), std::io::Error> {
         let start = Instant::now();
-        let stream = {
-            match &request_type {
-                DirectPath(_) => super::freebind_connect(origin_src, addr).await,
-                Hbone(req) => {
-                    let origin_src = if origin_src.is_some() {
-                        // overwrite the original source if encoded in fwded from waypoint
-                        super::get_original_src_from_fwded(req).map_or(origin_src, Some)
-                    } else {
-                        origin_src
-                    };
-                    super::freebind_connect(origin_src, addr).await
-                }
-            }
-        };
+        let stream = super::freebind_connect(orig_src, addr).await;
         match stream {
             Err(err) => {
                 warn!(dur=?start.elapsed(), "connection to {} failed: {}", addr, err);
@@ -246,35 +234,39 @@ impl Inbound {
                         .body(Body::empty())
                         .unwrap());
                 }
-                let org_src = if enable_original_source {
-                    Some(conn.src_ip)
-                } else {
-                    None
-                };
+                let orig_src = enable_original_source.then_some(conn.src_ip);
 
                 let Some(upstream) = workloads.fetch_workload(&addr.ip()).await else {
-
-                                       info!(%conn, "unknown destination");
+                    info!(%conn, "unknown destination");
                     return Ok(Response::builder()
                         .status(StatusCode::NOT_FOUND)
                         .body(Body::empty())
                         .unwrap());
                 };
-                if !upstream.waypoint_addresses.is_empty() {
-                    let from_waypoint = conn
-                        .src_identity
-                        .as_ref()
-                        .map(|i| i == &upstream.identity())
-                        .unwrap_or(false);
-                    if !from_waypoint {
-                        info!(%conn, "bypassed waypoint");
-                        return Ok(Response::builder()
-                            .status(StatusCode::UNAUTHORIZED)
-                            .body(Body::empty())
-                            .unwrap());
-                    }
+                // TODO: This only identifies the service account; we need a more reliable way
+                // to identify specifically the waypoint proxy.
+                let from_waypoint = conn
+                    .src_identity
+                    .as_ref()
+                    .map(|i| i == &upstream.identity())
+                    .unwrap_or(false);
+                if !upstream.waypoint_addresses.is_empty() && !from_waypoint {
+                    info!(%conn, "bypassed waypoint");
+                    return Ok(Response::builder()
+                        .status(StatusCode::UNAUTHORIZED)
+                        .body(Body::empty())
+                        .unwrap());
                 }
-                let status_code = match Self::handle_inbound(Hbone(req), org_src, addr)
+                let orig_src = if orig_src.is_some() && from_waypoint {
+                    // If the request is from our waypoint, trust the Forwarded header.
+                    // For other request types, we can only trust the source from the connection.
+                    // Since our own waypoint is in the same trust domain though, we can use Forwarded,
+                    // which drops the requirement of spoofing IPs from waypoints
+                    super::get_original_src_from_fwded(&req).or(orig_src)
+                } else {
+                    orig_src
+                };
+                let status_code = match Self::handle_inbound(Hbone(req), orig_src, addr)
                     .instrument(tracing::span::Span::current())
                     .await
                 {

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -96,7 +96,7 @@ impl Outbound {
                     }
                 }
             }
-        };
+        }.in_current_span();
 
         // Stop accepting once we drain.
         // Note: we are *not* waiting for all connections to be closed. In the future, we may consider

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -18,6 +18,8 @@ use std::time::Instant;
 
 use boring::ssl::ConnectConfiguration;
 use drain::Watch;
+
+use hyper::header::FORWARDED;
 use hyper::StatusCode;
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, error, info, info_span, trace, trace_span, warn, Instrument};
@@ -37,12 +39,13 @@ pub struct Outbound {
 }
 
 impl Outbound {
-    pub(super) async fn new(pi: ProxyInputs, drain: Watch) -> Result<Outbound, Error> {
+    pub(super) async fn new(mut pi: ProxyInputs, drain: Watch) -> Result<Outbound, Error> {
         let listener: TcpListener = TcpListener::bind(pi.cfg.outbound_addr)
             .await
             .map_err(|e| Error::Bind(pi.cfg.outbound_addr, e))?;
-
-        let transparent = socket::set_transparent(&listener).is_ok();
+        let transparent = super::maybe_set_transparent(&pi, &listener)?;
+        // Override with our explicitly configured setting
+        pi.cfg.enable_original_source = Some(transparent);
 
         info!(
             address=%listener.local_addr().unwrap(),
@@ -159,7 +162,7 @@ impl OutboundConnection {
             // We *could* apply this to all traffic, rather than just for destinations that are "captured"
             // However, we would then get inconsistent behavior where only node-local pods have RBAC enforced.
             info!("proxying to {} using node local fast path", req.destination);
-            let origin_src = if self.pi.cfg.enable_original_source {
+            let origin_src = if self.pi.cfg.enable_original_source.unwrap_or_default() {
                 super::get_original_src_from_stream(&stream)
             } else {
                 None
@@ -198,27 +201,24 @@ impl OutboundConnection {
                     .http2_max_frame_size(self.pi.cfg.frame_size)
                     .http2_initial_connection_window_size(self.pi.cfg.connection_window_size);
 
+                let mut f = http_types::proxies::Forwarded::new();
+                f.add_for(remote_addr.to_string());
+
                 let request = hyper::Request::builder()
                     .uri(&req.destination.to_string())
                     .method(hyper::Method::CONNECT)
                     .version(hyper::Version::HTTP_2)
                     .header(BAGGAGE_HEADER, baggage(&req))
-                    .header(TRACEPARENT_HEADER, self.id.header());
-                let request = if self.pi.cfg.enable_original_source
-                    && req.request_type != RequestType::Direct
-                {
-                    request.header(hyper::header::FORWARDED, format!("for={}", remote_addr))
-                } else {
-                    request
-                };
-                let request = request.body(hyper::Body::empty()).unwrap();
-                let local = if self.pi.cfg.enable_original_source
-                    && req.request_type == RequestType::Direct
-                {
-                    Some(remote_addr)
-                } else {
-                    None
-                };
+                    .header(FORWARDED, f.value().unwrap())
+                    .header(TRACEPARENT_HEADER, self.id.header())
+                    .body(hyper::Body::empty())
+                    .unwrap();
+                let local = self
+                    .pi
+                    .cfg
+                    .enable_original_source
+                    .unwrap_or_default()
+                    .then_some(remote_addr);
                 let id = &req.source.identity();
                 let cert = self.pi.cert_manager.fetch_certificate(id).await?;
                 let connector = cert
@@ -264,7 +264,7 @@ impl OutboundConnection {
                     req.destination, req.gateway, req.request_type
                 );
                 // Create a TCP connection to upstream
-                let local = if self.pi.cfg.enable_original_source {
+                let local = if self.pi.cfg.enable_original_source.unwrap_or_default() {
                     super::get_original_src_from_stream(&stream)
                 } else {
                     None

--- a/src/test_helpers/netns.rs
+++ b/src/test_helpers/netns.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::{sync, thread};
 
+use anyhow::anyhow;
 use netns_rs::NetNs;
 use tokio::runtime::{Handle, RuntimeFlavor};
 use tracing::{debug, warn, Instrument};
@@ -29,29 +30,49 @@ use crate::test_helpers::helpers;
 
 pub struct NamespaceManager {
     prefix: String,
-    root: NetNs,
-    namespaces: Arc<Mutex<HashMap<String, u8>>>,
+    state: Arc<Mutex<State>>,
+}
+
+#[derive(Default, Debug)]
+struct Network {
+    id: u8,
+    node_id: u8,
+    node: String,
+}
+
+struct NodeNetwork {
+    id: u8,
+    net: NetNs,
+}
+
+#[derive(Default)]
+struct State {
+    pods: HashMap<String, Network>,
+    nodes: HashMap<String, NodeNetwork>,
 }
 
 #[derive(Clone)]
 pub struct Resolver {
-    namespaces: Arc<Mutex<HashMap<String, u8>>>,
+    state: Arc<Mutex<State>>,
 }
 
 impl Resolver {
     pub fn resolve(&self, name: &str) -> Option<IpAddr> {
-        self.namespaces
+        self.state
             .lock()
             .unwrap()
+            .pods
             .get(name)
-            .map(|i| id_to_ip(*i))
+            .map(|i| id_to_ip(i.node_id, i.id))
     }
 }
 
 #[derive(Debug)]
 pub struct Namespace {
     id: u8,
+    node_id: u8,
     name: String,
+    node_name: String,
     netns: NetNs,
 }
 
@@ -65,7 +86,7 @@ impl Ready {
 
 impl Namespace {
     pub fn ip(&self) -> IpAddr {
-        id_to_ip(self.id)
+        id_to_ip(self.node_id, self.id)
     }
 
     pub fn interface(&self) -> String {
@@ -95,6 +116,7 @@ impl Namespace {
         Fut: Future<Output = anyhow::Result<()>>,
     {
         let name = self.name.clone();
+        let node_name = self.node_name.clone();
         let (tx, rx) = sync::mpsc::sync_channel::<()>(0);
         // Change network namespaces changes the entire thread, so we want to run each network in its own thread
         let j = thread::spawn(move || {
@@ -104,20 +126,22 @@ impl Namespace {
                         .enable_all()
                         .build()
                         .unwrap();
-                    rt.block_on(
-                        f(Ready(tx)).instrument(tracing::info_span!("run", namespace = self.name)),
-                    )
+                    rt.block_on(f(Ready(tx)).instrument(tracing::info_span!(
+                        "run",
+                        name = self.name,
+                        node = self.node_name
+                    )))
                 })
                 .unwrap()
         });
-        debug!(namespace = name, "awaiting ready");
+        debug!(%name, %node_name, "awaiting ready");
         // Await readiness
         if rx.recv().is_err() {
-            debug!(namespace = name, "failed ready");
+            debug!(%name, %node_name, "failed ready");
             j.join().unwrap()?;
             anyhow::bail!("readiness dropped; used ready.set_ready() instead");
         }
-        debug!(namespace = name, "ready");
+        debug!(%name, %node_name, "ready");
         Ok(j)
     }
 }
@@ -135,8 +159,8 @@ fn drop_namespace(name: &str) {
     }
 }
 
-fn id_to_ip(i: u8) -> IpAddr {
-    IpAddr::from([10, 0, i, 1])
+fn id_to_ip(node_id: u8, pod_id: u8) -> IpAddr {
+    IpAddr::from([10, 0, node_id, pod_id])
 }
 
 // Clear out the namespace on Drop. This gives best effort assurance our test cleans up properly
@@ -144,8 +168,12 @@ impl Drop for NamespaceManager {
     fn drop(&mut self) {
         // Drop the root namespace
         drop_namespace(&self.prefix);
-        for (name, _) in self.namespaces.lock().unwrap().iter() {
-            drop_namespace(&format!("{}-{name}", self.prefix));
+        let state = self.state.lock().unwrap();
+        for (name, ns) in state.pods.iter() {
+            drop_namespace(&format!("{}~{}~{name}", self.prefix, &ns.node));
+        }
+        for (name, _) in state.nodes.iter() {
+            drop_namespace(&format!("{}~{name}", self.prefix));
         }
     }
 }
@@ -159,23 +187,25 @@ impl NamespaceManager {
                 "Namespaces require single threaded"
             );
         }
-        let ns = NetNs::new(prefix)?;
+        let _ns = NetNs::new(prefix)?;
         // Build Self early so we cleanup if later commands fail
         let res = Self {
             prefix: prefix.to_string(),
-            root: ns,
-            namespaces: Default::default(),
+            state: Default::default(),
         };
+        helpers::run_command(&format!(
+            "
+ip -n {prefix} link add name br0 type bridge
+ip -n {prefix} link set dev br0 up
+ip -n {prefix} addr add 172.172.0.1/16 dev br0
+"
+        ))?;
         Ok(res)
-    }
-
-    pub(super) fn count(&self) -> u8 {
-        self.namespaces.lock().unwrap().len() as u8
     }
 
     pub fn resolver(&self) -> Resolver {
         Resolver {
-            namespaces: self.namespaces.clone(),
+            state: self.state.clone(),
         }
     }
 
@@ -183,53 +213,123 @@ impl NamespaceManager {
         self.resolver().resolve(name)
     }
 
-    pub(super) fn run_in_root_namespace(
+    pub(super) fn run_in_node(
         &self,
+        node: &str,
         f: impl FnOnce() -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
-        self.root.run(|_| f())?
+        self.state
+            .lock()
+            .unwrap()
+            .nodes
+            .get(node)
+            .ok_or_else(|| anyhow!("unknown node"))?
+            .net
+            .run(|_| f())?
     }
 
     /// child constructs a new network namespace "inside" the root namespace.
     /// Each namespace gets a unique IP address, and is configured to be able to route to all other namespaces
     /// through the root network namespace.
-    pub fn child(&self, name: &str) -> anyhow::Result<Namespace> {
-        let mut namespaces = self.namespaces.lock().unwrap();
+    pub fn child(&self, node: &str, name: &str) -> anyhow::Result<Namespace> {
+        debug!(%node, %name, "building namespace");
+        let mut state = self.state.lock().unwrap();
         // Namespaces are never removed, so its safe (for now) to use the size
-        // 10.0.0.x is the host namespace, so skip 0
-        assert!(namespaces.len() < 255, "only 255 networks allowed");
-        let id = namespaces.len() as u8 + 1;
+        // 10.0.0.1 is the node namespace, so skip 0 and 1
+        assert!(state.pods.len() < 254, "only 255 networks allowed");
+        let id = state.pods.len() as u8 + 2;
+        let node_net = format!("{}~{node}", &self.prefix);
         let prefix = &self.prefix;
+        if state.pods.contains_key(name) {
+            panic!("pod {name} already registered");
+        }
+        if !state.nodes.contains_key(node) {
+            assert!(state.nodes.len() < 16, "only 16 nodes allowed");
+            let node_id = state.nodes.len() as u8 + 2;
+            // Setup node
+            let netns = NetNs::new(&node_net)?;
+            state.nodes.insert(
+                node.to_string(),
+                NodeNetwork {
+                    id: node_id,
+                    net: netns,
+                },
+            );
+            let veth = format!("veth{node_id}");
+            helpers::run_command(&format!(
+                "
+set -ex
+ip -n {prefix} link add {veth} type veth peer name eth0 netns {node_net}
+ip -n {prefix} link set dev {veth} up
+ip -n {prefix} link set dev {veth} master br0
+# Give our node an IP
+ip -n {node_net} link set dev eth0 up
+ip -n {node_net} addr add 172.172.0.{node_id}/16 dev eth0
+# Route everything to the network
+ip -n {node_net} route add default via 172.172.0.1
+# TODO: cross product routing for
+ip -n {node_net} route add 172.172.0.0/17 dev eth0 scope link src 172.172.0.{node_id}
+"
+            ))?;
+            for (node, s) in state.nodes.iter() {
+                if s.id == node_id {
+                    // ourselves, skip
+                    continue;
+                }
+                let other_id = s.id;
+                let other_net = format!("{}~{node}", &self.prefix);
+                helpers::run_command(&format!(
+                    "
+set -ex
+# For each other node, give a route to it for all pods in the node
+ip -n {node_net} route add 10.0.{other_id}.0/24 via 172.172.0.{other_id} dev eth0
+# Also give that node a route to us
+ip -n {other_net} route add 10.0.{node_id}.0/24 via 172.172.0.{node_id} dev eth0
+"
+                ))?;
+            }
+        }
+        let node_id = state.nodes.get(node).unwrap().id;
         let veth = format!("veth{id}");
-        let net = format!("{}-{name}", prefix);
+        let net = format!("{}~{node}~{name}", prefix);
         let netns = NetNs::new(&net)?;
         let ns = Namespace {
             id,
+            node_id,
             netns,
+            node_name: node.to_string(),
             name: name.to_string(),
         };
         let ip = ns.ip();
+        state.pods.insert(
+            name.to_string(),
+            Network {
+                id,
+                node_id,
+                node: node.to_string(),
+            },
+        );
         // Give the namespace a veth and configure routing
         // Largely inspired by https://github.com/containernetworking/plugins/blob/main/plugins/main/ptp/ptp.go
         helpers::run_command(&format!(
             "
-ip -n {prefix} link add {veth} type veth peer name eth0 netns {net}
-ip -n {prefix} link set dev {veth} up
-ip -n {prefix} addr add 10.0.0.1 dev {veth}
-ip -n {prefix} route add {ip} dev {veth} scope host
+set -ex
+ip -n {node_net} link add {veth} type veth peer name eth0 netns {net}
+ip -n {node_net} link set dev {veth} up
+ip -n {node_net} addr add 10.0.{node_id}.1 dev {veth}
+ip -n {node_net} route add {ip} dev {veth} scope host
 
 ip -n {net} link set dev lo up
 ip -n {net} link set dev eth0 up
-ip -n {net} addr add {ip}/16 dev eth0
-ip -n {net} route add default via 10.0.0.1
-ip -n {net} route add 10.0.0.1 dev eth0 scope link src {ip}
-ip -n {net} route del 10.0.0.0/16 # remove auto-kernel route
-ip -n {net} route add 10.0.0.0/16 via 10.0.0.1 src {ip}
-ip netns exec {prefix} sysctl -w net.ipv4.conf.all.rp_filter=0
-ip netns exec {prefix} sysctl -w net.ipv4.conf.{veth}.rp_filter=0
+ip -n {net} addr add {ip}/24 dev eth0
+ip -n {net} route add default via 10.0.{node_id}.1
+ip -n {net} route add 10.0.{node_id}.1 dev eth0 scope link src {ip}
+ip -n {net} route del 10.0.{node_id}.0/24 # remove auto-kernel route
+ip -n {net} route add 10.0.{node_id}.0/24 via 10.0.{node_id}.1 src {ip}
+ip netns exec {node_net} sysctl -w net.ipv4.conf.all.rp_filter=0
+ip netns exec {node_net} sysctl -w net.ipv4.conf.{veth}.rp_filter=0
 "
         ))?;
-        namespaces.insert(name.to_string(), id);
         Ok(ns)
     }
 }


### PR DESCRIPTION
* Switch to a library impl of Forwarded. The one we wrote does not handle edge cases. Added tests to cover these.
* Unconditionally append Forwarded (still useful, even if its not used by the ztunnel on the other end)
* Unconditionally spoof the outbound IP
* Only use `Forwarded` from trusted waypoint
* Allow explicitly opt in or opt out. By default, auto detect support

This aligns with https://docs.google.com/document/d/17fDTMLg-22UPfh62d5wumAOIpbeoOyWix2WTE54hDNc/edit#

I also wrote e2e tests in istio/istio; they pass with and without this PR