### PR TITLE
Set the baggage cluster ID from the env

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ use crate::identity;
 const KUBERNETES_SERVICE_HOST: &str = "KUBERNETES_SERVICE_HOST";
 const NODE_NAME: &str = "NODE_NAME";
 const INSTANCE_IP: &str = "INSTANCE_IP";
+const CLUSTER_ID: &str = "CLUSTER_ID";
 const LOCAL_XDS_PATH: &str = "LOCAL_XDS_PATH";
 const XDS_ON_DEMAND: &str = "XDS_ON_DEMAND";
 const XDS_ADDRESS: &str = "XDS_ADDRESS";
@@ -43,6 +44,7 @@ const DEFAULT_ADMIN_PORT: u16 = 15000;
 const DEFAULT_READINESS_PORT: u16 = 15021;
 const DEFAULT_STATS_PORT: u16 = 15020;
 const DEFAULT_DRAIN_DURATION: Duration = Duration::from_secs(5);
+const DEFAULT_CLUSTER_ID: &str = "Kubernetes";
 
 const ISTIO_META_PREFIX: &str = "ISTIO_META_";
 
@@ -86,6 +88,8 @@ pub struct Config {
     pub local_node: Option<String>,
     /// The local_ip we are running at.
     pub local_ip: Option<IpAddr>,
+    /// The Cluster ID of the cluster that his ztunnel belongs to
+    pub cluster_id: String,
 
     /// CA address to use. If fake_ca is set, this will be None.
     /// Note: we do not implicitly use None when set to "" since using the fake_ca is not secure.
@@ -182,6 +186,8 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             .or_else(|| Some(default_istiod_address.clone())),
     );
 
+    let cluster_id = parse_default(CLUSTER_ID, DEFAULT_CLUSTER_ID.to_string())?;
+
     let fake_ca = parse_default(FAKE_CA, false)?;
     let ca_address = empty_to_none(if fake_ca {
         None
@@ -221,6 +227,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
 
         local_node: parse(NODE_NAME)?,
         local_ip: parse(INSTANCE_IP)?,
+        cluster_id,
 
         xds_address,
         // TODO: full FindRootCAForXDS logic like in Istio

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -239,7 +239,10 @@ impl OutboundConnection {
                     .uri(&req.destination.to_string())
                     .method(hyper::Method::CONNECT)
                     .version(hyper::Version::HTTP_2)
-                    .header(BAGGAGE_HEADER, baggage(&req))
+                    .header(
+                        BAGGAGE_HEADER,
+                        baggage(&req, self.pi.cfg.cluster_id.clone()),
+                    )
                     .header(FORWARDED, f.value().unwrap())
                     .header(TRACEPARENT_HEADER, self.id.header())
                     .body(hyper::Body::empty())
@@ -417,9 +420,8 @@ impl OutboundConnection {
     }
 }
 
-fn baggage(r: &Request) -> String {
+fn baggage(r: &Request, cluster: String) -> String {
     format!("k8s.cluster.name={cluster},k8s.namespace.name={namespace},k8s.{workload_type}.name={workload_name},service.name={name},service.version={version}",
-            cluster = "Kubernetes",// todo
             namespace = r.source.namespace,
             workload_type = r.source.workload_type,
             workload_name = r.source.workload_name,


### PR DESCRIPTION
Setting the cluster ID in the baggage header to the value of `CLUSTER_ID` env variable for the Waypoint to use as the source cluster on emitted metrics.

`CLUSTER_ID` already exists in ztunnel daemonset.

This is *not* setting the source cluster label on metrics generated by the source/destination ztunnel.