### PR TITLE
skip serializing bytes content of root certs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -59,7 +59,7 @@ const DEFAULT_ROOT_CERT_PROVIDER: &str = "./var/run/secrets/istio/root-cert.pem"
 #[derive(serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum RootCert {
     File(PathBuf),
-    Static(Bytes),
+    Static(#[serde(skip)] Bytes),
     Default,
 }
 


### PR DESCRIPTION
Fixes #461 

Now if you're missing a valid cert in the env or the file doesn't exist you get 

```
ca_root_cert: Static
```

when logging the config contents, and then you get 

```
Error: failed to create CSR: invalid root certificate: [NO_START_LINE]
```


Less cryptic, doesn't block testing setups that don't care about root certs. 

