### PR TITLE
Rename proxy mode "Sidecar" to "Serverless"

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -57,8 +57,8 @@ const XDS_ROOT_CERT_PROVIDER_ENV: &str = "XDS_CERT_PROVIDER";
 const CA_ROOT_CERT_PROVIDER_ENV: &str = "CA_CERT_PROVIDER";
 const DEFAULT_ROOT_CERT_PROVIDER: &str = "./var/run/secrets/istio/root-cert.pem";
 
-const PROXY_MODE_SIDECAR: &str = "sidecar";
-const PROXY_MODE_NODE: &str = "node";
+const PROXY_MODE_DEDICATED: &str = "dedicated";
+const PROXY_MODE_SHARED: &str = "shared";
 
 #[derive(serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum RootCert {
@@ -85,8 +85,8 @@ impl ConfigSource {
 #[derive(serde::Serialize, Default, Clone, Debug, PartialEq, Eq)]
 pub enum ProxyMode {
     #[default]
-    Node,
-    Sidecar,
+    Shared,
+    Dedicated,
 }
 
 #[derive(serde::Serialize, Clone, Debug, PartialEq, Eq)]
@@ -105,7 +105,7 @@ pub struct Config {
 
     /// The name of the node this ztunnel is running as.
     pub local_node: Option<String>,
-    /// The proxy mode of ztunnel, Node or Sidecar, default to Node.
+    /// The proxy mode of ztunnel, Shared or Dedicated, default to Shared.
     pub proxy_mode: ProxyMode,
     /// The local_ip we are running at.
     pub local_ip: Option<IpAddr>,
@@ -277,11 +277,11 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         local_node: parse(NODE_NAME)?,
         proxy_mode: match parse::<String>(PROXY_MODE)? {
             Some(proxy_mode) => match proxy_mode.as_str() {
-                PROXY_MODE_SIDECAR => ProxyMode::Sidecar,
-                PROXY_MODE_NODE => ProxyMode::Node,
+                PROXY_MODE_DEDICATED => ProxyMode::Dedicated,
+                PROXY_MODE_SHARED => ProxyMode::Shared,
                 _ => return Err(Error::EnvVar(PROXY_MODE.to_string(), proxy_mode)),
             },
-            None => ProxyMode::Node,
+            None => ProxyMode::Shared,
         },
         local_ip: parse(INSTANCE_IP)?,
         cluster_id,

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -388,7 +388,7 @@ impl SecretManager {
             cfg.ca_address.unwrap(),
             cfg.ca_root_cert,
             cfg.auth,
-            cfg.proxy_mode == ProxyMode::Node,
+            cfg.proxy_mode == ProxyMode::Shared,
         )?;
         Ok(Self::new_with_client(caclient))
     }

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -85,7 +85,7 @@ impl InboundPassthrough {
     ) -> Result<(), Error> {
         let orig = socket::orig_dst_addr_or_default(&inbound);
         // Check if it is a recursive call when proxy mode is Node.
-        if pi.cfg.proxy_mode == ProxyMode::Node && Some(orig.ip()) == pi.cfg.local_ip {
+        if pi.cfg.proxy_mode == ProxyMode::Shared && Some(orig.ip()) == pi.cfg.local_ip {
             return Err(Error::SelfCall);
         }
         info!(%source, destination=%orig, component="inbound plaintext", "accepted connection");

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -128,7 +128,7 @@ impl OutboundConnection {
         orig_dst_addr: SocketAddr,
         block_passthrough: bool,
     ) -> Result<(), Error> {
-        if self.pi.cfg.proxy_mode == ProxyMode::Node
+        if self.pi.cfg.proxy_mode == ProxyMode::Shared
             && Some(orig_dst_addr.ip()) == self.pi.cfg.local_ip
         {
             return Err(Error::SelfCall);
@@ -143,7 +143,7 @@ impl OutboundConnection {
             // domains. But for socks5
             return Err(Error::UnknownDestination(req.destination.ip()));
         }
-        let can_fastpath = self.pi.cfg.proxy_mode == ProxyMode::Node
+        let can_fastpath = self.pi.cfg.proxy_mode == ProxyMode::Shared
             && req.protocol == Protocol::HBONE
             && !req
                 .destination_workload

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -615,7 +615,7 @@ impl WorkloadStore {
             }
         }
 
-        if self.proxy_mode == ProxyMode::Node && Some(&w.node) == self.local_node.as_ref() {
+        if self.proxy_mode == ProxyMode::Shared && Some(&w.node) == self.local_node.as_ref() {
             if let Some(tx) = self.cert_tx.as_mut() {
                 if let Err(e) = tx.try_send(widentity) {
                     info!("couldn't prefetch: {:?}", e)


### PR DESCRIPTION
* Ztunnel is more of a VPC or network layer, not a full-blown sidecar.
* Also to avoid confusion with the old sidecars.

Check comments here: https://docs.google.com/document/d/135gWueRb5KW2vc0RerE2vGKBoCFxbqoLVBuTGJBcxO4/edit?disco=AAAArETr0pI