### PR TITLE
Support setting: DISABLE_IMPERSONATED_IDENTITY

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,8 @@ use crate::identity;
 
 const KUBERNETES_SERVICE_HOST: &str = "KUBERNETES_SERVICE_HOST";
 const NODE_NAME: &str = "NODE_NAME";
+const POD_NAME: &str = "POD_NAME";
+const POD_NAMESPACE: &str = "POD_NAMESPACE";
 const INSTANCE_IP: &str = "INSTANCE_IP";
 const CLUSTER_ID: &str = "CLUSTER_ID";
 const LOCAL_XDS_PATH: &str = "LOCAL_XDS_PATH";
@@ -38,6 +40,7 @@ const FAKE_CA: &str = "FAKE_CA";
 const ZTUNNEL_WORKER_THREADS: &str = "ZTUNNEL_WORKER_THREADS";
 const ENABLE_ORIG_SRC: &str = "ENABLE_ORIG_SRC";
 const PROXY_CONFIG: &str = "PROXY_CONFIG";
+const ENABLE_IMPERSONATED_IDENTITY: &str = "ENABLE_IMPERSONATED_IDENTITY";
 
 const DEFAULT_WORKER_THREADS: u16 = 2;
 const DEFAULT_ADMIN_PORT: u16 = 15000;
@@ -86,6 +89,10 @@ pub struct Config {
 
     /// The name of the node this ztunnel is running as.
     pub local_node: Option<String>,
+    /// The name of the pod this ztunnel is running as.
+    pub local_pod: Option<String>,
+    /// The namespace of the pod this ztunnel is running as.
+    pub local_pod_namespace: Option<String>,
     /// The local_ip we are running at.
     pub local_ip: Option<IpAddr>,
     /// The Cluster ID of the cluster that his ztunnel belongs to
@@ -122,6 +129,10 @@ pub struct Config {
 
     // CLI args passed to ztunnel at runtime
     pub proxy_args: String,
+
+    // If true, fetch certs for pod on the same node with impersonated identity.
+    // If false, only fetch cert for current pod (used in serverless environment).
+    pub enable_impersonated_identity: bool,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -226,6 +237,8 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15001),
 
         local_node: parse(NODE_NAME)?,
+        local_pod: parse(POD_NAME)?,
+        local_pod_namespace: parse(POD_NAMESPACE)?,
         local_ip: parse(INSTANCE_IP)?,
         cluster_id,
 
@@ -252,6 +265,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
 
         enable_original_source: parse(ENABLE_ORIG_SRC)?,
         proxy_args: parse_args(),
+        enable_impersonated_identity: parse_default(ENABLE_IMPERSONATED_IDENTITY, true)?,
     })
 }
 

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -30,13 +30,22 @@ use crate::xds::istio::ca::IstioCertificateRequest;
 
 pub struct CaClient {
     pub client: IstioCertificateServiceClient<InterceptedService<TlsGrpcChannel, AuthSource>>,
+    pub enable_impersonated_identity: bool,
 }
 
 impl CaClient {
-    pub fn new(address: String, root_cert: RootCert, auth: AuthSource) -> Result<CaClient, Error> {
+    pub fn new(
+        address: String,
+        root_cert: RootCert,
+        auth: AuthSource,
+        enable_impersonated_identity: bool,
+    ) -> Result<CaClient, Error> {
         let svc = tls::grpc_connector(address, root_cert)?;
         let client = IstioCertificateServiceClient::with_interceptor(svc, auth);
-        Ok(CaClient { client })
+        Ok(CaClient {
+            client,
+            enable_impersonated_identity,
+        })
     }
 }
 
@@ -54,14 +63,20 @@ impl CaClient {
         let req = IstioCertificateRequest {
             csr,
             validity_duration: 60 * 60 * 24, // 24 hours
-            metadata: Some(Struct {
-                fields: BTreeMap::from([(
-                    "ImpersonatedIdentity".into(),
-                    prost_types::Value {
-                        kind: Some(Kind::StringValue(id.to_string())),
-                    },
-                )]),
-            }),
+            metadata: {
+                if self.enable_impersonated_identity {
+                    Some(Struct {
+                        fields: BTreeMap::from([(
+                            "ImpersonatedIdentity".into(),
+                            prost_types::Value {
+                                kind: Some(Kind::StringValue(id.to_string())),
+                            },
+                        )]),
+                    })
+                } else {
+                    None
+                }
+            },
         };
         let resp = self
             .client

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -381,7 +381,12 @@ pub struct SecretManager {
 
 impl SecretManager {
     pub fn new(cfg: crate::config::Config) -> Result<Self, Error> {
-        let caclient = CaClient::new(cfg.ca_address.unwrap(), cfg.ca_root_cert, cfg.auth)?;
+        let caclient = CaClient::new(
+            cfg.ca_address.unwrap(),
+            cfg.ca_root_cert,
+            cfg.auth,
+            cfg.enable_impersonated_identity,
+        )?;
         Ok(Self::new_with_client(caclient))
     }
 

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -83,7 +83,9 @@ impl InboundPassthrough {
         mut inbound: TcpStream,
     ) -> Result<(), Error> {
         let orig = socket::orig_dst_addr_or_default(&inbound);
-        if Some(orig.ip()) == pi.cfg.local_ip {
+        // If it's not in serverless environment (enable_impersonated_identity is true), check if it
+        // is a recursive call.
+        if pi.cfg.enable_impersonated_identity && Some(orig.ip()) == pi.cfg.local_ip {
             return Err(Error::SelfCall);
         }
         info!(%source, destination=%orig, component="inbound plaintext", "accepted connection");

--- a/src/test_helpers/ca.rs
+++ b/src/test_helpers/ca.rs
@@ -75,6 +75,7 @@ impl CaServer {
             "https://".to_string() + &server_addr.to_string(),
             root_cert,
             AuthSource::Token(PathBuf::from(r"src/test_helpers/fake-jwt")),
+            false,
         )
         .unwrap();
         (tx, client)


### PR DESCRIPTION
Let ztunnel be able to fetch certificates in serverless environment, part of #440