### PR TITLE
Add bytes received and sent to hbone connection

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -248,14 +248,15 @@ impl OutboundConnection {
                 let mut upgraded = hyper::upgrade::on(response).await?;
                 match super::copy_hbone(&mut upgraded, &mut stream)
                     .instrument(trace_span!("hbone client"))
-                    .await {
-                        Ok((sent, recv)) => {
-                            self.pi.metrics.record_count(&sent_bytes, sent);
-                            self.pi.metrics.record_count(&received_bytes, recv);
-                            Ok(())
-                        }
-                        Err(e) => Err(Error::Io(e)), 
+                    .await
+                {
+                    Ok((sent, recv)) => {
+                        self.pi.metrics.record_count(&sent_bytes, sent);
+                        self.pi.metrics.record_count(&received_bytes, recv);
+                        Ok(())
                     }
+                    Err(e) => Err(Error::Io(e)),
+                }
             }
             Protocol::TCP => {
                 info!(

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -246,10 +246,16 @@ impl OutboundConnection {
                     return Err(Error::HttpStatus(code));
                 }
                 let mut upgraded = hyper::upgrade::on(response).await?;
-                super::copy_hbone(&mut upgraded, &mut stream)
+                match super::copy_hbone(&mut upgraded, &mut stream)
                     .instrument(trace_span!("hbone client"))
-                    .await?;
-                Ok(())
+                    .await {
+                        Ok((sent, recv)) => {
+                            self.pi.metrics.record_count(&sent_bytes, sent);
+                            self.pi.metrics.record_count(&received_bytes, recv);
+                            Ok(())
+                        }
+                        Err(e) => Err(Error::Io(e)), 
+                    }
             }
             Protocol::TCP => {
                 info!(


### PR DESCRIPTION
Noticed that TCP connections opened/closed are also counted with HBONE connections.
#310 only covered read/write bytes for TCP connections.