### PR TITLE
Add PROXY_MODE setting, remove ENABLE_IMPERSONATED_IDENTITY

### DIFF
--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -19,6 +19,7 @@ use std::fmt::Write;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::config::ProxyMode;
 use async_trait::async_trait;
 
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
@@ -386,7 +387,7 @@ impl SecretManager {
             cfg.ca_address.unwrap(),
             cfg.ca_root_cert,
             cfg.auth,
-            cfg.enable_impersonated_identity,
+            cfg.proxy_mode == ProxyMode::Node,
         )?;
         Ok(Self::new_with_client(caclient))
     }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -284,15 +284,14 @@ impl OutboundConnection {
                     return Err(Error::HttpStatus(code));
                 }
                 let mut upgraded = hyper::upgrade::on(response).await?;
-                let res = super::copy_hbone(
+                super::copy_hbone(
                     &mut upgraded,
                     &mut stream,
                     &self.pi.metrics,
                     transferred_bytes,
                 )
                 .instrument(trace_span!("hbone client"))
-                .await;
-                res
+                .await
             }
             Protocol::TCP => {
                 info!(

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -103,7 +103,6 @@ impl TestApp {
         let body = body::to_bytes(body).await?;
         let iter = std::str::from_utf8(&body)?
             .lines()
-            .into_iter()
             .map(|x| Ok::<_, io::Error>(x.to_string()));
         let scrape = prometheus_parse::Scrape::parse(iter).unwrap();
         Ok(ParsedMetrics { scrape })

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -28,7 +28,7 @@ use tracing::{debug, error, info, instrument, trace};
 use xds::istio::security::Authorization as XdsAuthorization;
 use xds::istio::workload::Workload as XdsWorkload;
 
-use crate::config::ConfigSource;
+use crate::config::{ConfigSource, ProxyMode};
 use crate::identity::{Identity, SecretManager};
 use crate::metrics::Metrics;
 use crate::rbac::{Authorization, RbacScope};
@@ -320,27 +320,7 @@ impl WorkloadManager {
         });
         let workloads: Arc<Mutex<WorkloadStore>> = Arc::new(Mutex::new(WorkloadStore {
             cert_tx: Some(tx),
-            local_node: {
-                if config.enable_impersonated_identity {
-                    config.local_node.clone()
-                } else {
-                    None
-                }
-            },
-            local_pod: {
-                if config.enable_impersonated_identity {
-                    None
-                } else {
-                    config.local_pod.clone()
-                }
-            },
-            local_namespace: {
-                if config.enable_impersonated_identity {
-                    None
-                } else {
-                    config.local_pod_namespace.clone()
-                }
-            },
+            proxy_mode: config.proxy_mode.clone(),
             ..Default::default()
         }));
         let xds_workloads = workloads.clone();
@@ -592,13 +572,9 @@ pub struct WorkloadStore {
     #[serde(skip_serializing, default)]
     cert_tx: Option<mpsc::Sender<Identity>>,
 
-    // needed to determine whether or not to prefetch certs, will be None if ENABLE_IMPERSONATED_IDENTITY
-    // is set to false.
-    local_node: Option<String>,
-    // needed to determine whether or not to prefetch certs in serverless environment, will be None if
-    // ENABLE_IMPERSONATED_IDENTITY set to true.
-    local_pod: Option<String>,
-    local_namespace: Option<String>,
+    // needed to determine whether or not to prefetch certs
+    proxy_mode: ProxyMode,
+    local_node: Option<String>
 }
 
 impl WorkloadStore {
@@ -638,10 +614,8 @@ impl WorkloadStore {
                 }
             }
         }
-        if Some(&w.node) == self.local_node.as_ref()
-            || (Some(&w.name) == self.local_pod.as_ref()
-                && Some(&w.namespace) == self.local_namespace.as_ref())
-        {
+
+        if self.proxy_mode == ProxyMode::Node && Some(&w.node) == self.local_node.as_ref() {
             if let Some(tx) = self.cert_tx.as_mut() {
                 if let Err(e) = tx.try_send(widentity) {
                     info!("couldn't prefetch: {:?}", e)

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -574,7 +574,7 @@ pub struct WorkloadStore {
 
     // needed to determine whether or not to prefetch certs
     proxy_mode: ProxyMode,
-    local_node: Option<String>
+    local_node: Option<String>,
 }
 
 impl WorkloadStore {


### PR DESCRIPTION
1. Add `PROXY_MODE`, the proxy mode of ztunnel, `node` or `sidecar`, default to `node`.
2. Remove `ENABLE_IMPERSONATED_IDENTITY`, replaced by `PROXY_MODE`.

When set `PROXY_MODE` to `sidecar`:
1. Only fetch cert for the current pod (from env `POD_NAME` and `POD_NAMESPACE`).
2. Disable impersonated identity when fetching cert.
3. Disable fast path (`DirectLocal`).
4. Disable recursion check.

Refers https://github.com/istio/ztunnel/pull/448#issuecomment-1464672506

cc @howardjohn @bleggett @hzxuzhonghu 