### PR TITLE
admin: split stats into its own port

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,28 @@
+# Architecture
+
+## Threading/Runtimes
+
+Ztunnel runs two distinct async runtimes:
+* The "main" thread, runs a single threaded Tokio runtime for admin purposes, such as debug interfaces and XDS. This is isolated to avoid impacting the data plane.
+* The "worker" thread(s) run a multi-thread Tokio runtime to handle users requests. This defaults to 2 threads, but is configurable.
+
+## Ports
+
+Ztunnel runs with the following ports:
+
+| Port  | Purpose                               |
+|-------|---------------------------------------|
+| 15001 | Pod outbound traffic capture          |
+| 15006 | Pod inbound plaintext traffic capture |
+| 15008 | Pod inbound HBONE traffic capture     |
+| 15080 | Pod outbound `socks5` traffic         |
+| 15021 | Readiness                             |
+| 15000 | Admin (Admin thread) (Localhost)      |
+| 15020 | Metrics (Admin thread)                |
+
+The three admin ports (Readiness, Admin, and Metrics) are intentionally split.
+
+* The readiness port ought to run on the "main" thread to ensure we are actually checking the path the data plan handles
+* The admin port must be only on localhost, and it should be on the admin thread for isolation
+* The metrics port should be on the admin thread to avoid isolation.
+  This *could* be on the readiness port, but historically we had found that the stats query can be very expensive and lead to tail latencies in the data plane.

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -69,12 +69,7 @@ fn initialize_environment(mode: Mode) -> (Arc<Mutex<TestEnv>>, Runtime) {
             .await
             .unwrap();
 
-        let ta = TestApp {
-            admin_address: app.admin_address,
-            proxy_addresses: app.proxy_addresses,
-            readiness_address: app.readiness_address,
-            cert_manager,
-        };
+        let ta = TestApp::from((&app, cert_manager));
         ta.ready().await;
         let echo = tcp::TestServer::new(mode, 0).await;
         let echo_addr = helpers::with_ip(echo.address(), TEST_WORKLOAD_SOURCE.parse().unwrap());

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Forked from https://github.com/olix0r/kubert/blob/main/kubert/src/admin.rs
-
 use std::collections::HashMap;
 use std::{net::SocketAddr, time::Duration};
 
@@ -22,36 +20,29 @@ use drain::Watch;
 use gperftools::heap_profiler::HEAP_PROFILER;
 #[cfg(feature = "gperftools")]
 use gperftools::profiler::PROFILER;
-use hyper::server::conn::AddrIncoming;
 use hyper::{Body, Request, Response};
 use pprof::protos::Message;
 #[cfg(feature = "gperftools")]
 use tokio::fs::File;
 #[cfg(feature = "gperftools")]
 use tokio::io::AsyncReadExt;
-use tokio::sync::oneshot;
-use tracing::{error, info};
+use tracing::error;
 
 use crate::config::Config;
-use crate::hyper_util::{empty_response, plaintext_response};
+use crate::hyper_util::{empty_response, plaintext_response, Server};
 use crate::version::BuildInfo;
 use crate::workload::LocalConfig;
 use crate::workload::WorkloadInformation;
-use crate::{config, signal, telemetry};
+use crate::{signal, telemetry};
 
-/// Supports configuring an admin server
-pub struct Builder {
-    addr: SocketAddr,
-    workload_info: WorkloadInformation,
-    config: Config,
-}
-
-pub struct Server {
-    addr: SocketAddr,
-    server: hyper::server::Builder<AddrIncoming>,
+struct State {
     workload_info: WorkloadInformation,
     config: Config,
     shutdown_trigger: signal::ShutdownTrigger,
+}
+
+pub struct Service {
+    s: Server<State>,
 }
 
 #[derive(serde::Serialize, Debug, Clone)]
@@ -63,126 +54,54 @@ pub struct ConfigDump {
     config: Config,
 }
 
-impl Builder {
-    pub fn new(config: config::Config, workload_info: WorkloadInformation) -> Self {
-        Self {
-            addr: config.admin_addr,
-            workload_info,
-            config,
-        }
+impl Service {
+    pub fn new(
+        config: Config,
+        workload_info: WorkloadInformation,
+        shutdown_trigger: signal::ShutdownTrigger,
+        drain_rx: Watch,
+    ) -> hyper::Result<Self> {
+        Server::<State>::bind(
+            "admin",
+            config.admin_addr,
+            shutdown_trigger.clone(),
+            drain_rx,
+            State {
+                config,
+                workload_info,
+                shutdown_trigger,
+            },
+        )
+        .map(|s| Service { s })
     }
 
-    pub fn bind(self, shutdown_trigger: signal::ShutdownTrigger) -> hyper::Result<Server> {
-        let Self {
-            addr,
-            workload_info,
-            config,
-        } = self;
-
-        let bind = AddrIncoming::bind(&addr)?;
-        let addr = bind.local_addr();
-        let server = hyper::Server::builder(bind)
-            .http1_half_close(true)
-            .http1_header_read_timeout(Duration::from_secs(2))
-            .http1_max_buf_size(8 * 1024);
-
-        Ok(Server {
-            addr,
-            server,
-            workload_info,
-            config,
-            shutdown_trigger,
-        })
-    }
-}
-
-impl Server {
     pub fn address(&self) -> SocketAddr {
-        self.addr
+        self.s.address()
     }
 
-    pub fn spawn(self, drain_rx: Watch) {
-        let _dx = drain_rx.clone();
-        let (tx, rx) = oneshot::channel();
-        let workload_info = self.workload_info.clone();
-        let config: Config = self.config;
-        let shutdown_trigger = self.shutdown_trigger.clone();
-        let server = self
-            .server
-            .serve(hyper::service::make_service_fn(move |_conn| {
-                let workload_info = workload_info.clone();
-                let shutdown_trigger = shutdown_trigger.clone();
-                let config: Config = config.clone();
-                async move {
-                    let workload_info = workload_info.clone();
-                    Ok::<_, hyper::Error>(hyper::service::service_fn(move |req| {
-                        let workload_info = workload_info.clone();
-                        let shutdown_trigger = shutdown_trigger.clone();
-                        let config: Config = config.clone();
-
-                        let config_dump: ConfigDump = ConfigDump {
-                            workload_info,
-                            static_config: Default::default(),
-                            version: BuildInfo::new(),
-                            config,
-                        };
-                        async move {
-                            match req.uri().path() {
-                                "/debug/pprof/profile" => {
-                                    Ok::<_, hyper::Error>(handle_pprof(req).await)
-                                }
-                                "/debug/gprof/profile" => {
-                                    Ok::<_, hyper::Error>(handle_gprof(req).await)
-                                }
-                                "/debug/gprof/heap" => {
-                                    Ok::<_, hyper::Error>(handle_gprof_heap(req).await)
-                                }
-                                "/quitquitquit" => Ok::<_, hyper::Error>(
-                                    handle_server_shutdown(shutdown_trigger, req).await,
-                                ),
-                                "/config_dump" => Ok::<_, hyper::Error>(
-                                    handle_config_dump(config_dump, req).await,
-                                ),
-                                "/logging" => Ok::<_, hyper::Error>(handle_logging(req).await),
-                                _ => Ok::<_, hyper::Error>(empty_response(
-                                    hyper::StatusCode::NOT_FOUND,
-                                )),
-                            }
-                        }
-                    }))
+    pub fn spawn(self) {
+        self.s.spawn(|state, req| async move {
+            match req.uri().path() {
+                "/debug/pprof/profile" => Ok(handle_pprof(req).await),
+                "/debug/gprof/profile" => Ok(handle_gprof(req).await),
+                "/debug/gprof/heap" => Ok(handle_gprof_heap(req).await),
+                "/quitquitquit" => {
+                    Ok(handle_server_shutdown(state.shutdown_trigger.clone(), req).await)
                 }
-            }))
-            .with_graceful_shutdown(async {
-                // Wait until the drain is signaled
-                let shutdown = drain_rx.signaled().await;
-                // Once `shutdown` is dropped, we are declaring the drain is complete. Hyper will start draining
-                // once with_graceful_shutdown function exists, so we need to exit the function but later
-                // drop `shutdown`.
-                if tx.send(shutdown).is_err() {
-                    error!("admin receiver dropped")
-                }
-                info!("starting drain of admin server");
-            });
-
-        info!(
-            address=%self.addr,
-            component="admin",
-            "listener established",
-        );
-        let shutdown_trigger = self.shutdown_trigger;
-        tokio::spawn(async move {
-            if let Err(err) = server.await {
-                error!("Serving admin start failed: {err}");
-                shutdown_trigger.shutdown_now().await;
-            } else {
-                // Now that the server has gracefully exited, drop `shutdown` to allow draining to proceed
-                match rx.await {
-                    Ok(shutdown) => drop(shutdown),
-                    Err(_) => info!("admin sender dropped"),
-                }
-                info!("admin server terminated");
+                "/config_dump" => Ok(handle_config_dump(
+                    ConfigDump {
+                        workload_info: state.workload_info.clone(),
+                        static_config: Default::default(),
+                        version: BuildInfo::new(),
+                        config: state.config.clone(),
+                    },
+                    req,
+                )
+                .await),
+                "/logging" => Ok(handle_logging(req).await),
+                _ => Ok(empty_response(hyper::StatusCode::NOT_FOUND)),
             }
-        });
+        })
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
@@ -200,8 +200,9 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             .unwrap_or(DEFAULT_DRAIN_DURATION),
 
         // admin API should only be accessible over localhost
+        // todo: bind to both v4 localhost and v6
         admin_addr: SocketAddr::new(
-            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
             pc.proxy_admin_port.unwrap_or(DEFAULT_ADMIN_PORT),
         ),
         stats_addr: SocketAddr::new(

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -12,16 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use hyper::{Body, Response};
+use std::future::Future;
 use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
 
+use drain::Watch;
+use hyper::{Body, Request, Response};
 use hyper::server::conn::AddrIncoming;
-
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
 use tokio_stream::{Stream, StreamExt};
-use tracing::{debug, warn};
+use tracing::{debug, error, info, warn};
 
+use crate::signal;
 use crate::tls::{BoringTlsAcceptor, CertProvider, TlsError};
+
 pub fn tls_server<T: CertProvider + Clone + 'static>(
     acceptor: T,
     listener: TcpListener,
@@ -59,4 +66,104 @@ pub fn plaintext_response(code: hyper::StatusCode, body: String) -> Response<Bod
         .header(hyper::header::CONTENT_TYPE, "text/plain")
         .body(body.into())
         .unwrap()
+}
+
+/// Server implements a generic HTTP server with the follow behavior:
+/// * HTTP/1.1 plaintext only
+/// * Draining
+/// * Triggers the app to shutdown on errors
+pub struct Server<S> {
+    name: String,
+    addr: SocketAddr,
+    server: hyper::server::Builder<AddrIncoming>,
+    shutdown_trigger: signal::ShutdownTrigger,
+    drain_rx: Watch,
+    state: Arc<S>,
+}
+
+impl<S> Server<S> {
+    pub fn bind(
+        name: &str,
+        addr: SocketAddr,
+        shutdown_trigger: signal::ShutdownTrigger,
+        drain_rx: Watch,
+        s: S,
+    ) -> hyper::Result<Self> {
+        let bind = AddrIncoming::bind(&addr)?;
+        let addr = bind.local_addr();
+        let server = hyper::Server::builder(bind)
+            .http1_half_close(true)
+            .http1_header_read_timeout(Duration::from_secs(2))
+            .http1_max_buf_size(8 * 1024);
+
+        Ok(Server {
+            name: name.to_string(),
+            addr,
+            server,
+            shutdown_trigger,
+            drain_rx,
+            state: Arc::new(s),
+        })
+    }
+
+    pub fn address(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn spawn<F, R>(self, f: F)
+        where
+            S: Send + Sync + 'static,
+            F: Fn(Arc<S>, Request<Body>) -> R + Send + Sync+ 'static,
+            R: Future<Output = Result<Response<Body>, hyper::Error>> + Send + Sync+ 'static{
+        let drain_rx = self.drain_rx;
+        let name = self.name.clone();
+        let (tx, rx) = oneshot::channel();
+        let state = self.state.clone();
+        let f = Arc::new(f);
+        let server = self
+            .server
+            .serve(hyper::service::make_service_fn(move |_conn| {
+                let state = state.clone();
+                let f = f.clone();
+                async {
+                    Ok::<_, hyper::Error>(hyper::service::service_fn(move |req| {
+                        let state = state.clone();
+                        let fut = f(state, req);
+                        fut
+                    }))
+                }
+            }))
+            .with_graceful_shutdown(async move {
+                // Wait until the drain is signaled
+                let shutdown = drain_rx.signaled().await;
+                // Once `shutdown` is dropped, we are declaring the drain is complete. Hyper will start draining
+                // once with_graceful_shutdown function exists, so we need to exit the function but later
+                // drop `shutdown`.
+                if tx.send(shutdown).is_err() {
+                    error!("{name}: receiver dropped");
+                }
+                info!("starting drain of {name} server");
+            });
+
+        info!(
+            address=%self.addr,
+            component=self.name,
+            "listener established",
+        );
+        let shutdown_trigger = self.shutdown_trigger;
+        let name = self.name;
+        tokio::spawn(async move {
+            if let Err(err) = server.await {
+                error!("Serving {name} start failed: {err}");
+                shutdown_trigger.shutdown_now().await;
+            } else {
+                // Now that the server has gracefully exited, drop `shutdown` to allow draining to proceed
+                match rx.await {
+                    Ok(shutdown) => drop(shutdown),
+                    Err(_) => info!("{name} sender dropped"),
+                }
+                info!("{name} server terminated");
+            }
+        });
+    }
 }

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use drain::Watch;
-use hyper::{Body, Request, Response};
 use hyper::server::conn::AddrIncoming;
+use hyper::{Body, Request, Response};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use tokio_stream::{Stream, StreamExt};
@@ -111,10 +111,11 @@ impl<S> Server<S> {
     }
 
     pub fn spawn<F, R>(self, f: F)
-        where
-            S: Send + Sync + 'static,
-            F: Fn(Arc<S>, Request<Body>) -> R + Send + Sync+ 'static,
-            R: Future<Output = Result<Response<Body>, hyper::Error>> + Send + Sync+ 'static{
+    where
+        S: Send + Sync + 'static,
+        F: Fn(Arc<S>, Request<Body>) -> R + Send + Sync + 'static,
+        R: Future<Output = Result<Response<Body>, hyper::Error>> + Send + Sync + 'static,
+    {
         let drain_rx = self.drain_rx;
         let name = self.name.clone();
         let (tx, rx) = oneshot::channel();
@@ -128,8 +129,8 @@ impl<S> Server<S> {
                 async {
                     Ok::<_, hyper::Error>(hyper::service::service_fn(move |req| {
                         let state = state.clone();
-                        let fut = f(state, req);
-                        fut
+
+                        f(state, req)
                     }))
                 }
             }))

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use hyper::{Body, Response};
 use std::io;
 
 use hyper::server::conn::AddrIncoming;
@@ -43,4 +44,19 @@ pub fn tls_server<T: CertProvider + Clone + 'static>(
                 true
             }
         })
+}
+
+pub fn empty_response(code: hyper::StatusCode) -> Response<Body> {
+    Response::builder()
+        .status(code)
+        .body(Body::default())
+        .unwrap()
+}
+
+pub fn plaintext_response(code: hyper::StatusCode, body: String) -> Response<Body> {
+    Response::builder()
+        .status(code)
+        .header(hyper::header::CONTENT_TYPE, "text/plain")
+        .body(body.into())
+        .unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod rbac;
 pub mod readiness;
 pub mod signal;
 pub mod socket;
+pub mod stats;
 pub mod telemetry;
 pub mod tls;
 pub mod version;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,6 @@ fn version() -> anyhow::Result<()> {
 
 async fn proxy(cfg: config::Config) -> anyhow::Result<()> {
     info!("version: {}", version::BuildInfo::new());
-    info!("running with config: {cfg:#?}");
+    info!("running with config: {}", serde_yaml::to_string(&cfg)?);
     app::build(cfg).await?.wait_termination().await
 }

--- a/src/readiness/server.rs
+++ b/src/readiness/server.rs
@@ -12,113 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{config, readiness, signal};
+use std::net::SocketAddr;
+
 use drain::Watch;
-use hyper::server::conn::AddrIncoming;
 use hyper::{Body, Request, Response};
 use itertools::Itertools;
-use std::net::SocketAddr;
-use std::time::Duration;
-use tokio::sync::oneshot;
-use tracing::{error, info};
 
-pub struct Builder {
-    addr: SocketAddr,
-    ready: readiness::Ready,
+use crate::hyper_util::{empty_response, plaintext_response, Server};
+use crate::{config, readiness, signal};
+
+pub struct Service {
+    s: Server<readiness::Ready>,
 }
 
-impl Builder {
-    pub fn new(config: config::Config, ready: readiness::Ready) -> Self {
-        Self {
-            addr: config.readiness_addr,
-            ready,
-        }
-    }
-
-    pub fn bind(self, shutdown_trigger: signal::ShutdownTrigger) -> hyper::Result<Server> {
-        let Self { addr, ready } = self;
-
-        let bind = AddrIncoming::bind(&addr)?;
-        let addr = bind.local_addr();
-        let server = hyper::Server::builder(bind)
-            .http1_half_close(true)
-            .http1_header_read_timeout(Duration::from_secs(2))
-            .http1_max_buf_size(8 * 1024);
-
-        Ok(Server {
-            addr,
-            ready,
-            server,
+impl Service {
+    pub fn new(
+        config: config::Config,
+        ready: readiness::Ready,
+        shutdown_trigger: signal::ShutdownTrigger,
+        drain_rx: Watch,
+    ) -> hyper::Result<Self> {
+        Server::<readiness::Ready>::bind(
+            "readiness",
+            config.readiness_addr,
             shutdown_trigger,
-        })
+            drain_rx,
+            ready,
+        )
+        .map(|s| Service { s })
     }
-}
 
-pub struct Server {
-    addr: SocketAddr,
-    ready: readiness::Ready,
-    server: hyper::server::Builder<hyper::server::conn::AddrIncoming>,
-    shutdown_trigger: signal::ShutdownTrigger,
-}
-
-impl Server {
     pub fn address(&self) -> SocketAddr {
-        self.addr
+        self.s.address()
     }
 
-    pub fn spawn(self, drain_rx: Watch) {
-        let _dx = drain_rx.clone();
-        let ready = self.ready.clone();
-        let (tx, rx) = oneshot::channel();
-        let server = self
-            .server
-            .serve(hyper::service::make_service_fn(move |_conn| {
-                let ready = ready.clone();
-                async move {
-                    Ok::<_, hyper::Error>(hyper::service::service_fn(move |req| {
-                        let ready = ready.clone();
-                        async move {
-                            match req.uri().path() {
-                                "/healthz/ready" => {
-                                    Ok::<_, hyper::Error>(handle_ready(&ready, req).await)
-                                }
-                                _ => Ok::<_, hyper::Error>(
-                                    Response::builder()
-                                        .status(hyper::StatusCode::NOT_FOUND)
-                                        .body(Body::default())
-                                        .unwrap(),
-                                ),
-                            }
-                        }
-                    }))
-                }
-            }))
-            .with_graceful_shutdown(async {
-                // Wait until the drain is signaled
-                let shutdown = drain_rx.signaled().await;
-                // Once `shutdown` is dropped, we are declaring the drain is complete. Hyper will start draining
-                // once with_graceful_shutdown function exists, so we need to exit the function but later
-                // drop `shutdown`.
-                if tx.send(shutdown).is_err() {
-                    error!("readiness receiver dropped")
-                }
-                info!("starting drain of readiness server");
-            });
-        info!("Serving readiness server at {}", self.addr);
-        let shutdown_trigger = self.shutdown_trigger;
-        tokio::spawn(async move {
-            if let Err(err) = server.await {
-                error!("Serving readiness start failed: {err}");
-                shutdown_trigger.shutdown_now().await;
-            } else {
-                // Now that the server has gracefully exited, drop `shutdown` to allow draining to proceed
-                match rx.await {
-                    Ok(shutdown) => drop(shutdown),
-                    Err(_) => info!("readiness server sender dropped"),
-                }
-                info!("readiness server terminated");
+    pub fn spawn(self) {
+        self.s.spawn(|ready, req| async move {
+            match req.uri().path() {
+                "/healthz/ready" => Ok(handle_ready(&ready, req).await),
+                _ => Ok(empty_response(hyper::StatusCode::NOT_FOUND)),
             }
-        });
+        })
     }
 }
 
@@ -139,19 +73,4 @@ async fn handle_ready(ready: &readiness::Ready, req: Request<Body>) -> Response<
         }
         _ => empty_response(hyper::StatusCode::METHOD_NOT_ALLOWED),
     }
-}
-
-fn empty_response(code: hyper::StatusCode) -> Response<Body> {
-    Response::builder()
-        .status(code)
-        .body(Body::default())
-        .unwrap()
-}
-
-fn plaintext_response(code: hyper::StatusCode, body: String) -> Response<Body> {
-    Response::builder()
-        .status(code)
-        .header(hyper::header::CONTENT_TYPE, "text/plain")
-        .body(body.into())
-        .unwrap()
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,156 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Forked from https://github.com/olix0r/kubert/blob/main/kubert/src/admin.rs
+
+use std::sync::Mutex;
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use drain::Watch;
+use hyper::server::conn::AddrIncoming;
+use hyper::{Body, Request, Response};
+use prometheus_client::encoding::text::encode;
+use prometheus_client::registry::Registry;
+use tokio::sync::oneshot;
+use tracing::{error, info};
+
+use crate::config::Config;
+
+use crate::hyper_util::empty_response;
+use crate::signal;
+
+/// Supports configuring an admin server
+pub struct Builder {
+    addr: SocketAddr,
+}
+
+pub struct Server {
+    addr: SocketAddr,
+    server: hyper::server::Builder<AddrIncoming>,
+    registry: Arc<Mutex<Registry>>,
+    shutdown_trigger: signal::ShutdownTrigger,
+}
+
+impl Builder {
+    pub fn new(config: Config) -> Self {
+        Self {
+            addr: config.stats_addr,
+        }
+    }
+
+    pub fn bind(
+        self,
+        registry: Registry,
+        shutdown_trigger: signal::ShutdownTrigger,
+    ) -> hyper::Result<Server> {
+        let Self { addr } = self;
+
+        let bind = AddrIncoming::bind(&addr)?;
+        let addr = bind.local_addr();
+        let server = hyper::Server::builder(bind)
+            .http1_half_close(true)
+            .http1_header_read_timeout(Duration::from_secs(2))
+            .http1_max_buf_size(8 * 1024);
+        let registry = Arc::new(Mutex::new(registry));
+
+        Ok(Server {
+            addr,
+            server,
+            registry,
+            shutdown_trigger,
+        })
+    }
+}
+
+impl Server {
+    pub fn registry(&self) -> Arc<Mutex<Registry>> {
+        Arc::clone(&self.registry)
+    }
+
+    pub fn address(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn spawn(self, drain_rx: Watch) {
+        let _dx = drain_rx.clone();
+        let (tx, rx) = oneshot::channel();
+        let registry = self.registry.clone();
+        let server = self
+            .server
+            .serve(hyper::service::make_service_fn(move |_conn| {
+                let registry = registry.clone();
+                async move {
+                    Ok::<_, hyper::Error>(hyper::service::service_fn(move |req| {
+                        let registry = registry.clone();
+                        async move {
+                            match req.uri().path() {
+                                "/metrics" => {
+                                    Ok::<_, hyper::Error>(handle_metrics(registry, req).await)
+                                }
+                                _ => Ok::<_, hyper::Error>(empty_response(
+                                    hyper::StatusCode::NOT_FOUND,
+                                )),
+                            }
+                        }
+                    }))
+                }
+            }))
+            .with_graceful_shutdown(async {
+                // Wait until the drain is signaled
+                let shutdown = drain_rx.signaled().await;
+                // Once `shutdown` is dropped, we are declaring the drain is complete. Hyper will start draining
+                // once with_graceful_shutdown function exists, so we need to exit the function but later
+                // drop `shutdown`.
+                if tx.send(shutdown).is_err() {
+                    error!("stats receiver dropped")
+                }
+                info!("starting drain of stats server");
+            });
+
+        info!(
+            address=%self.addr,
+            component="stats",
+            "listener established",
+        );
+        let shutdown_trigger = self.shutdown_trigger;
+        tokio::spawn(async move {
+            if let Err(err) = server.await {
+                error!("Serving stats start failed: {err}");
+                shutdown_trigger.shutdown_now().await;
+            } else {
+                // Now that the server has gracefully exited, drop `shutdown` to allow draining to proceed
+                match rx.await {
+                    Ok(shutdown) => drop(shutdown),
+                    Err(_) => info!("stats sender dropped"),
+                }
+                info!("stats server terminated");
+            }
+        });
+    }
+}
+
+async fn handle_metrics(reg: Arc<Mutex<Registry>>, _req: Request<Body>) -> Response<Body> {
+    let mut buf = String::new();
+    let reg = reg.lock().unwrap();
+    encode(&mut buf, &reg).unwrap();
+
+    Response::builder()
+        .status(hyper::StatusCode::OK)
+        .header(
+            hyper::header::CONTENT_TYPE,
+            "application/openmetrics-text;charset=utf-8;version=1.0.0",
+        )
+        .body(Body::from(buf))
+        .unwrap()
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -12,131 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Forked from https://github.com/olix0r/kubert/blob/main/kubert/src/admin.rs
-
 use std::sync::Mutex;
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc};
 
 use drain::Watch;
-use hyper::server::conn::AddrIncoming;
 use hyper::{Body, Request, Response};
 use prometheus_client::encoding::text::encode;
 use prometheus_client::registry::Registry;
-use tokio::sync::oneshot;
-use tracing::{error, info};
 
 use crate::config::Config;
-
-use crate::hyper_util::empty_response;
+use crate::hyper_util::{empty_response, Server};
 use crate::signal;
 
-/// Supports configuring an admin server
-pub struct Builder {
-    addr: SocketAddr,
+pub struct Service {
+    s: Server<Mutex<Registry>>,
 }
 
-pub struct Server {
-    addr: SocketAddr,
-    server: hyper::server::Builder<AddrIncoming>,
-    registry: Arc<Mutex<Registry>>,
-    shutdown_trigger: signal::ShutdownTrigger,
-}
-
-impl Builder {
-    pub fn new(config: Config) -> Self {
-        Self {
-            addr: config.stats_addr,
-        }
-    }
-
-    pub fn bind(
-        self,
+impl Service {
+    pub fn new(
+        config: Config,
         registry: Registry,
         shutdown_trigger: signal::ShutdownTrigger,
-    ) -> hyper::Result<Server> {
-        let Self { addr } = self;
-
-        let bind = AddrIncoming::bind(&addr)?;
-        let addr = bind.local_addr();
-        let server = hyper::Server::builder(bind)
-            .http1_half_close(true)
-            .http1_header_read_timeout(Duration::from_secs(2))
-            .http1_max_buf_size(8 * 1024);
-        let registry = Arc::new(Mutex::new(registry));
-
-        Ok(Server {
-            addr,
-            server,
-            registry,
+        drain_rx: Watch,
+    ) -> hyper::Result<Self> {
+        Server::<Mutex<Registry>>::bind(
+            "stats",
+            config.stats_addr,
             shutdown_trigger,
-        })
-    }
-}
-
-impl Server {
-    pub fn registry(&self) -> Arc<Mutex<Registry>> {
-        Arc::clone(&self.registry)
+            drain_rx,
+            Mutex::new(registry),
+        )
+        .map(|s| Service { s })
     }
 
     pub fn address(&self) -> SocketAddr {
-        self.addr
+        self.s.address()
     }
 
-    pub fn spawn(self, drain_rx: Watch) {
-        let _dx = drain_rx.clone();
-        let (tx, rx) = oneshot::channel();
-        let registry = self.registry.clone();
-        let server = self
-            .server
-            .serve(hyper::service::make_service_fn(move |_conn| {
-                let registry = registry.clone();
-                async move {
-                    Ok::<_, hyper::Error>(hyper::service::service_fn(move |req| {
-                        let registry = registry.clone();
-                        async move {
-                            match req.uri().path() {
-                                "/metrics" => {
-                                    Ok::<_, hyper::Error>(handle_metrics(registry, req).await)
-                                }
-                                _ => Ok::<_, hyper::Error>(empty_response(
-                                    hyper::StatusCode::NOT_FOUND,
-                                )),
-                            }
-                        }
-                    }))
-                }
-            }))
-            .with_graceful_shutdown(async {
-                // Wait until the drain is signaled
-                let shutdown = drain_rx.signaled().await;
-                // Once `shutdown` is dropped, we are declaring the drain is complete. Hyper will start draining
-                // once with_graceful_shutdown function exists, so we need to exit the function but later
-                // drop `shutdown`.
-                if tx.send(shutdown).is_err() {
-                    error!("stats receiver dropped")
-                }
-                info!("starting drain of stats server");
-            });
-
-        info!(
-            address=%self.addr,
-            component="stats",
-            "listener established",
-        );
-        let shutdown_trigger = self.shutdown_trigger;
-        tokio::spawn(async move {
-            if let Err(err) = server.await {
-                error!("Serving stats start failed: {err}");
-                shutdown_trigger.shutdown_now().await;
-            } else {
-                // Now that the server has gracefully exited, drop `shutdown` to allow draining to proceed
-                match rx.await {
-                    Ok(shutdown) => drop(shutdown),
-                    Err(_) => info!("stats sender dropped"),
-                }
-                info!("stats server terminated");
+    pub fn spawn(self) {
+        self.s.spawn(|registry, req| async move {
+            match req.uri().path() {
+                "/metrics" => Ok(handle_metrics(registry, req).await),
+                _ => Ok(empty_response(hyper::StatusCode::NOT_FOUND)),
             }
-        });
+        })
     }
 }
 

--- a/src/test_helpers/components.rs
+++ b/src/test_helpers/components.rs
@@ -84,7 +84,9 @@ impl WorkloadManager {
             let app = crate::app::build_with_cert(cfg, cert_manager.clone()).await?;
 
             let ta = TestApp {
+                // Not actually accessible
                 admin_address: helpers::with_ip(app.admin_address, ip),
+                stats_address: helpers::with_ip(app.stats_address, ip),
                 proxy_addresses: proxy::Addresses {
                     outbound: helpers::with_ip(app.proxy_addresses.outbound, ip),
                     inbound: helpers::with_ip(app.proxy_addresses.inbound, ip),


### PR DESCRIPTION
Finishes https://github.com/istio/ztunnel/issues/78

This moves stats to its own port. This was a pretty small change but ended up refactoring out the server logic since we were copy+pasting 100s of lines of code 3 times.


In Istio, we just need to change 1 spot that refers to the old port.