### PR TITLE
Fix loopback connections with direct inbound proxy and enable transparent socket: true

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -317,7 +317,7 @@ pub async fn freebind_connect(local: Option<IpAddr>, addr: SocketAddr) -> io::Re
             }
             // TODO: Need figure out how to handle case of loadbalancing to itself.
             //       We use ztunnel addr instead, otherwise app side will be confused.
-            Some(src) if src == socket::to_canonical(addr).ip() => {
+            Some(src) if src == socket::to_canonical(addr).ip() || addr.ip().is_loopback() => {
                 trace!(%src, dest=%addr, "dest and source are the same, connect directly");
                 Ok(TcpStream::connect(addr).await?)
             }


### PR DESCRIPTION
Fix loopback connections with direct inbound proxy and enable transparent socket: true

in https://github.com/istio/ztunnel/pull/333 the default behavior is now to unconditionally spoof the outbound IP. this does not work if the outbound ip is loopback, like it used to before this default was changed. this PR fixes that scenario so ztunnel can proxy to itself if there was a good reason to (e.g. in integration tests)