### PR TITLE
slight cleanup in fips enabled tests

### DIFF
--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -607,8 +607,15 @@ pub mod tests {
     use super::generate_test_certs;
 
     #[test]
+    #[cfg(feature = "fips")]
     fn is_fips_enabled() {
         assert!(boring::fips::enabled());
+    }
+
+    #[test]
+    #[cfg(not(feature = "fips"))]
+    fn is_fips_disabled() {
+        assert_eq!(!boring::fips::enabled());
     }
 
     #[test]
@@ -640,11 +647,5 @@ pub mod tests {
         );
         assert!(!future_certs.is_expired());
         assert_eq!(future_certs.get_duration_until_refresh(), zero_dur);
-    }
-
-    #[test]
-    #[cfg(not(feature = "fips"))]
-    fn is_fips_disabled() {
-        assert_eq!(false, boring::fips::enabled());
     }
 }


### PR DESCRIPTION
* Cleanup a small clippy warning
* Allow tests to pass in a non FIPS build. Right now the tests will fail with `--no-default-features`. Is this intentional? 