### PR TITLE
Prevent proxying outbound traffic with DirectLocal in serverless environment

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -374,7 +374,8 @@ impl OutboundConnection {
             return Err(Error::NoGatewayAddress(Box::new(us.workload.clone())));
         }
         // For case source client and upstream server are on the same node
-        if !us.workload.node.is_empty()
+        if self.pi.cfg.enable_impersonated_identity
+            && !us.workload.node.is_empty()
             && self.pi.cfg.local_node.as_ref() == Some(&us.workload.node) // looks weird but in Rust borrows can be compared and will behave the same as owned (https://doc.rust-lang.org/std/primitive.reference.html)
             && us.workload.protocol == Protocol::HBONE
         {


### PR DESCRIPTION
In serverless(`enable_impersonated_identity` is false), node is virtual, pods on the same "node" do not share the ztunnel, we can't let outbound traffic go through DirectLocal fast path.