### PR TITLE
Implement prioritized certificate fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,6 +1643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7685ca4cc0b3ad748c22ce6803e23b55b9206ef7715b965ebeaf41639238fdc"
+dependencies = [
+ "autocfg",
+ "indexmap",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,6 +2885,7 @@ dependencies = [
  "netns-rs",
  "once_cell",
  "pprof",
+ "priority-queue",
  "prometheus-client",
  "prometheus-parse",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ socket2 = "0.4.7"
 byteorder = "1.3.4"
 thiserror = "1.0.38"
 tls-listener = { version  = "0.6.0", features = ["hyper-h2"] }
-tokio = {"version"= "1", features=["full"]}
+tokio = {"version"= "1", features=["full", "test-util"]}
 tokio-boring = { version = "2.1.5" }
 tokio-stream = "0.1.9"
 tonic = { version = "0.8", default-features=false, features = ["channel", "transport", "prost", "codegen"]}
@@ -68,6 +68,7 @@ ipnet = { version = "2.7.0", features = ["serde"] }
 http-types = { version = "2.12.0", default-features = false }
 netns-rs = "0.1.0"
 textnonce = { version = "1.0.0" }
+priority-queue = "1.3.0"
 
 [build-dependencies]
 tonic-build = { version = "0.8", default-features=false, features = ["prost"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1501,6 +1501,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9c6be70d989d21a136eb86c2d83e4b328447fac4a88dace2143c179c86267"
+dependencies = [
+ "autocfg",
+ "indexmap",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,6 +2671,7 @@ dependencies = [
  "netns-rs",
  "once_cell",
  "pprof",
+ "priority-queue",
  "prometheus-client",
  "prometheus-parse",
  "prost",

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -29,7 +29,7 @@ pub mod mock {
     pub use super::manager::mock::new_secret_manager;
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
     #[error("failed to create CSR: {0}")]
     Signing(#[from] tls::Error),

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -177,7 +177,8 @@ pub mod mock {
             let not_before = self
                 .cfg
                 .time_conv
-                .instant_to_system_time(Instant::now().into());
+                .instant_to_system_time(Instant::now().into())
+                .expect("SystemTime cannot represent current time. Was the process started in extreme future?");
             let not_after = not_before + self.cfg.cert_lifetime;
 
             let certs = generate_test_certs_at(&id.clone().into(), not_before, not_after);

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -99,35 +99,91 @@ impl CertificateProvider for CaClient {
 }
 
 pub mod mock {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use async_trait::async_trait;
+    use tokio::sync::RwLock;
+    use tokio::time::Instant;
 
     use crate::identity::{CertificateProvider, Identity};
-    use crate::tls::{generate_test_certs, Certs};
+    use crate::tls::{generate_test_certs_at, Certs};
 
     use super::*;
 
-    #[derive(Clone, Debug)]
-    pub struct CaClient {
+    #[derive(Default)]
+    struct ClientState {
+        fetches: Vec<Identity>,
+    }
+
+    #[derive(Clone)]
+    pub struct ClientConfig {
         pub cert_lifetime: Duration,
+        pub time_conv: crate::time::Converter,
+        // If non-zero, causes fetch_certificate calls to sleep for the specified duration before
+        // returning. This is helpful to let tests that pause tokio time get more control over code
+        // execution.
+        pub fetch_latency: Duration,
+    }
+
+    impl Default for ClientConfig {
+        fn default() -> Self {
+            Self {
+                fetch_latency: Duration::ZERO,
+                cert_lifetime: Duration::from_secs(10),
+                time_conv: crate::time::Converter::new(),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct CaClient {
+        cfg: ClientConfig,
+        state: Arc<RwLock<ClientState>>,
+    }
+
+    impl CaClient {
+        pub fn new(cfg: ClientConfig) -> CaClient {
+            CaClient {
+                cfg,
+                state: Default::default(),
+            }
+        }
+
+        pub fn cert_lifetime(&self) -> Duration {
+            self.cfg.cert_lifetime
+        }
+
+        // Returns a list of fetch_certificate calls, in the order they happened. Calls are added
+        // just before the function returns (ie. after the potential sleep controlled by the
+        // fetch_latency config option).
+        pub async fn fetches(&self) -> Vec<Identity> {
+            self.state.read().await.fetches.clone()
+        }
+
+        pub async fn clear_fetches(&self) {
+            self.state.write().await.fetches.clear();
+        }
     }
 
     #[async_trait]
     impl CertificateProvider for CaClient {
         async fn fetch_certificate(&self, id: &Identity) -> Result<Certs, Error> {
-            let certs = generate_test_certs(
-                &id.clone().into(),
-                Duration::from_secs(0),
-                self.cert_lifetime,
-            );
-            return Ok(certs);
-        }
-    }
+            if self.cfg.fetch_latency != Duration::ZERO {
+                tokio::time::sleep(self.cfg.fetch_latency).await;
+            }
 
-    impl CaClient {
-        pub fn new(cert_lifetime: Duration) -> CaClient {
-            CaClient { cert_lifetime }
+            // Get SystemTime::now() via Instant::now() to allow mocking in tests.
+            let not_before = self
+                .cfg
+                .time_conv
+                .instant_to_system_time(Instant::now().into());
+            let not_after = not_before + self.cfg.cert_lifetime;
+
+            let certs = generate_test_certs_at(&id.clone().into(), not_before, not_after);
+
+            self.state.write().await.fetches.push(id.clone());
+            return Ok(certs);
         }
     }
 }

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::Write;
 use std::str::FromStr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
-use tokio::sync::watch;
-use tokio::time::{sleep, Duration};
-use tracing::{debug, instrument};
-use tracing::{info, warn};
+use tokio::sync::{mpsc, watch, Mutex};
+use tokio::time::{sleep_until, Duration, Instant};
 
-use crate::identity::Error::Spiffe;
 use crate::tls;
 
-use super::Error;
+use super::Error::{self, Spiffe};
 use super::{CaClient, CertificateProvider};
 
 const CERT_REFRESH_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(60);
@@ -100,140 +98,341 @@ impl Default for Identity {
     }
 }
 
+#[derive(PartialOrd, PartialEq, Eq, Ord, Debug)]
+pub enum Priority {
+    // Needs to be in the order of the lowest priority.
+    Background,
+    Warmup,
+    RealTime,
+}
+
+enum CertState {
+    // Should happen only on the first request for an Identity.
+    Initializing,
+    Available(tls::Certs),
+    // The last attempt to fetch the certificate has failed and there is no previous certificate
+    // available.
+    //
+    // In the future it may also mean that the last available certificate has expired. Note that
+    // this shouldn't change the semantics, strictly speaking - there always is a chance that the
+    // certificate will expire before it is used by the caller.
+    Unavailable(Error),
+}
+
+// Represents a watch::channel storing the certificate state. Contains None only during the first
+// request to the CertificateProvider.
+struct CertChannel {
+    rx: watch::Receiver<CertState>,
+    // This struct is referenced by SecretManager, it contains both channel ends: the receiver
+    // (used on the SecretManager side) and the sender (used by the background refreshing task).
+    // While this makes the code simpler, do note that it makes it impossible to use sender closure
+    // as an indication of the background task failing.
+    tx: watch::Sender<CertState>,
+}
+
+#[derive(Eq, PartialEq)]
+struct PendingPriority(Priority, Instant);
+
+impl Ord for PendingPriority {
+    // Lexicographical comparison but reverse the second component (Instant).
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.0.cmp(&other.0) {
+            Ordering::Equal => other.1.cmp(&self.1),
+            ne => ne,
+        }
+    }
+}
+
+impl PartialOrd for PendingPriority {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// Implements the actual logic behind SecretManager.
+struct Worker<C: CertificateProvider> {
+    client: C,
+    // For now, certificates contain SystemTime so we need to convert it to Instant. Using Converter
+    // allows us to work on Instants without referring to the current SystemTime, which allows for
+    // time control in unit tests.
+    //
+    // TODO: Change tls::Certs to use Instant instead of SystemTime.
+    time_conv: crate::time::Converter,
+    // Maps Identity to the certificate state.
+    certs: Mutex<HashMap<Identity, CertChannel>>,
+    // How many concurrent fetch_certificate calls can be pending at a time.
+    concurrency: u16,
+}
+
+impl<C: CertificateProvider> Worker<C> {
+    fn new(
+        client: C,
+        requests: mpsc::Receiver<(Identity, Priority)>,
+        cfg: SecretManagerConfig,
+    ) -> (Arc<Self>, tokio::task::JoinHandle<()>) {
+        if cfg.concurrency == 0 {
+            panic!("concurrency cannot be 0, operations would block forever");
+        }
+        let worker = Arc::new(Self {
+            client,
+            time_conv: cfg.time_conv,
+            concurrency: cfg.concurrency,
+            certs: Default::default(),
+        });
+
+        // Process requests in the background. The task will terminate on its own when the
+        // identities channel is dropped.
+        let w = worker.clone();
+        (worker, tokio::spawn(async move { w.run(requests).await }))
+    }
+
+    // Manages certificate updates. Since all the work is done in a single task, the code is
+    // lock-free. This is OK as the code is I/O bound so we don't need the extra parallelism.
+    async fn run(&self, mut requests: mpsc::Receiver<(Identity, Priority)>) {
+        use futures::stream::FuturesUnordered;
+        use futures::StreamExt;
+        use priority_queue::PriorityQueue;
+
+        // A set of futures refreshing the certificates. Each future completes with the identity for
+        // which it was invoked and a resulting certificate or error.
+        let mut workers = FuturesUnordered::new();
+        // The set of identities for which there are pending requests. Elements of workers and
+        // processing correspond to each other.
+        let mut processing = HashSet::new();
+        // Identities for which we will need to refresh certificates in the future, ordered by the
+        // priority and time at which the refresh needs to happen.
+        //
+        // Note that while the sorting criteria may seem too simple, it is in fact correct due to
+        // the specifics of values inserted. Only Background priority items are ever inserted into
+        // the future, for all other priorities Instant::now() is used as the scheduled time of the
+        // refresh. In other words, at any point in time, there are no high-priority
+        // (not Background) items scheduled to run in the future.
+        let mut pending: PriorityQueue<Identity, PendingPriority> = PriorityQueue::new();
+
+        'main: loop {
+            let next = pending.peek().map(|(_, PendingPriority(_, ts))| *ts);
+            tokio::select! {
+                res = requests.recv() => match res {
+                    Some((id, pri)) => {
+                        if !processing.contains(&id) {
+                            pending.push_increase(id, PendingPriority(pri, Instant::now()));
+                        }
+                    },
+                    None => {
+                        break 'main
+                    },
+                },
+                Some(res) = workers.next() => match res {
+                    Err(_) => break 'main,
+                    Ok((id, certs)) => {
+                        processing.remove(&id);
+                        let refresh_at = match certs {
+                            None => Instant::now() + CERT_REFRESH_FAILURE_RETRY_DELAY,
+                            Some(certs) => {
+                                let certs: tls::Certs = certs; // Type annotation.
+                                self.time_conv.system_time_to_instant(certs.refresh_at()).into()
+                            },
+                        };
+                        // TODO: Add some jitter.
+                        pending.push_increase(id, PendingPriority(Priority::Background, refresh_at));
+                    },
+                },
+                true = maybe_sleep_until(next), if workers.len() < self.concurrency as usize => {
+                    let (id, _) = pending.pop().unwrap();
+                    processing.insert(id.clone());
+                    workers.push(self.refresh(id.clone()));
+                },
+            };
+        }
+        // SecretManager dropped, drain remaining requests and terminate background processing.
+        while let Some(_) = workers.next().await {}
+    }
+
+    async fn refresh(
+        &self,
+        id: Identity,
+    ) -> Result<(Identity, Option<tls::Certs>), watch::error::SendError<CertState>> {
+        let (state, res) = match self.client.fetch_certificate(&id).await {
+            Ok(certs) => (CertState::Available(certs.clone()), Some(certs)),
+            Err(err) => (CertState::Unavailable(err), None),
+        };
+        match self.update_certs(&id, state).await {
+            Err(e) => Err(e),
+            Ok(()) => Ok((id, res)),
+        }
+    }
+
+    // Fails if nobody is listening, ie. the SecretManager is no more. Should trigger background
+    // processing shutdown in such case.
+    async fn update_certs(
+        &self,
+        id: &Identity,
+        certs: CertState,
+    ) -> Result<(), watch::error::SendError<CertState>> {
+        let all_certs = self.certs.lock().await;
+        let state = all_certs.get(id).unwrap();
+        state.tx.send(certs)
+    }
+}
+
+// tokio::select evaluates each pattern before checking the (optional) associated condition. Work
+// around that by returning false to fail the pattern match when sleep is not viable.
+async fn maybe_sleep_until(till: Option<Instant>) -> bool {
+    match till {
+        Some(till) => {
+            sleep_until(till).await;
+            true
+        }
+        None => false,
+    }
+}
+
+pub struct SecretManagerConfig {
+    time_conv: crate::time::Converter,
+    concurrency: u16,
+}
+
 /// SecretManager provides a wrapper around a CertificateProvider with caching.
 /// It is designed to be cheap to clone.
 #[derive(Clone)]
-pub struct SecretManager<C: CertificateProvider>
-where
-    C: Clone,
-{
-    client: C,
-    cache: Arc<RwLock<HashMap<Identity, watch::Receiver<Option<tls::Certs>>>>>,
+pub struct SecretManager<C: CertificateProvider> {
+    worker: Arc<Worker<C>>,
+    // Channel to which certificate requests are sent to. The Identity for which request is being
+    // sent for must have a corresponding entry in the worker's certs map (which is where the
+    // result can be read from).
+    requests: mpsc::Sender<(Identity, Priority)>,
+}
+
+impl<T: CertificateProvider> SecretManager<T> {
+    pub fn new_with_client(client: T) -> Self {
+        Self::new_internal(
+            client,
+            SecretManagerConfig {
+                time_conv: crate::time::Converter::new(),
+                concurrency: 8,
+            },
+        )
+        .0
+    }
+
+    fn new_internal(client: T, cfg: SecretManagerConfig) -> (Self, tokio::task::JoinHandle<()>) {
+        let (tx, rx) = mpsc::channel(10);
+        let (worker, handle) = Worker::new(client, rx, cfg);
+        (
+            Self {
+                worker,
+                requests: tx,
+            },
+            handle,
+        )
+    }
+
+    async fn start_fetch(
+        &self,
+        id: &Identity,
+        pri: Priority,
+    ) -> Result<watch::Receiver<CertState>, Error> {
+        let mut certs = self.worker.certs.lock().await;
+        match certs.get(id) {
+            // Identity found in cache and is already being refreshed.
+            Some(st) => Ok(st.rx.clone()),
+            // New identity, start managing it and return the newly created channel.
+            None => {
+                let (tx, rx) = watch::channel(CertState::Initializing);
+                certs.insert(id.clone(), CertChannel { rx: rx.clone(), tx });
+                drop(certs);
+                // Notify the background worker to start refreshing the certificate.
+                match self.requests.send((id.clone(), pri)).await {
+                    // Note that this should not happen, the background worker is expected to be
+                    // running.
+                    //
+                    // TODO: Better error propagation.
+                    Err(_) => Err(Error::EmptyResponse(id.clone())),
+                    Ok(()) => Ok(rx),
+                }
+            }
+        }
+    }
+
+    async fn wait(
+        &self,
+        id: &Identity,
+        mut rx: watch::Receiver<CertState>,
+    ) -> Result<tls::Certs, Error> {
+        tokio::select! {
+            // Wait for the initial value if not ready yet.
+            res = rx.changed() => match res {
+                Err(_) => Err(Error::EmptyResponse(id.clone())),
+                Ok(()) => match *rx.borrow() {
+                    CertState::Unavailable(ref err) => Err(err.clone()),
+                    CertState::Available(ref certs) => Ok(certs.clone()),
+                    CertState::Initializing => unreachable!("Only the initial state can be Initializing, but the state has changed"),
+                },
+            },
+            // Fail if the background worker died. Ideally we'd detect it by rx.changed() failing
+            // above, but making sure that senders are owned by the background worker (and so drop
+            // on panic/other error) complicates the code.
+            _ = self.requests.closed() => Err(Error::EmptyResponse(id.clone())),
+        }
+    }
+
+    pub async fn fetch_certificate_pri(
+        &self,
+        id: &Identity,
+        pri: Priority,
+    ) -> Result<tls::Certs, Error> {
+        // This method is intentionally left simple, since since unit tests are based on start_fetch
+        // and wait. Any changes should go to one of those two methods, and if that proves
+        // impossible - unit testing strategy may need to be rethinked.
+        self.wait(id, self.start_fetch(id, pri).await?).await
+    }
+}
+
+#[async_trait]
+impl<T: CertificateProvider + Clone> CertificateProvider for SecretManager<T> {
+    async fn fetch_certificate(&self, id: &Identity) -> Result<tls::Certs, Error> {
+        self.fetch_certificate_pri(id, Priority::RealTime).await
+    }
 }
 
 impl SecretManager<CaClient> {
     pub fn new(cfg: crate::config::Config) -> Result<Self, Error> {
         let caclient = CaClient::new(cfg.ca_address.unwrap(), cfg.ca_root_cert.clone(), cfg.auth)?;
-        let cache: HashMap<Identity, watch::Receiver<Option<tls::Certs>>> = Default::default();
-        Ok(Self {
-            client: caclient,
-            cache: Arc::new(RwLock::new(cache)),
-        })
-    }
-}
-
-impl<T: CertificateProvider + Clone> SecretManager<T> {
-    async fn refresh_handler(&self, id: Identity, tx: watch::Sender<Option<tls::Certs>>) {
-        loop {
-            let sleep_dur = match self.client.fetch_certificate(&id).await {
-                Err(err) => {
-                    warn!(identity=%id, ?err, "fail cert refresh");
-                    let mut write_locked_cache = self.cache.write().unwrap();
-                    let Some(certs_rx) = write_locked_cache.get(&id) else {
-                        // Should not be possible, but if there is no receiver
-                        // in the cache, then no one is using these certs that
-                        // are being refreshed, so let's stop refreshing them.
-                        return;
-                    };
-
-                    let certs_op = certs_rx.borrow().clone();
-                    if certs_op.is_none() || certs_op.unwrap().is_expired() {
-                        write_locked_cache.remove(&id);
-                        return;
-                    }
-                    CERT_REFRESH_FAILURE_RETRY_DELAY
-                }
-                Ok(fetched_certs) => {
-                    match tx.send(Some(fetched_certs.clone())) {
-                        Err(_) => {
-                            // This means no receivers left. Should not be possible.
-                            let mut locked_cache = self.cache.write().unwrap();
-                            locked_cache.remove(&id);
-                            return;
-                        }
-                        Ok(_) => {
-                            info!(identity=%id, "refreshed certs");
-                        }
-                    }
-                    fetched_certs.get_duration_until_refresh()
-                }
-            };
-            sleep(sleep_dur).await;
-        }
-    }
-}
-
-#[async_trait]
-impl<T: CertificateProvider + Clone + Send + 'static> CertificateProvider for SecretManager<T> {
-    #[instrument(skip_all, fields(%id))]
-    async fn fetch_certificate(&self, id: &Identity) -> Result<tls::Certs, Error> {
-        let mut cache_rx;
-        {
-            let read_locked_cache = self.cache.read().unwrap();
-            match read_locked_cache.get(id) {
-                None => {
-                    drop(read_locked_cache);
-                    let mut write_locked_cache = self.cache.write().unwrap();
-                    match write_locked_cache.get(id) {
-                        Some(cert_rx) => {
-                            // A different thread got here before us and is handling the fetch.
-                            // Take a copy of the receiver.
-                            cache_rx = cert_rx.clone();
-                        }
-                        None => {
-                            let (tx, rx) = watch::channel(None);
-                            write_locked_cache.insert(id.clone(), rx.clone());
-                            drop(write_locked_cache);
-                            let s = self.clone();
-                            let id = id.clone();
-                            tokio::spawn(async move { s.refresh_handler(id, tx).await });
-                            cache_rx = rx;
-                        }
-                    };
-                }
-                Some(cert_rcvr) => {
-                    cache_rx = cert_rcvr.clone();
-                }
-            }
-        }
-
-        // We have a channel receiver, so use it to get the cert.
-        match cache_rx.changed().await {
-            Err(_) => {
-                // CA request failed or other error.
-                warn!("Cert sender has been dropped.");
-                return Err(Error::EmptyResponse(id.clone()));
-            }
-            Ok(_) => {
-                let current_cert = cache_rx.borrow().clone();
-                if let Some(cert) = current_cert {
-                    debug!("return cached cert");
-                    return Ok(cert);
-                }
-                return Err(Error::EmptyResponse(id.clone()));
-            }
-        }
+        Ok(Self::new_with_client(caclient))
     }
 }
 
 pub mod mock {
-    use std::collections::HashMap;
-    use std::sync::{Arc, RwLock};
     use std::time::Duration;
 
-    use tokio::sync::watch;
+    use crate::identity::caclient::mock::{self, CaClient as MockCaClient};
 
-    use crate::identity::caclient::mock::CaClient as MockCaClient;
-    use crate::tls::Certs;
-
-    use super::{Identity, SecretManager};
+    use super::SecretManager;
 
     pub fn new_secret_manager(cert_lifetime: Duration) -> SecretManager<MockCaClient> {
-        let cache: HashMap<Identity, watch::Receiver<Option<Certs>>> = Default::default();
-        let ca_client = MockCaClient::new(cert_lifetime);
-        SecretManager {
-            client: ca_client,
-            cache: Arc::new(RwLock::new(cache)),
+        let time_conv = crate::time::Converter::new();
+        let client = MockCaClient::new(mock::ClientConfig {
+            cert_lifetime,
+            time_conv: time_conv.clone(),
+            ..Default::default()
+        });
+        SecretManager::new_internal(
+            client,
+            super::SecretManagerConfig {
+                time_conv,
+                concurrency: 2,
+            },
+        )
+        .0
+    }
+
+    impl SecretManager<MockCaClient> {
+        pub async fn cache_len(&self) -> usize {
+            self.worker.certs.lock().await.len()
+        }
+
+        pub fn client(&self) -> &MockCaClient {
+            &self.worker.client
         }
     }
 }
@@ -275,7 +474,7 @@ mod tests {
             sm.fetch_certificate(&id)
                 .await
                 .expect("Didn't get a cert as expected.");
-            sleep(Duration::from_micros(500)).await;
+            tokio::time::sleep(Duration::from_micros(500)).await;
         }
     }
 
@@ -285,7 +484,7 @@ mod tests {
         dur: Duration,
     ) {
         let start_time = time::Instant::now();
-        let expected_update_interval = sm.client.cert_lifetime.as_millis() / 2;
+        let expected_update_interval = sm.worker.client.cert_lifetime().as_millis() / 2;
         let mut total_updates = 0;
         let mut current_cert = sm
             .fetch_certificate(&id)
@@ -304,7 +503,7 @@ mod tests {
             if time::Instant::now() - start_time > dur {
                 break;
             }
-            sleep(Duration::from_micros(100)).await;
+            tokio::time::sleep(Duration::from_micros(100)).await;
         }
         assert_eq!(total_updates, dur.as_millis() / expected_update_interval);
     }
@@ -321,7 +520,7 @@ mod tests {
         for result in results.iter() {
             assert!(result.is_ok());
         }
-        assert_eq!(100, secret_manager.cache.read().unwrap().len());
+        assert_eq!(100, secret_manager.cache_len().await);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
@@ -354,6 +553,235 @@ mod tests {
         for result in results.iter() {
             assert!(result.is_ok());
         }
+    }
+
+    fn collect_strings<T: Iterator>(xs: T) -> Vec<String>
+    where
+        T::Item: ToString,
+    {
+        xs.map(|x| x.to_string()).collect()
+    }
+
+    const NANOSEC: Duration = Duration::from_nanos(1);
+    const MILLISEC: Duration = Duration::from_millis(1);
+    const SEC: Duration = Duration::from_secs(1);
+    const CERT_HALFLIFE: Duration = Duration::from_secs(50);
+
+    // Wraps SecretManager to retain the background worker handle, so that it can be waited on at
+    // the end of the test.
+    struct TestSecretManager {
+        secret_manager: SecretManager<caclient::mock::CaClient>,
+        worker: tokio::task::JoinHandle<()>,
+    }
+
+    impl TestSecretManager {
+        // Deconstructs the TestSecretManager into the background worker handle. This drops the
+        // underlying SecretManager so that the underlying worker should terminate soon after this
+        // call.
+        fn into_worker(self) -> tokio::task::JoinHandle<()> {
+            self.worker
+        }
+
+        // Consume the SecretManager and wait for the background worker to finish.
+        async fn tear_down(self) {
+            self.into_worker().await.unwrap();
+        }
+    }
+
+    // For an easy access to the underlying SecretManager.
+    impl std::ops::Deref for TestSecretManager {
+        type Target = SecretManager<caclient::mock::CaClient>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.secret_manager
+        }
+    }
+
+    fn setup(concurrency: u16) -> TestSecretManager {
+        // Tests that use this function rely on Tokio's test time pause and auto-advance. It gets a
+        // bit tricky so a few things to remember:
+        //  - When *all* futures are blocked waiting for a specific time, the runtime will
+        //    auto-advance the timer to ~that time.
+        //  - Tokio's time functions have millisecond granularity, so sleeping 1ns results in a 1ms
+        //    clock skip.
+        //  - In practice, sleep calls add some number of microseconds and then round down to the
+        //    nearest millisecond. That means eg. sleep(1ms) will advance the timer by 2ms while
+        //    sleep(600us) will advance the timer by only 1ms.
+        let time_conv = crate::time::Converter::new();
+        let client = caclient::mock::CaClient::new(caclient::mock::ClientConfig {
+            time_conv: time_conv.clone(),
+            fetch_latency: SEC,
+            cert_lifetime: 2 * CERT_HALFLIFE,
+        });
+
+        let (secret_manager, worker) = SecretManager::new_internal(
+            client,
+            SecretManagerConfig {
+                time_conv,
+                concurrency,
+            },
+        );
+        TestSecretManager {
+            secret_manager,
+            worker,
+        }
+    }
+
+    fn identity(name: &str) -> Identity {
+        Identity::Spiffe {
+            trust_domain: "test".to_string(),
+            namespace: "test".to_string(),
+            service_account: name.to_string(),
+        }
+    }
+
+    fn identity_n(name: &str, n: u8) -> Identity {
+        Identity::Spiffe {
+            trust_domain: "test".to_string(),
+            namespace: "test".to_string(),
+            service_account: format!("{name}{n}"),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_priority() {
+        let secret_manager = setup(1);
+
+        let requests = vec![
+            (identity("id1"), Priority::Background),
+            (identity("id2"), Priority::Background),
+            (identity("id3"), Priority::Warmup),
+            (identity("id4"), Priority::RealTime),
+        ];
+        let expected = vec![
+            identity("id1"),
+            identity("id4"),
+            identity("id3"),
+            identity("id2"),
+        ];
+
+        // Capture the start time of the test
+        let start = Instant::now();
+        let mut tasks = Vec::new();
+        for (id, pri) in requests {
+            // Force the background worker to proceed as far as possible without sleeping
+            // (which happens in CaClient). This is technically not needed before the first
+            // SecretManager call but putting it here makes for simpler computation later on.
+            tokio::time::sleep(NANOSEC).await;
+            let sm = secret_manager.clone();
+            let rx = sm.start_fetch(&id, pri).await.unwrap();
+            tasks.push(tokio::spawn(async move { sm.wait(&id, rx).await }));
+            // Now the request has either started (for the first request) or is queued in the
+            // background worker.
+        }
+        // Process all pending requests.
+        for result in futures::future::join_all(tasks).await {
+            assert_matches!(result, Ok(Ok(_)));
+        }
+
+        let client = secret_manager.client();
+        // Ensure all requests have been issued in the expected order.
+        assert_eq!(
+            collect_strings(client.fetches().await.iter()),
+            collect_strings(expected.iter()),
+        );
+
+        client.clear_fetches().await;
+        // Certificates should start refreshing at start + CERT_HALFLIFE, so just before that there
+        // should be no new CaClient calls.
+        tokio::time::sleep_until(start + CERT_HALFLIFE - MILLISEC).await;
+        assert!(client.fetches().await.is_empty());
+
+        // Each certificate request is delayed by 1ms, and each CaClient call takes 1s. So CaClient
+        // calls complete at 1s1ms, 2s2ms, and so on. Wait till the last CaClient call completion +
+        // CERT_HALFLIFE to ensure all background refreshes have been issues, and then an extra
+        // second to ensure the last one has completed.
+        let num_ids = expected.len() as u32;
+        tokio::time::sleep_until(start + CERT_HALFLIFE + num_ids * (SEC + MILLISEC) + SEC).await;
+        assert_eq!(
+            collect_strings(client.fetches().await.iter()),
+            collect_strings(expected.iter()),
+        );
+
+        secret_manager.tear_down().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_warmup() {
+        let secret_manager = setup(1);
+
+        // Capture the start time of the test
+        let start = Instant::now();
+        let mut tasks = Vec::new();
+        for i in 1..21 {
+            let sm = secret_manager.clone();
+            tasks.push(tokio::spawn(async move {
+                sm.fetch_certificate_pri(&identity_n("warmup-", i), Priority::Warmup)
+                    .await
+                    .unwrap();
+            }));
+        }
+        // Ensure all requests are executing/queued in the background worker.
+        tokio::time::sleep(NANOSEC).await; // Expect this to advance the timer by exactly 1ms.
+        secret_manager
+            .fetch_certificate_pri(&identity("realtime"), Priority::RealTime)
+            .await
+            .unwrap();
+        assert!(Instant::now().duration_since(start) <= 2 * SEC);
+
+        secret_manager.tear_down().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_duplicate_requests() {
+        let secret_manager = setup(1);
+        let id = identity("id1");
+        let mut rxs = Vec::new();
+        for _ in 1..5 {
+            let rx = secret_manager
+                .start_fetch(&id, Priority::RealTime)
+                .await
+                .unwrap();
+            rxs.push(rx);
+        }
+        let mut rxs_iter = rxs.into_iter();
+        let want = secret_manager
+            .wait(&id, rxs_iter.next().unwrap())
+            .await
+            .unwrap();
+        for rx in rxs_iter {
+            let got = secret_manager.wait(&id, rx).await.unwrap();
+            assert_eq!(got, want);
+        }
+        assert_eq!(secret_manager.client().fetches().await.len(), 1);
+
+        secret_manager.tear_down().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_concurrency() {
+        let start = Instant::now();
+        let secret_manager = setup(4);
+        let mut futs = Vec::new();
+        for i in 0..4 {
+            let id = identity_n("id-", i);
+            futs.push(async {
+                let id = id; // Move instead of borrowing.
+                secret_manager
+                    .fetch_certificate_pri(&id, Priority::RealTime)
+                    .await
+            });
+        }
+        for result in futures::future::join_all(futs).await {
+            result.unwrap();
+        }
+        assert_eq!(Instant::now().duration_since(start), SEC);
+        secret_manager.tear_down().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_unused_cleanup() {
+        setup(1).tear_down().await;
     }
 
     #[test]

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -257,7 +257,7 @@ mod tests {
             };
             sm.fetch_certificate(&id)
                 .await
-                .unwrap_or_else(|_| panic!("Didn't get a cert as expected."));
+                .expect("Didn't get a cert as expected.");
         }
     }
 
@@ -274,7 +274,7 @@ mod tests {
             }
             sm.fetch_certificate(&id)
                 .await
-                .unwrap_or_else(|_| panic!("Didn't get a cert as expected."));
+                .expect("Didn't get a cert as expected.");
             sleep(Duration::from_micros(500)).await;
         }
     }
@@ -290,12 +290,12 @@ mod tests {
         let mut current_cert = sm
             .fetch_certificate(&id)
             .await
-            .unwrap_or_else(|_| panic!("Didn't get a cert as expected."));
+            .expect("Didn't get a cert as expected.");
         loop {
             let new_cert = sm
                 .fetch_certificate(&id)
                 .await
-                .unwrap_or_else(|_| panic!("Didn't get a cert as expected."));
+                .expect("Didn't get a cert as expected.");
 
             if current_cert != new_cert {
                 total_updates += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod signal;
 pub mod socket;
 pub mod stats;
 pub mod telemetry;
+pub mod time;
 pub mod tls;
 pub mod version;
 pub mod workload;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,74 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::{Instant, SystemTime};
+
+#[derive(Clone)]
+pub struct Converter {
+    now: Instant,
+    sys_now: SystemTime,
+}
+
+impl Converter {
+    pub fn new() -> Self {
+        Self {
+            sys_now: SystemTime::now(),
+            now: Instant::now(),
+        }
+    }
+
+    pub fn system_time_to_instant(&self, t: SystemTime) -> Instant {
+        match t.duration_since(self.sys_now) {
+            Ok(d) => self.now + d,
+            Err(_) => match self.sys_now.duration_since(t) {
+                Ok(d) => self.now - d,
+                Err(_) => panic!("time both before and after"),
+            },
+        }
+    }
+
+    pub fn instant_to_system_time(&self, t: Instant) -> SystemTime {
+        if t > self.now {
+            self.sys_now + t.saturating_duration_since(self.now)
+        } else {
+            self.sys_now - self.now.saturating_duration_since(t)
+        }
+    }
+
+    pub fn elapsed_nanos(&self, now: Instant) -> u128 {
+        now.duration_since(self.now).as_nanos()
+    }
+
+    pub fn subsec_nanos(&self) -> u32 {
+        self.sys_now
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn test_converter() {
+        const DELAY: Duration = Duration::from_secs(1);
+        let conv = super::Converter::new();
+        let now = Instant::now();
+        let sys_now = conv.instant_to_system_time(now);
+        let later = conv.system_time_to_instant(sys_now + DELAY);
+        assert_eq!(later, now + DELAY);
+    }
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -14,11 +14,13 @@
 
 pub mod boring;
 
+use std::sync::Arc;
+
 pub use crate::tls::boring::*;
 use ::boring::error::ErrorStack;
 use hyper::http::uri::InvalidUri;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
     #[error("invalid operation: {0:?}")]
     SslError(#[from] ErrorStack),
@@ -27,5 +29,11 @@ pub enum Error {
     InvalidRootCert(ErrorStack),
 
     #[error("invalid uri: {0}")]
-    InvalidUri(#[from] InvalidUri),
+    InvalidUri(#[from] Arc<InvalidUri>),
+}
+
+impl From<InvalidUri> for Error {
+    fn from(err: InvalidUri) -> Self {
+        Error::InvalidUri(Arc::new(err))
+    }
 }


### PR DESCRIPTION
Provides the interface requested in #334.

This allows all certificate requests to be assigned a priority. The SecretManager will issue a configurable number of concurrent requests in the order of priority and request time (priority always wins). In particular, high-priority calls inserted later can skip lower-priority calls in the queue.

Certificate refreshes are queued at the lowest (Background) priority.

The new functionality is not used yet - just available as a new method in SecretManager (and its implementation used to back the existing fetch_certificates call). For code simplicity, SecretManager was changed to have no parallelism (but allow configurable concurrency). The code isn't as computationally heavy to require multiple cores and most of the time should be spent waiting on certificate fetches. This in particular lets us reduce synchronization and data ownership issues.

Unit tests proved tricky - they rely on tokio's time control facilities. Those are pretty hard to get right, and pretty hard to debug. Ideally tokio would evolve to at least make this type of testing more debuggable (eg. panic on auto-advance for specific blocks of code). We may decide maintaining those tests is too much burden, but at least for the moment they let us test code without having to add test-only instrumentation.