### PR TITLE
disable san check on ca response for dedicated proxy

### DIFF
--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -55,7 +55,7 @@ impl CaClient {
         let cs = tls::CsrOptions {
             san: id.to_string(),
         }
-            .generate()?;
+        .generate()?;
         let csr: Vec<u8> = cs.csr;
         let pkey = cs.pkey;
 
@@ -250,7 +250,7 @@ mod tests {
         let res = test_ca_client_with_response(IstioCertificateResponse {
             cert_chain: vec![String::from_utf8(certs.x509().to_pem().unwrap()).unwrap()],
         })
-            .await;
+        .await;
         assert_matches!(res, Err(Error::SanError(_)));
     }
 
@@ -264,7 +264,7 @@ mod tests {
         let res = test_ca_client_with_response(IstioCertificateResponse {
             cert_chain: vec![String::from_utf8(certs.x509().to_pem().unwrap()).unwrap()],
         })
-            .await;
+        .await;
         assert_matches!(res, Ok(_));
     }
 }

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -55,7 +55,7 @@ impl CaClient {
         let cs = tls::CsrOptions {
             san: id.to_string(),
         }
-        .generate()?;
+            .generate()?;
         let csr: Vec<u8> = cs.csr;
         let pkey = cs.pkey;
 
@@ -96,9 +96,11 @@ impl CaClient {
             vec![]
         };
         let certs = tls::cert_from(&pkey, leaf, chain);
-        certs
-            .verify_san(id)
-            .map_err(|_| Error::SanError(id.to_owned()))?;
+        if self.enable_impersonated_identity {
+            certs
+                .verify_san(id)
+                .map_err(|_| Error::SanError(id.to_owned()))?;
+        }
         Ok(certs)
     }
 }
@@ -248,7 +250,7 @@ mod tests {
         let res = test_ca_client_with_response(IstioCertificateResponse {
             cert_chain: vec![String::from_utf8(certs.x509().to_pem().unwrap()).unwrap()],
         })
-        .await;
+            .await;
         assert_matches!(res, Err(Error::SanError(_)));
     }
 
@@ -262,7 +264,7 @@ mod tests {
         let res = test_ca_client_with_response(IstioCertificateResponse {
             cert_chain: vec![String::from_utf8(certs.x509().to_pem().unwrap()).unwrap()],
         })
-        .await;
+            .await;
         assert_matches!(res, Ok(_));
     }
 }

--- a/src/test_helpers/ca.rs
+++ b/src/test_helpers/ca.rs
@@ -75,7 +75,7 @@ impl CaServer {
             "https://".to_string() + &server_addr.to_string(),
             root_cert,
             AuthSource::Token(PathBuf::from(r"src/test_helpers/fake-jwt")),
-            false,
+            true,
         )
         .unwrap();
         (tx, client)


### PR DESCRIPTION
If the ztunnel knows what it's local identity _should_ be we could check that instead of ignoring the check like I'm doing in this PR. 

AFAIK we have no similar check in istio-agent. 
This check was originally added to fail early if we ended up fetching the ztunnel identity instead of the one we wanted to impersonate in shared mode. 