### PR TITLE
Always print backtrace on `cargo test`

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -1,11 +1,11 @@
 include common/Makefile.common.mk
 
 test:
-	cargo test --benches --tests --bins
+	RUST_BACKTRACE=1 cargo test --benches --tests --bins
 
 test-root: export CARGO_TARGET_$(shell rustc -vV | sed -n 's|host: ||p' | tr [:lower:] [:upper:]| tr - _)_RUNNER = sudo -E
 test-root:
-	cargo test --benches --tests --bins
+	RUST_BACKTRACE=1 cargo test --benches --tests --bins
 
 build:
 	cargo build


### PR DESCRIPTION
Minor twiddle: Always backtrace on test failure - arguably always useful when tests fail, no downside I can see.