### PR TITLE
Tweak config_dump format for certs

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -35,7 +35,7 @@ use tracing::error;
 
 use crate::config::Config;
 use crate::hyper_util::{empty_response, plaintext_response, Server};
-use crate::identity::{self, SecretManager};
+use crate::identity::SecretManager;
 use crate::tls::asn1_time_to_system_time;
 use crate::version::BuildInfo;
 use crate::workload::LocalConfig;
@@ -167,7 +167,7 @@ async fn dump_certs(cert_manager: &SecretManager) -> Vec<CertsDump> {
                 identity: id.to_string(),
                 ..Default::default()
             };
-            use identity::CertState::*;
+            use crate::identity::CertState::*;
             match certs {
                 Initializing(_) => dump.state = "Initializing".to_string(),
                 Unavailable(err) => dump.state = format!("Unavailable: {err}"),

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -31,7 +31,6 @@ use crate::tls;
 use super::CaClient;
 use super::Error::{self, Spiffe};
 
-
 const CERT_REFRESH_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(60);
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]


### PR DESCRIPTION
 - Expose errors to /config_dump instead of via tracing
 - Use empty ca_cert lists instead of a list with dummy object for unavailable certificates (note: can also not have the field altotheget for non-available certs, not sure which is preferred)