### PR TITLE
Publish arm64 binary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
 target-dir = "out/rust"
 [env]
-BORING_BSSL_PATH = { value = "vendor/boringssl-fips/linux_arm64", force = true, relative = true }
+BORING_BSSL_PATH = { value = "vendor/boringssl-fips/linux_x86_64", force = true, relative = true }
 BORING_BSSL_INCLUDE_PATH = { value = "vendor/boringssl-fips/include/", force = true, relative = true }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
 target-dir = "out/rust"
 [env]
-BORING_BSSL_PATH = { value = "vendor/boringssl-fips/linux_x86_64", force = true, relative = true }
+BORING_BSSL_PATH = { value = "vendor/boringssl-fips/linux_arm64", force = true, relative = true }
 BORING_BSSL_INCLUDE_PATH = { value = "vendor/boringssl-fips/include/", force = true, relative = true }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,8 +22,13 @@ WD=$(cd "$WD" || exit; pwd)
 cargo build --release
 
 case $(uname -m) in
-    x86_64) export ARCH=amd64;;
-    aarch64) export ARCH=arm64;;
+    x86_64)
+      export ARCH=amd64;;
+    aarch64)
+      export ARCH=arm64
+      # TODO(https://github.com/istio/ztunnel/issues/357) clean up this hack
+      sed -i 's/x86_64/arm64/g' .cargo/config.toml
+      ;;
     *) echo "unsupported architecture"; exit 1 ;;
 esac
 


### PR DESCRIPTION
This isn't ideal but we need to start publishing at least amd64, and my shortcut to do this (https://github.com/istio/istio/pull/43331) doesn't work without a lot of effort. For now we can just hack it.

CI job coming soon: https://github.com/istio/test-infra/pull/4570

Fixes https://github.com/istio/ztunnel/issues/394