### PR TITLE
Clean up use of SecretManager

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -28,7 +28,7 @@ use tracing::{error, trace, warn, Instrument};
 
 use inbound::Inbound;
 
-use crate::identity::CertificateProvider;
+use crate::identity::SecretManager;
 use crate::metrics::{traffic, Metrics, Recorder};
 use crate::proxy::inbound_passthrough::InboundPassthrough;
 use crate::proxy::outbound::Outbound;
@@ -52,7 +52,7 @@ pub struct Proxy {
 #[derive(Clone)]
 pub(super) struct ProxyInputs {
     cfg: config::Config,
-    cert_manager: Box<dyn CertificateProvider>,
+    cert_manager: Arc<SecretManager>,
     hbone_port: u16,
     workloads: WorkloadInformation,
     metrics: Arc<Metrics>,
@@ -62,7 +62,7 @@ impl Proxy {
     pub async fn new(
         cfg: config::Config,
         workloads: WorkloadInformation,
-        cert_manager: Box<dyn CertificateProvider>,
+        cert_manager: Arc<SecretManager>,
         metrics: Arc<Metrics>,
         drain: Watch,
     ) -> Result<Proxy, Error> {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -26,7 +26,7 @@ use tokio::sync::oneshot;
 use tracing::{debug, error, info, instrument, trace, trace_span, warn, Instrument};
 
 use crate::config::Config;
-use crate::identity::CertificateProvider;
+use crate::identity::SecretManager;
 use crate::metrics::traffic::{ConnectionOpen, Reporter};
 use crate::metrics::{traffic, Metrics, Recorder};
 use crate::proxy::inbound::InboundConnect::{DirectPath, Hbone};
@@ -42,7 +42,7 @@ use super::Error;
 pub(super) struct Inbound {
     cfg: Config,
     listener: TcpListener,
-    cert_manager: Box<dyn CertificateProvider>,
+    cert_manager: Arc<SecretManager>,
     workloads: WorkloadInformation,
     drain: Watch,
     metrics: Arc<Metrics>,
@@ -389,7 +389,7 @@ pub(super) enum InboundConnect {
 
 #[derive(Clone)]
 struct InboundCertProvider {
-    cert_manager: Box<dyn CertificateProvider>,
+    cert_manager: Arc<SecretManager>,
     workloads: WorkloadInformation,
 }
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -518,7 +518,7 @@ mod tests {
         };
         let outbound = OutboundConnection {
             pi: ProxyInputs {
-                cert_manager: Box::new(identity::mock::new_secret_manager(Duration::from_secs(10))),
+                cert_manager: identity::mock::new_secret_manager(Duration::from_secs(10)),
                 workloads: wi,
                 hbone_port: 15008,
                 cfg,

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -17,6 +17,7 @@ use std::future::Future;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::ops::Deref;
+use std::sync::Arc;
 use std::time::Duration;
 
 use hyper::{body, Body, Client, Method, Request, Response};
@@ -26,7 +27,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpSocket, TcpStream};
 
 use crate::app::Bound;
-use crate::identity::mock::CaClient as MockCaClient;
 use crate::identity::SecretManager;
 use crate::test_helpers::TEST_WORKLOAD_SOURCE;
 use crate::*;
@@ -39,11 +39,11 @@ pub struct TestApp {
     pub stats_address: SocketAddr,
     pub readiness_address: SocketAddr,
     pub proxy_addresses: proxy::Addresses,
-    pub cert_manager: SecretManager<MockCaClient>,
+    pub cert_manager: Arc<SecretManager>,
 }
 
-impl From<(&Bound, SecretManager<MockCaClient>)> for TestApp {
-    fn from((app, cert_manager): (&Bound, SecretManager<MockCaClient>)) -> Self {
+impl From<(&Bound, Arc<SecretManager>)> for TestApp {
+    fn from((app, cert_manager): (&Bound, Arc<SecretManager>)) -> Self {
         Self {
             admin_address: app.admin_address,
             stats_address: app.stats_address,

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -29,7 +29,7 @@ use xds::istio::security::Authorization as XdsAuthorization;
 use xds::istio::workload::Workload as XdsWorkload;
 
 use crate::config::ConfigSource;
-use crate::identity::{CertificateProvider, Identity};
+use crate::identity::{Identity, SecretManager};
 use crate::metrics::Metrics;
 use crate::rbac::{Authorization, RbacScope};
 use crate::workload::WorkloadError::EnumParse;
@@ -282,7 +282,7 @@ impl WorkloadManager {
         config: config::Config,
         metrics: Arc<Metrics>,
         awaiting_ready: readiness::BlockReady,
-        cert_manager: Box<dyn CertificateProvider>,
+        cert_manager: Arc<SecretManager>,
     ) -> anyhow::Result<WorkloadManager> {
         let (tx, mut rx) = mpsc::channel::<Identity>(256);
         // todo ratelimit prefetching to a reasonable limit

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -23,7 +23,6 @@ use tokio::time::timeout;
 use tracing::{error, info};
 
 use ztunnel::identity;
-use ztunnel::identity::CertificateProvider;
 use ztunnel::test_helpers::app::TestApp;
 use ztunnel::test_helpers::components::WorkloadManager;
 use ztunnel::test_helpers::helpers::initialize_telemetry;


### PR DESCRIPTION
 - Don't generalize over the underlying CertificateProvider, use Box<dyn trait> instead
 - Do not allow cloning SecretManager; Use Arc instead
 - Minor clean up in SecretManager tests