### PR TITLE
Clean up identity mock code

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -64,7 +64,7 @@ fn initialize_environment(mode: Mode) -> (Arc<Mutex<TestEnv>>, Runtime) {
         .unwrap();
     // Global setup: spin up an echo server and ztunnel instance
     let (env, _) = rt.block_on(async move {
-        let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(10));
+        let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
         let app = app::build_with_cert(test_helpers::test_config(), cert_manager.clone())
             .await
             .unwrap();

--- a/src/app.rs
+++ b/src/app.rs
@@ -132,7 +132,7 @@ pub async fn build_with_cert(
 
 pub async fn build(config: config::Config) -> anyhow::Result<Bound> {
     if config.fake_ca {
-        let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(86400));
+        let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(86400));
         build_with_cert(config, cert_manager).await
     } else {
         let cert_manager = identity::SecretManager::new(config.clone())?;

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod caclient;
-
-pub use caclient::*;
-use std::str::Utf8Error;
-pub mod manager;
-pub use manager::*;
-pub mod auth;
-
 use crate::tls;
+use std::str::Utf8Error;
+
+mod caclient;
+pub use caclient::*;
+
+mod manager;
+pub use manager::*;
+
+mod auth;
 pub use auth::*;
+
+pub mod mock {
+    pub use super::caclient::mock::CaClient;
+    pub use super::manager::mock::new_secret_manager;
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -98,6 +98,40 @@ impl CertificateProvider for CaClient {
     }
 }
 
+pub mod mock {
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+
+    use crate::identity::{CertificateProvider, Identity};
+    use crate::tls::{generate_test_certs, Certs};
+
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    pub struct CaClient {
+        pub cert_lifetime: Duration,
+    }
+
+    #[async_trait]
+    impl CertificateProvider for CaClient {
+        async fn fetch_certificate(&self, id: &Identity) -> Result<Certs, Error> {
+            let certs = generate_test_certs(
+                &id.clone().into(),
+                Duration::from_secs(0),
+                self.cert_lifetime,
+            );
+            return Ok(certs);
+        }
+    }
+
+    impl CaClient {
+        pub fn new(cert_lifetime: Duration) -> CaClient {
+            CaClient { cert_lifetime }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -518,7 +518,7 @@ mod tests {
         };
         let outbound = OutboundConnection {
             pi: ProxyInputs {
-                cert_manager: Box::new(identity::mock::MockCaClient::new(Duration::from_secs(10))),
+                cert_manager: Box::new(identity::mock::new_secret_manager(Duration::from_secs(10))),
                 workloads: wi,
                 hbone_port: 15008,
                 cfg,

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -26,7 +26,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpSocket, TcpStream};
 
 use crate::app::Bound;
-use crate::identity::mock::MockCaClient;
+use crate::identity::mock::CaClient as MockCaClient;
 use crate::identity::SecretManager;
 use crate::test_helpers::TEST_WORKLOAD_SOURCE;
 use crate::*;
@@ -60,7 +60,7 @@ where
     Fut: Future<Output = FO>,
 {
     initialize_telemetry();
-    let cert_manager = MockCaClient::new(Duration::from_secs(10));
+    let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
     let app = app::build_with_cert(cfg, cert_manager.clone())
         .await
         .unwrap();

--- a/src/test_helpers/components.rs
+++ b/src/test_helpers/components.rs
@@ -81,7 +81,7 @@ impl WorkloadManager {
         // Setup the ztunnel...
         ns.run_ready(move |ready| async move {
             helpers::run_command(&format!("scripts/ztunnel-redirect.sh {ip} {waypoints}"))?;
-            let cert_manager = identity::mock::MockCaClient::new(Duration::from_secs(10));
+            let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
             let app = crate::app::build_with_cert(cfg, cert_manager.clone()).await?;
 
             let ta = TestApp {

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -23,7 +23,7 @@ use tokio::net::TcpStream;
 use tokio::time;
 use tokio::time::timeout;
 
-use ztunnel::identity::mock::MockCaClient;
+use ztunnel::identity::mock::new_secret_manager;
 
 use ztunnel::test_helpers::app as testapp;
 use ztunnel::test_helpers::app::TestApp;
@@ -87,7 +87,7 @@ async fn test_conflicting_bind_error_admin() {
 async fn test_shutdown_drain() {
     helpers::initialize_telemetry();
 
-    let cert_manager = MockCaClient::new(Duration::from_secs(10));
+    let cert_manager = new_secret_manager(Duration::from_secs(10));
     let app = ztunnel::app::build_with_cert(test_config(), cert_manager.clone())
         .await
         .unwrap();
@@ -129,7 +129,7 @@ async fn test_shutdown_forced_drain() {
     let mut cfg = test_config();
     cfg.termination_grace_period = Duration::from_millis(10);
 
-    let cert_manager = MockCaClient::new(Duration::from_secs(10));
+    let cert_manager = new_secret_manager(Duration::from_secs(10));
     let app = ztunnel::app::build_with_cert(cfg, cert_manager.clone())
         .await
         .unwrap();


### PR DESCRIPTION
 - Move MockCaClient to caclient.rs
 - Get rid of the "Mock" prefix when inside the mock module
 - Unexport identity submodules, they are an implementation detail
 - Add a mock::new_secret_manager function to construct SecretManager<MockCaClient>, having MockCaClient::new return a SecretManager is confusing