### PR TITLE
deps: update to hyper 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,8 +126,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.4.5",
+ "hyper 0.14.25",
  "itoa",
  "matchit",
  "memchr",
@@ -152,7 +152,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http",
- "http-body",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
@@ -214,8 +214,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "boring"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c713ad6d8d7a681a43870ac37b89efd2a08015ceb4b256d82707509c1f0b6bb"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#d7ae5903fbcb469a31b0d00897f0bb4b17532fa2"
 dependencies = [
  "bitflags",
  "boring-sys",
@@ -227,8 +226,7 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7663d3069437a5ccdb2b5f4f481c8b80446daea10fa8503844e89ac65fcdc363"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#d7ae5903fbcb469a31b0d00897f0bb4b17532fa2"
 dependencies = [
  "bindgen",
  "cmake",
@@ -973,6 +971,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951dfc2e32ac02d67c90c0d65bd27009a635dc9b381a2cc7d284ab01e3a0150d"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92445bc9cc14bfa0a3ce56817dc3b5bcc227a168781a356b702410789cec0d10"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body 1.0.0-rc.2",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-types"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,7 +1043,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
- "http-body",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -1035,20 +1056,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-boring"
-version = "2.1.2"
+name = "hyper"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7419ead5df56b00201fc95d01b2b5fed1329216f72306e3480c5dd6c2b8aa0a"
+checksum = "7b75264b2003a3913f118d35c586e535293b3e22e41f074930762929d071e092"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body 1.0.0-rc.2",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-boring"
+version = "3.0.0"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#d7ae5903fbcb469a31b0d00897f0bb4b17532fa2"
 dependencies = [
  "antidote",
  "boring",
  "http",
- "hyper",
+ "hyper 1.0.0-rc.3",
+ "hyper-util",
  "linked_hash_set",
  "once_cell",
  "tokio",
  "tokio-boring",
  "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1057,10 +1101,28 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.25",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.0.0"
+source = "git+https://github.com/howardjohn/hyper-util?branch=client/h2-timer#5f15fb087d2b2b64e2019a06990b07a055f479f5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http",
+ "hyper 1.0.0-rc.3",
+ "once_cell",
+ "pin-project-lite",
+ "socket2 0.4.9",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2322,7 +2384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97abcaa5d5850d3b469898d1e0939b57c3afb4475122e792cdd1c82b07f5de06"
 dependencies = [
  "futures-util",
- "hyper",
  "pin-project-lite",
  "thiserror",
  "tokio",
@@ -2351,8 +2412,7 @@ dependencies = [
 [[package]]
 name = "tokio-boring"
 version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb059337235a89f03252c6285da8f0a6747a85bbd42e9ece70178d578054cba7"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#d7ae5903fbcb469a31b0d00897f0bb4b17532fa2"
 dependencies = [
  "boring",
  "boring-sys",
@@ -2420,8 +2480,8 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.4.5",
+ "hyper 0.14.25",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -2469,6 +2529,21 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-hyper-http-body-compat"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2373750972dd4efeef7ac0971cebd6597c6f3f98202bb5217763dcca99617d"
+dependencies = [
+ "http",
+ "http-body 0.4.5",
+ "http-body 1.0.0-rc.2",
+ "hyper 1.0.0-rc.3",
+ "pin-project-lite",
+ "tower",
+ "tower-service",
 ]
 
 [[package]]
@@ -2882,11 +2957,16 @@ dependencies = [
  "diff",
  "drain",
  "futures",
+ "futures-util",
  "go-parse-duration",
  "gperftools",
+ "http-body 0.4.5",
+ "http-body 1.0.0-rc.2",
+ "http-body-util",
  "http-types",
- "hyper",
+ "hyper 1.0.0-rc.3",
  "hyper-boring",
+ "hyper-util",
  "ipnet",
  "itertools",
  "libc",
@@ -2918,6 +2998,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "tower-hyper-http-body-compat",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,18 @@ anyhow = "1.0"
 async-stream = "0.3.3"
 async-trait = "0.1.58"
 atty = "0.2"
-boring = { version = "2.1.0"}
-bytes = { version = "1", features=["serde"]}
-console-subscriber = { version = "0.1.6" , optional = true}
+# Fork will be dropped once Hyper goes 1.0.0
+hyper-boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0" }
+boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0" }
+tokio-boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0" }
+bytes = { version = "1", features = ["serde"] }
+console-subscriber = { version = "0.1.6", optional = true }
 drain = "0.1.1"
 futures = "0.3.12"
 gperftools = { version = "0.2.0", features = ["heap"], optional = true }
-hyper = { version = "0.14.18", features = ["full"] }
-hyper-boring = { version= "2.1.2" }
+hyper = { version = "1.0.0-rc.3", features = ["full"] }
+# Pending https://github.com/hyperium/hyper-util/pull/25
+hyper-util = { git = "https://github.com/howardjohn/hyper-util", branch = "client/h2-timer", features = ["full"] }
 libc = "0.2.126"
 log = "0.4"
 once_cell = "1.16.0"
@@ -51,14 +55,13 @@ serde_yaml = "0.9"
 socket2 = { version = "0.5", features = ["all"] }
 byteorder = "1.3.4"
 thiserror = "1.0.38"
-tls-listener = { version  = "0.6.0", features = ["hyper-h2"] }
-tokio = {"version"= "1", features=["full", "test-util"]}
-tokio-boring = { version = "2.1.5" }
-tokio-stream = "0.1.9"
-tonic = { version = "0.8", default-features=false, features = ["channel", "transport", "prost", "codegen"]}
+tls-listener = { version = "0.6.0" }
+tokio = { "version" = "1", features = ["full", "test-util"] }
+tokio-stream = { version = "0.1.12", features = ["net"] }
+tonic = { version = "0.8", default-features = false, features = ["prost", "codegen"] }
 tower = { version = "0.4.12", features = ["full"] }
 tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.16" , features = ["registry", "env-filter"]}
+tracing-subscriber = { version = "0.3.16", features = ["registry", "env-filter"] }
 realm_io = "0.4"
 go-parse-duration = "0.1.1"
 prometheus-parse = "0.2.3"
@@ -69,10 +72,15 @@ http-types = { version = "2.12.0", default-features = false }
 netns-rs = "0.1.0"
 textnonce = { version = "1.0.0" }
 priority-queue = "1.3.0"
+http-body-util = "0.1.0-rc.2"
+http-body-04 = { package = "http-body", version = "0.4" }
+http-body-1 = { package = "http-body", version = "1.0.0-rc.2" }
+tower-hyper-http-body-compat = { version = "0", features = ["server", "http2"] }
+futures-util = "0.3.26"
 chrono = "0.4.23"
 
 [build-dependencies]
-tonic-build = { version = "0.8", default-features=false, features = ["prost"] }
+tonic-build = { version = "0.8", default-features = false, features = ["prost"] }
 prost-build = "0.11"
 anyhow = "1.0.65"
 rustc_version = "0.4.0"

--- a/benches/README.md
+++ b/benches/README.md
@@ -7,7 +7,7 @@ This folder provides Rust benchmarks.
 ```shell
 $ cargo bench # Just run benchmarks
 $ cargo bench -- --quick # Just run benchmarks, with less samples
-$ cargo bench -- --profile-time 10s # run benchmarks with cpu profile; results will be in out/rust/criterion/<group>/<test>/profile/profile.pb
+$ cargo bench -- --profile-time 10 # run benchmarks with cpu profile; results will be in out/rust/criterion/<group>/<test>/profile/profile.pb
 $ # Compare to a baseline
 $ cargo bench -- --save-baseline <name> # save baseline
 $ # ...change something...

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -121,51 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "axum"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,8 +175,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "boring"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c713ad6d8d7a681a43870ac37b89efd2a08015ceb4b256d82707509c1f0b6bb"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#d7ae5903fbcb469a31b0d00897f0bb4b17532fa2"
 dependencies = [
  "bitflags",
  "boring-sys",
@@ -233,8 +187,7 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7663d3069437a5ccdb2b5f4f481c8b80446daea10fa8503844e89ac65fcdc363"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#d7ae5903fbcb469a31b0d00897f0bb4b17532fa2"
 dependencies = [
  "bindgen",
  "cmake",
@@ -895,6 +848,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951dfc2e32ac02d67c90c0d65bd27009a635dc9b381a2cc7d284ab01e3a0150d"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92445bc9cc14bfa0a3ce56817dc3b5bcc227a168781a356b702410789cec0d10"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body 1.0.0-rc.2",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-types"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,14 +912,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
- "http-body",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -951,32 +925,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-boring"
-version = "2.1.2"
+name = "hyper"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7419ead5df56b00201fc95d01b2b5fed1329216f72306e3480c5dd6c2b8aa0a"
+checksum = "7b75264b2003a3913f118d35c586e535293b3e22e41f074930762929d071e092"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body 1.0.0-rc.2",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-boring"
+version = "3.0.0"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#d7ae5903fbcb469a31b0d00897f0bb4b17532fa2"
 dependencies = [
  "antidote",
  "boring",
  "http",
- "hyper",
+ "hyper 1.0.0-rc.3",
+ "hyper-util",
  "linked_hash_set",
  "once_cell",
  "tokio",
  "tokio-boring",
  "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+name = "hyper-util"
+version = "0.0.0"
+source = "git+https://github.com/howardjohn/hyper-util?branch=client/h2-timer#5f15fb087d2b2b64e2019a06990b07a055f479f5"
 dependencies = [
- "hyper",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "hyper 1.0.0-rc.3",
+ "once_cell",
  "pin-project-lite",
+ "socket2 0.4.9",
  "tokio",
- "tokio-io-timeout",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1189,12 +1192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,12 +1223,6 @@ checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1849,12 +1840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
-
-[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,12 +2056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
 name = "tempfile"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,7 +2166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97abcaa5d5850d3b469898d1e0939b57c3afb4475122e792cdd1c82b07f5de06"
 dependencies = [
  "futures-util",
- "hyper",
  "pin-project-lite",
  "thiserror",
  "tokio",
@@ -2215,21 +2193,10 @@ dependencies = [
 [[package]]
 name = "tokio-boring"
 version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb059337235a89f03252c6285da8f0a6747a85bbd42e9ece70178d578054cba7"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#d7ae5903fbcb469a31b0d00897f0bb4b17532fa2"
 dependencies = [
  "boring",
  "boring-sys",
- "tokio",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
  "tokio",
 ]
 
@@ -2277,28 +2244,21 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
  "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
  "http",
- "http-body",
- "hyper",
- "hyper-timeout",
+ "http-body 0.4.5",
  "percent-encoding",
  "pin-project",
  "prost",
  "prost-derive",
- "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -2333,6 +2293,21 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-hyper-http-body-compat"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2373750972dd4efeef7ac0971cebd6597c6f3f98202bb5217763dcca99617d"
+dependencies = [
+ "http",
+ "http-body 0.4.5",
+ "http-body 1.0.0-rc.2",
+ "hyper 1.0.0-rc.3",
+ "pin-project-lite",
+ "tower",
+ "tower-service",
 ]
 
 [[package]]
@@ -2379,16 +2354,6 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -2737,10 +2702,15 @@ dependencies = [
  "chrono",
  "drain",
  "futures",
+ "futures-util",
  "go-parse-duration",
+ "http-body 0.4.5",
+ "http-body 1.0.0-rc.2",
+ "http-body-util",
  "http-types",
- "hyper",
+ "hyper 1.0.0-rc.3",
  "hyper-boring",
+ "hyper-util",
  "ipnet",
  "itertools",
  "libc",
@@ -2770,6 +2740,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "tower-hyper-http-body-compat",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2780,7 +2751,7 @@ name = "ztunnel-fuzz"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "hyper",
+ "hyper 0.14.25",
  "libfuzzer-sys",
  "prost",
  "ztunnel",

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -12,55 +12,156 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
-use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    pin::Pin,
+    time::{Duration, Instant},
+};
 
+use bytes::Bytes;
 use drain::Watch;
-use hyper::server::conn::AddrIncoming;
-use hyper::{Body, Request, Response};
+use http_body_util::Full;
+use hyper::client;
+use hyper::rt::Sleep;
+use hyper::server::conn::{http1, http2};
+use hyper::{Request, Response};
+use hyper_util::client::connect::HttpConnector;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::oneshot;
-use tokio_stream::{Stream, StreamExt};
-use tracing::{debug, error, info, warn};
+use tokio_stream::Stream;
+use tracing::{debug, info, warn};
 
-use crate::signal;
-use crate::tls::{BoringTlsAcceptor, CertProvider, TlsError};
+use crate::tls::{BoringTlsAcceptor, CertProvider};
 
 pub fn tls_server<T: CertProvider + Clone + 'static>(
     acceptor: T,
     listener: TcpListener,
-) -> impl Stream<
-    Item = Result<tokio_boring::SslStream<TcpStream>, tls_listener::Error<io::Error, TlsError>>,
-> {
+) -> impl Stream<Item = tokio_boring::SslStream<TcpStream>> {
+    use tokio_stream::StreamExt;
     let boring_acceptor = BoringTlsAcceptor { acceptor };
-    let mut listener = AddrIncoming::from_listener(listener).expect("server bind");
-    listener.set_nodelay(true);
 
     tls_listener::builder(boring_acceptor)
         .listen(listener)
-        .filter(|conn| {
+        .filter_map(|conn| {
             // Avoid 'By default, if a client fails the TLS handshake, that is treated as an error, and the TlsListener will return an Err'
-            if let Err(err) = conn {
-                warn!("TLS handshake error: {}", err);
-                false
-            } else {
-                debug!("TLS handshake succeeded");
-                true
+            match conn {
+                Err(err) => {
+                    warn!("TLS handshake error: {}", err);
+                    None
+                }
+                Ok(s) => {
+                    debug!("TLS handshake succeeded");
+                    Some(s)
+                }
             }
         })
 }
 
-pub fn empty_response(code: hyper::StatusCode) -> Response<Body> {
+#[derive(Clone)]
+/// An Executor that uses the tokio runtime.
+pub struct TokioExecutor;
+
+impl<F> hyper::rt::Executor<F> for TokioExecutor
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    fn execute(&self, fut: F) {
+        tokio::task::spawn(fut);
+    }
+}
+
+/// A Timer that uses the tokio runtime.
+
+#[derive(Clone, Debug)]
+pub struct TokioTimer;
+
+impl hyper::rt::Timer for TokioTimer {
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
+        let s = tokio::time::sleep(duration);
+        let hs = TokioSleep { inner: Box::pin(s) };
+        Box::pin(hs)
+    }
+
+    fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
+        Box::pin(TokioSleep {
+            inner: Box::pin(tokio::time::sleep_until(deadline.into())),
+        })
+    }
+}
+
+struct TokioTimeout<T> {
+    inner: Pin<Box<tokio::time::Timeout<T>>>,
+}
+
+impl<T> Future for TokioTimeout<T>
+where
+    T: Future,
+{
+    type Output = Result<T::Output, tokio::time::error::Elapsed>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(context)
+    }
+}
+
+// Use TokioSleep to get tokio::time::Sleep to implement Unpin.
+// see https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html
+pub(crate) struct TokioSleep {
+    pub(crate) inner: Pin<Box<tokio::time::Sleep>>,
+}
+
+impl Future for TokioSleep {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
+}
+
+// Use HasSleep to get tokio::time::Sleep to implement Unpin.
+// see https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html
+
+impl Sleep for TokioSleep {}
+
+pub fn http2_server() -> http2::Builder<TokioExecutor> {
+    let mut b = http2::Builder::new(TokioExecutor);
+    b.timer(TokioTimer);
+    b
+}
+
+pub fn http1_server() -> http1::Builder {
+    let mut b = http1::Builder::new();
+    b.timer(TokioTimer);
+    b
+}
+
+pub fn http2_client() -> client::conn::http2::Builder {
+    let mut b = client::conn::http2::Builder::new(TokioExecutor);
+    b.timer(TokioTimer);
+    b
+}
+
+pub fn pooling_client<B>() -> ::hyper_util::client::legacy::Client<HttpConnector, B>
+where
+    B: http_body_1::Body + Send,
+    B::Data: Send,
+{
+    ::hyper_util::client::legacy::Client::builder(::hyper_util::rt::TokioExecutor::new())
+        .timer(TokioTimer)
+        .build_http()
+}
+
+pub fn empty_response(code: hyper::StatusCode) -> Response<Full<Bytes>> {
     Response::builder()
         .status(code)
-        .body(Body::default())
+        .body(Full::default())
         .unwrap()
 }
 
-pub fn plaintext_response(code: hyper::StatusCode, body: String) -> Response<Body> {
+pub fn plaintext_response(code: hyper::StatusCode, body: String) -> Response<Full<Bytes>> {
     Response::builder()
         .status(code)
         .header(hyper::header::CONTENT_TYPE, "text/plain")
@@ -71,100 +172,82 @@ pub fn plaintext_response(code: hyper::StatusCode, body: String) -> Response<Bod
 /// Server implements a generic HTTP server with the follow behavior:
 /// * HTTP/1.1 plaintext only
 /// * Draining
-/// * Triggers the app to shutdown on errors
 pub struct Server<S> {
     name: String,
-    addr: SocketAddr,
-    server: hyper::server::Builder<AddrIncoming>,
-    shutdown_trigger: signal::ShutdownTrigger,
+    bind: TcpListener,
     drain_rx: Watch,
     state: Arc<S>,
 }
 
 impl<S> Server<S> {
-    pub fn bind(
-        name: &str,
-        addr: SocketAddr,
-        shutdown_trigger: signal::ShutdownTrigger,
-        drain_rx: Watch,
-        s: S,
-    ) -> hyper::Result<Self> {
-        let bind = AddrIncoming::bind(&addr)?;
-        let addr = bind.local_addr();
-        let server = hyper::Server::builder(bind)
-            .http1_half_close(true)
-            .http1_header_read_timeout(Duration::from_secs(2))
-            .http1_max_buf_size(8 * 1024);
-
+    pub async fn bind(name: &str, addr: SocketAddr, drain_rx: Watch, s: S) -> anyhow::Result<Self> {
+        let bind = TcpListener::bind(&addr).await?;
         Ok(Server {
             name: name.to_string(),
-            addr,
-            server,
-            shutdown_trigger,
+            bind,
             drain_rx,
             state: Arc::new(s),
         })
     }
 
     pub fn address(&self) -> SocketAddr {
-        self.addr
+        self.bind.local_addr().expect("local address must be ready")
     }
 
     pub fn spawn<F, R>(self, f: F)
     where
         S: Send + Sync + 'static,
-        F: Fn(Arc<S>, Request<Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<Body>, hyper::Error>> + Send + Sync + 'static,
+        F: Fn(Arc<S>, Request<hyper::body::Incoming>) -> R + Send + Sync + 'static,
+        R: Future<Output = Result<Response<Full<Bytes>>, hyper::Error>> + Send + Sync + 'static,
     {
-        let drain_rx = self.drain_rx;
-        let name = self.name.clone();
-        let (tx, rx) = oneshot::channel();
+        use futures_util::StreamExt as OtherStreamExt;
+        let address = self.address();
+        let drain_stream = self.drain_rx.clone();
+        let drain_connections = self.drain_rx;
+        let _name = self.name.clone();
+        // let (tx, rx) = oneshot::channel();
         let state = self.state.clone();
         let f = Arc::new(f);
-        let server = self
-            .server
-            .serve(hyper::service::make_service_fn(move |_conn| {
-                let state = state.clone();
-                let f = f.clone();
-                async {
-                    Ok::<_, hyper::Error>(hyper::service::service_fn(move |req| {
-                        let state = state.clone();
-
-                        f(state, req)
-                    }))
-                }
-            }))
-            .with_graceful_shutdown(async move {
-                // Wait until the drain is signaled
-                let shutdown = drain_rx.signaled().await;
-                // Once `shutdown` is dropped, we are declaring the drain is complete. Hyper will start draining
-                // once with_graceful_shutdown function exists, so we need to exit the function but later
-                // drop `shutdown`.
-                if tx.send(shutdown).is_err() {
-                    error!("{name}: receiver dropped");
-                }
-                info!("starting drain of {name} server");
-            });
-
         info!(
-            address=%self.addr,
+            %address,
             component=self.name,
             "listener established",
         );
-        let shutdown_trigger = self.shutdown_trigger;
-        let name = self.name;
         tokio::spawn(async move {
-            if let Err(err) = server.await {
-                error!("Serving {name} start failed: {err}");
-                shutdown_trigger.shutdown_now().await;
-            } else {
-                // Now that the server has gracefully exited, drop `shutdown` to allow draining to proceed
-                match rx.await {
-                    Ok(shutdown) => drop(shutdown),
-                    Err(_) => info!("{name} sender dropped"),
-                }
-                info!("{name} server terminated");
+            let stream = tokio_stream::wrappers::TcpListenerStream::new(self.bind);
+            let mut stream = stream.take_until(Box::pin(drain_stream.signaled()));
+            while let Some(Ok(socket)) = stream.next().await {
+                let drain = drain_connections.clone();
+                let f = f.clone();
+                let state = state.clone();
+                tokio::spawn(async move {
+                    let serve = http1_server()
+                        .half_close(true)
+                        .header_read_timeout(Duration::from_secs(2))
+                        .max_buf_size(8 * 1024)
+                        .serve_connection(
+                            socket,
+                            hyper::service::service_fn(move |req| {
+                                let state = state.clone();
+
+                                f(state, req)
+                            }),
+                        );
+                    match futures_util::future::select(Box::pin(drain.signaled()), serve).await {
+                        futures_util::future::Either::Left((_shutdown, mut server)) => {
+                            let drain = std::pin::Pin::new(&mut server);
+                            drain.graceful_shutdown();
+                            server.await
+                        }
+                        futures_util::future::Either::Right((server, _shutdown)) => server,
+                    }
+                });
             }
+            info!(
+                %address,
+                component=self.name,
+                "listener drained",
+            );
         });
     }
 }

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -217,6 +217,7 @@ impl<S> Server<S> {
             let stream = tokio_stream::wrappers::TcpListenerStream::new(self.bind);
             let mut stream = stream.take_until(Box::pin(drain_stream.signaled()));
             while let Some(Ok(socket)) = stream.next().await {
+                socket.set_nodelay(true).unwrap();
                 let drain = drain_connections.clone();
                 let f = f.clone();
                 let state = state.clone();

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -14,13 +14,14 @@
 
 use std::collections::BTreeMap;
 
-use crate::config::RootCert;
 use async_trait::async_trait;
 use prost_types::value::Kind;
 use prost_types::Struct;
 use tonic::codegen::InterceptedService;
+
 use tracing::{instrument, warn};
 
+use crate::config::RootCert;
 use crate::identity::auth::AuthSource;
 use crate::identity::manager::Identity;
 use crate::identity::Error;
@@ -41,6 +42,9 @@ impl CaClient {
         enable_impersonated_identity: bool,
     ) -> Result<CaClient, Error> {
         let svc = tls::grpc_connector(address, root_cert)?;
+        // let client = IstioCertificateServiceClient::new(svc);
+        // let svc =
+        //     tower_hyper_http_body_compat::Hyper1HttpServiceAsTowerService03HttpService::new(svc);
         let client = IstioCertificateServiceClient::with_interceptor(svc, auth);
         Ok(CaClient {
             client,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -20,7 +20,8 @@ use std::{fmt, io};
 
 use boring::error::ErrorStack;
 use drain::Watch;
-use hyper::{header, Body, Request};
+
+use hyper::{header, Request};
 use rand::Rng;
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::time::timeout;
@@ -299,7 +300,7 @@ fn parse_socket_or_ip(i: &str) -> Option<IpAddr> {
         .or_else(|| i.parse::<IpAddr>().ok())
 }
 
-pub fn get_original_src_from_fwded(req: &Request<Body>) -> Option<IpAddr> {
+pub fn get_original_src_from_fwded<T>(req: &Request<T>) -> Option<IpAddr> {
     req.headers()
         .get(header::FORWARDED)
         .and_then(|rh| rh.to_str().ok())
@@ -379,6 +380,8 @@ pub async fn relay(
 mod tests {
     use std::assert_eq;
 
+    use bytes::Bytes;
+    use http_body_util::Empty;
     use hyper::http::request;
     use test_case::test_case;
 
@@ -400,7 +403,7 @@ mod tests {
     fn string_match(header: &str, expect: Option<&str>) {
         let headers = request::Builder::new()
             .header(header::FORWARDED, header)
-            .body(Body::empty())
+            .body(Empty::<Bytes>::new())
             .unwrap();
         let expect = expect.map(|i| i.parse::<IpAddr>().unwrap());
         assert_eq!(get_original_src_from_fwded(&headers), expect)

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -18,11 +18,15 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Instant;
 
+use bytes::Bytes;
 use drain::Watch;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use futures::stream::StreamExt;
+
+use http_body_util::Empty;
+use hyper::body::Incoming;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::oneshot;
 use tracing::{debug, error, info, instrument, trace, trace_span, warn, Instrument};
 
 use crate::baggage::parse_baggage_header;
@@ -78,67 +82,58 @@ impl Inbound {
     }
 
     pub(super) async fn run(self) {
-        let (tx, rx) = oneshot::channel();
-        let service = make_service_fn(|socket: &tokio_boring::SslStream<TcpStream>| {
-            let dst = crate::socket::orig_dst_addr_or_default(socket.get_ref());
-            let conn = rbac::Connection {
-                src_identity: socket
-                    .ssl()
-                    .peer_certificate()
-                    .and_then(|x| crate::tls::boring::extract_sans(&x).first().cloned()),
-                src_ip: to_canonical(socket.get_ref().peer_addr().unwrap()).ip(),
-                dst,
-            };
-            let workloads = self.workloads.clone();
-            debug!(%conn, "accepted connection");
-            let enable_original_source = self.cfg.enable_original_source;
-            let metrics = self.metrics.clone();
-            async move {
-                Ok::<_, hyper::Error>(service_fn(move |req| {
-                    Self::serve_connect(
-                        workloads.clone(),
-                        conn.clone(),
-                        enable_original_source.unwrap_or_default(),
-                        req,
-                        metrics.clone(),
-                    )
-                }))
-            }
-        });
-
+        // let (tx, rx) = oneshot::channel();
         let acceptor = InboundCertProvider {
             workloads: self.workloads.clone(),
             cert_manager: self.cert_manager.clone(),
         };
-        let tls_stream = crate::hyper_util::tls_server(acceptor, self.listener);
-        let incoming = hyper::server::accept::from_stream(tls_stream);
-
-        let server = Server::builder(incoming)
-            .http2_only(true)
-            .http2_initial_stream_window_size(self.cfg.window_size)
-            .http2_initial_connection_window_size(self.cfg.connection_window_size)
-            .http2_max_frame_size(self.cfg.frame_size)
-            .serve(service)
-            .with_graceful_shutdown(async {
-                // Wait until the drain is signaled
-                let shutdown = self.drain.signaled().await;
-                // Once `shutdown` is dropped, we are declaring the drain is complete. Hyper will start draining
-                // once with_graceful_shutdown function exists, so we need to exit the function but later
-                // drop `shutdown`.
-                if tx.send(shutdown).is_err() {
-                    error!("HBONE receiver dropped")
+        let workloads = self.workloads;
+        let drain_stream = self.drain.clone();
+        let stream = crate::hyper_util::tls_server(acceptor, self.listener);
+        let mut stream = stream.take_until(Box::pin(drain_stream.signaled()));
+        while let Some(socket) = stream.next().await {
+            let workloads = workloads.clone();
+            let metrics = self.metrics.clone();
+            let drain = self.drain.clone();
+            tokio::task::spawn(async move {
+                let dst = crate::socket::orig_dst_addr_or_default(socket.get_ref());
+                let conn = rbac::Connection {
+                    src_identity: socket
+                        .ssl()
+                        .peer_certificate()
+                        .and_then(|x| crate::tls::boring::extract_sans(&x).first().cloned()),
+                    src_ip: to_canonical(socket.get_ref().peer_addr().unwrap()).ip(),
+                    dst,
+                };
+                debug!(%conn, "accepted connection");
+                let enable_original_source = self.cfg.enable_original_source;
+                let server = crate::hyper_util::http2_server()
+                    .initial_stream_window_size(self.cfg.window_size)
+                    .initial_connection_window_size(self.cfg.connection_window_size)
+                    .max_frame_size(self.cfg.frame_size)
+                    .serve_connection(
+                        socket,
+                        service_fn(move |req| {
+                            Self::serve_connect(
+                                workloads.clone(),
+                                conn.clone(),
+                                enable_original_source.unwrap_or_default(),
+                                req,
+                                metrics.clone(),
+                            )
+                        }),
+                    );
+                match futures_util::future::select(Box::pin(drain.signaled()), server).await {
+                    futures_util::future::Either::Left((_shutdown, mut server)) => {
+                        let drain = std::pin::Pin::new(&mut server);
+                        drain.graceful_shutdown();
+                        server.await
+                    }
+                    futures_util::future::Either::Right((server, _shutdown)) => server,
                 }
-                info!("starting drain of inbound connections");
             });
-
-        if let Err(e) = server.await {
-            error!("server error: {}", e);
         }
-        // Now that the server has gracefully exited, drop `shutdown` to allow draining to proceed
-        match rx.await {
-            Ok(shutdown) => drop(shutdown),
-            Err(_) => info!("HBONE sender dropped"),
-        }
+        info!("all inbound connections drained");
     }
 
     /// handle_inbound serves an inbound connection with a target address `addr`.
@@ -226,7 +221,7 @@ impl Inbound {
         }
     }
 
-    fn extract_traceparent(req: &Request<Body>) -> TraceParent {
+    fn extract_traceparent(req: &Request<Incoming>) -> TraceParent {
         req.headers()
             .get(TRACEPARENT_HEADER)
             .and_then(|b| b.to_str().ok())
@@ -243,9 +238,9 @@ impl Inbound {
         workloads: WorkloadInformation,
         conn: rbac::Connection,
         enable_original_source: bool,
-        req: Request<Body>,
+        req: Request<Incoming>,
         metrics: Arc<Metrics>,
-    ) -> Result<Response<Body>, hyper::Error> {
+    ) -> Result<Response<Empty<Bytes>>, hyper::Error> {
         match req.method() {
             &Method::CONNECT => {
                 let uri = req.uri();
@@ -254,8 +249,8 @@ impl Inbound {
                 if addr.is_err() {
                     info!("Sending 400, {:?}", addr.err());
                     return Ok(Response::builder()
-                        .status(hyper::StatusCode::BAD_REQUEST)
-                        .body(Body::empty())
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(Empty::new())
                         .unwrap());
                 }
 
@@ -264,7 +259,7 @@ impl Inbound {
                     info!("Sending 400, ip mismatch {addr} != {}", conn.dst);
                     return Ok(Response::builder()
                         .status(StatusCode::BAD_REQUEST)
-                        .body(Body::empty())
+                        .body(Empty::new())
                         .unwrap());
                 }
                 // Orig has 15008, swap with the real port
@@ -273,7 +268,7 @@ impl Inbound {
                     info!(%conn, "unknown destination");
                     return Ok(Response::builder()
                         .status(StatusCode::NOT_FOUND)
-                        .body(Body::empty())
+                        .body(Empty::new())
                         .unwrap());
                 };
                 let (has_waypoint, from_waypoint) =
@@ -285,14 +280,14 @@ impl Inbound {
                     info!(%conn, "RBAC rejected");
                     return Ok(Response::builder()
                         .status(StatusCode::UNAUTHORIZED)
-                        .body(Body::empty())
+                        .body(Empty::new())
                         .unwrap());
                 }
                 if has_waypoint && !from_waypoint {
                     info!(%conn, "bypassed waypoint");
                     return Ok(Response::builder()
                         .status(StatusCode::UNAUTHORIZED)
-                        .body(Body::empty())
+                        .body(Empty::new())
                         .unwrap());
                 }
                 let source_ip = if from_waypoint {
@@ -344,15 +339,15 @@ impl Inbound {
 
                 Ok(Response::builder()
                     .status(status_code)
-                    .body(Body::empty())
+                    .body(Empty::new())
                     .unwrap())
             }
             // Return the 404 Not Found for other routes.
             method => {
                 info!("Sending 404, got {method}");
                 Ok(Response::builder()
-                    .status(hyper::StatusCode::NOT_FOUND)
-                    .body(Body::empty())
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Empty::new())
                     .unwrap())
             }
         }
@@ -390,7 +385,7 @@ pub(super) enum InboundConnect {
     /// context directly to the inbound handling in memory.
     DirectPath(TcpStream),
     /// Hbone is a standard HBONE request coming from the network.
-    Hbone(Request<Body>),
+    Hbone(Request<Incoming>),
 }
 
 #[derive(Clone)]

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -266,7 +266,7 @@ impl OutboundConnection {
                     .configure()
                     .expect("configure");
                 let tcp_stream = super::freebind_connect(local, req.gateway).await?;
-                tcp_stream.set_nodelay(false)?; // TODO: this is backwards of expectations
+                tcp_stream.set_nodelay(true)?; // TODO: this is backwards of expectations
                 let tls_stream = connect_tls(connector, tcp_stream).await?;
                 let (mut request_sender, connection) = builder
                     .handshake(tls_stream)

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -16,6 +16,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::time::Instant;
 
 use boring::ssl::ConnectConfiguration;
+use bytes::Bytes;
 use drain::Watch;
 use hyper::header::FORWARDED;
 use hyper::StatusCode;
@@ -29,7 +30,8 @@ use crate::metrics::traffic::Reporter;
 use crate::proxy::inbound::{Inbound, InboundConnect};
 use crate::proxy::{util, Error, ProxyInputs, TraceParent, BAGGAGE_HEADER, TRACEPARENT_HEADER};
 use crate::workload::{Protocol, Workload};
-use crate::{proxy, rbac, socket};
+use crate::{hyper_util, proxy, rbac, socket};
+use http_body_util::Empty;
 
 pub struct Outbound {
     pi: ProxyInputs,
@@ -229,12 +231,12 @@ impl OutboundConnection {
                 // Using the raw connection API, instead of client, is a bit annoying, but the only reasonable
                 // way to work around https://github.com/hyperium/hyper/issues/2863
                 // Eventually we will need to implement our own smarter pooling, TLS handshaking, etc anyways.
-                let mut builder = hyper::client::conn::Builder::new();
+                let mut builder =
+                    hyper::client::conn::http2::Builder::new(hyper_util::TokioExecutor);
                 let builder = builder
-                    .http2_only(true)
-                    .http2_initial_stream_window_size(self.pi.cfg.window_size)
-                    .http2_max_frame_size(self.pi.cfg.frame_size)
-                    .http2_initial_connection_window_size(self.pi.cfg.connection_window_size);
+                    .initial_stream_window_size(self.pi.cfg.window_size)
+                    .max_frame_size(self.pi.cfg.frame_size)
+                    .initial_connection_window_size(self.pi.cfg.connection_window_size);
 
                 let mut f = http_types::proxies::Forwarded::new();
                 f.add_for(remote_addr.to_string());
@@ -249,7 +251,7 @@ impl OutboundConnection {
                     )
                     .header(FORWARDED, f.value().unwrap())
                     .header(TRACEPARENT_HEADER, self.id.header())
-                    .body(hyper::Body::empty())
+                    .body(Empty::<Bytes>::new())
                     .unwrap();
                 let local = self
                     .pi
@@ -284,6 +286,7 @@ impl OutboundConnection {
                     return Err(Error::HttpStatus(code));
                 }
                 let mut upgraded = hyper::upgrade::on(response).await?;
+
                 super::copy_hbone(
                     &mut upgraded,
                     &mut stream,

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -266,7 +266,7 @@ impl OutboundConnection {
                     .configure()
                     .expect("configure");
                 let tcp_stream = super::freebind_connect(local, req.gateway).await?;
-                tcp_stream.set_nodelay(true)?;
+                tcp_stream.set_nodelay(false)?; // TODO: this is backwards of expectations
                 let tls_stream = connect_tls(connector, tcp_stream).await?;
                 let (mut request_sender, connection) = builder
                     .handshake(tls_stream)

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -110,6 +110,7 @@ impl TestServer {
     pub async fn run(self) {
         loop {
             let (mut socket, _) = self.listener.accept().await.unwrap();
+            socket.set_nodelay(true).unwrap();
 
             tokio::spawn(async move {
                 let (mut r, mut w) = socket.split();

--- a/src/tls/boring.rs
+++ b/src/tls/boring.rs
@@ -16,7 +16,7 @@ use std::pin::Pin;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::str::FromStr;
-use std::task::Poll;
+use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use boring::asn1::{Asn1Time, Asn1TimeRef};
@@ -33,13 +33,14 @@ use boring::x509::extension::{
 };
 use boring::x509::verify::X509CheckFlags;
 use boring::x509::{self, X509StoreContext, X509StoreContextRef, X509VerifyResult};
-use hyper::client::ResponseFuture;
-use hyper::server::conn::AddrStream;
-use hyper::{Request, Uri};
+use bytes::Bytes;
+use http_body_1::{Body, Frame};
+use hyper::body::Incoming;
+use hyper::{Request, Response, Uri};
 use rand::RngCore;
 use tokio::net::TcpStream;
 use tonic::body::BoxBody;
-use tower::Service;
+use tower_hyper_http_body_compat::{HttpBody04ToHttpBody1, HttpBody1ToHttpBody04};
 use tracing::{error, info};
 
 use crate::config::RootCert;
@@ -156,7 +157,7 @@ impl PartialEq for Certs {
 }
 
 impl Certs {
-    pub fn chain(&self) -> Result<bytes::Bytes, Error> {
+    pub fn chain(&self) -> Result<Bytes, Error> {
         Ok(self.chain[0].x509.to_pem()?.into())
     }
 
@@ -201,7 +202,10 @@ impl Certs {
 #[derive(Clone, Debug)]
 pub struct TlsGrpcChannel {
     uri: Uri,
-    client: hyper::Client<hyper_boring::HttpsConnector<hyper::client::HttpConnector>, BoxBody>,
+    client: hyper_util::client::legacy::Client<
+        hyper_boring::HttpsConnector<hyper_util::client::connect::HttpConnector>,
+        BoxBody1,
+    >,
 }
 
 /// grpc_connector provides a client TLS channel for gRPC requests.
@@ -225,7 +229,7 @@ pub fn grpc_connector(uri: String, root_cert: RootCert) -> Result<TlsGrpcChannel
         }
         RootCert::Default => {} // Already configured to use system root certs
     }
-    let mut http = hyper::client::HttpConnector::new();
+    let mut http = hyper_util::client::connect::HttpConnector::new();
     http.enforce_http(false);
     let mut https = hyper_boring::HttpsConnector::with_connector(http, conn)?;
     https.set_callback(move |cc, _| {
@@ -241,13 +245,70 @@ pub fn grpc_connector(uri: String, root_cert: RootCert) -> Result<TlsGrpcChannel
 
     // Configure hyper's client to be h2 only and build with the
     // correct https connector.
-    let hyper = hyper::Client::builder()
+    let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
         .http2_only(true)
         .http2_keep_alive_interval(Duration::from_secs(30))
         .http2_keep_alive_timeout(Duration::from_secs(10))
+        .timer(crate::hyper_util::TokioTimer)
         .build(https);
 
-    Ok(TlsGrpcChannel { uri, client: hyper })
+    Ok(TlsGrpcChannel { uri, client })
+}
+
+type BoxBody1 = HttpBody04ToHttpBody1<BoxBody>;
+
+#[derive(Default)]
+pub enum DefaultIncoming {
+    Some(Incoming),
+    #[default]
+    Empty,
+}
+
+impl Body for DefaultIncoming {
+    type Data = Bytes;
+    type Error = hyper::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match self.get_mut() {
+            DefaultIncoming::Some(ref mut i) => Pin::new(i).poll_frame(cx),
+            DefaultIncoming::Empty => Pin::new(&mut http_body_util::Empty::<Bytes>::new())
+                .poll_frame(cx)
+                .map_err(|_| unreachable!()),
+        }
+    }
+}
+
+impl tower::Service<Request<BoxBody>> for TlsGrpcChannel {
+    type Response = Response<HttpBody1ToHttpBody04<DefaultIncoming>>;
+    type Error = hyper_util::client::legacy::Error;
+    // type Error = hyper::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Ok(()).into()
+    }
+
+    fn call(&mut self, req: Request<BoxBody>) -> Self::Future {
+        let mut req = req.map(HttpBody04ToHttpBody1::new);
+
+        let uri = Uri::builder()
+            .scheme(self.uri.scheme().unwrap().to_owned())
+            .authority(self.uri.authority().unwrap().to_owned())
+            .path_and_query(req.uri().path_and_query().unwrap().to_owned())
+            .build()
+            .unwrap();
+        *req.uri_mut() = uri;
+        let future = self.client.request(req);
+        Box::pin(async move {
+            let res = future.await?;
+            Ok(res
+                .map(DefaultIncoming::Some)
+                .map(HttpBody1ToHttpBody04::new))
+        })
+    }
 }
 
 impl Certs {
@@ -398,27 +459,6 @@ impl SanChecker for x509::X509 {
     }
 }
 
-impl Service<Request<BoxBody>> for TlsGrpcChannel {
-    type Response = hyper::Response<hyper::Body>;
-    type Error = hyper::Error;
-    type Future = ResponseFuture;
-
-    fn poll_ready(&mut self, _: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Ok(()).into()
-    }
-
-    fn call(&mut self, mut req: Request<BoxBody>) -> Self::Future {
-        let uri = Uri::builder()
-            .scheme(self.uri.scheme().unwrap().to_owned())
-            .authority(self.uri.authority().unwrap().to_owned())
-            .path_and_query(req.uri().path_and_query().unwrap().to_owned())
-            .build()
-            .unwrap();
-        *req.uri_mut() = uri;
-        self.client.request(req)
-    }
-}
-
 enum Alpn {
     H2,
 }
@@ -474,7 +514,7 @@ pub enum TlsError {
     SslError(#[from] Error),
 }
 
-impl<F> tls_listener::AsyncTls<AddrStream> for BoringTlsAcceptor<F>
+impl<F> tls_listener::AsyncTls<TcpStream> for BoringTlsAcceptor<F>
 where
     F: CertProvider + Clone + 'static,
 {
@@ -482,12 +522,11 @@ where
     type Error = TlsError;
     type AcceptFuture = Pin<Box<dyn Future<Output = Result<Self::Stream, Self::Error>> + Send>>;
 
-    fn accept(&self, conn: AddrStream) -> Self::AcceptFuture {
-        let inner = conn.into_inner();
+    fn accept(&self, conn: TcpStream) -> Self::AcceptFuture {
         let mut acceptor = self.acceptor.clone();
         Box::pin(async move {
-            let tls = acceptor.fetch_cert(&inner).await?;
-            tokio_boring::accept(&tls, inner)
+            let tls = acceptor.fetch_cert(&conn).await?;
+            tokio_boring::accept(&tls, conn)
                 .await
                 .map_err(TlsError::Handshake)
         })

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -14,7 +14,6 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Display, Formatter};
-
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, mem};
@@ -655,7 +654,19 @@ pub enum AdsError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        time::SystemTime,
+    };
+
+    use prost::Message;
+    use prost_types::Any;
+    use textnonce::TextNonce;
+    use tokio::time::sleep;
+
+    use workload::Workload;
+    use xds::istio::workload::Workload as XdsWorkload;
+
     use crate::{
         test_helpers::{
             helpers::{self},
@@ -664,16 +675,8 @@ mod tests {
         workload,
         xds::{istio::workload::WorkloadType, WORKLOAD_TYPE},
     };
-    use prost::Message;
-    use prost_types::Any;
-    use std::{
-        net::{IpAddr, Ipv4Addr},
-        time::SystemTime,
-    };
-    use textnonce::TextNonce;
-    use tokio::time::sleep;
-    use workload::Workload;
-    use xds::istio::workload::Workload as XdsWorkload;
+
+    use super::*;
 
     const POLL_RATE: Duration = Duration::from_millis(2);
     const TEST_TIMEOUT: Duration = Duration::from_millis(100);

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::Bytes;
+use http_body_util::Empty;
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
-use hyper::{Body, Method};
+use hyper::Method;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
@@ -335,14 +337,14 @@ async fn test_waypoint_bypass() -> anyhow::Result<()> {
     let srv = resolve_target(manager.resolver(), "server");
     client
         .run(move || async move {
-            let mut builder = hyper::client::conn::Builder::new();
-            let builder = builder.http2_only(true);
+            let builder =
+                hyper::client::conn::http2::Builder::new(ztunnel::hyper_util::TokioExecutor);
 
             let request = hyper::Request::builder()
                 .uri(&srv.to_string())
                 .method(Method::CONNECT)
                 .version(hyper::Version::HTTP_2)
-                .body(Body::empty())
+                .body(Empty::<Bytes>::new())
                 .unwrap();
 
             let id = &identity::Identity::default();
@@ -390,14 +392,14 @@ async fn test_hbone_ip_mismatch() -> anyhow::Result<()> {
     let srv = resolve_target(manager.resolver(), "server");
     client
         .run(move || async move {
-            let mut builder = hyper::client::conn::Builder::new();
-            let builder = builder.http2_only(true);
+            let builder =
+                hyper::client::conn::http2::Builder::new(ztunnel::hyper_util::TokioExecutor);
 
             let request = hyper::Request::builder()
                 .uri(&srv.to_string())
                 .method(Method::CONNECT)
                 .version(hyper::Version::HTTP_2)
-                .body(Body::empty())
+                .body(Empty::<Bytes>::new())
                 .unwrap();
 
             let id = &identity::Identity::default();


### PR DESCRIPTION
This moves us to Hyper 1.0. This is not 100% fully launched but its in rc3 and pretty close. AS we are alpha, I think its appropriate to bite the bullet now and move early. The main bummer is we need to fork `boring` for a bit since they won't move to 1.0 until post-rc.

This will unblock https://github.com/istio/ztunnel/pull/293

Benchmarks show some concerning data but I think its a symptom of https://github.com/istio/ztunnel/issues/424 rather than a real regression