### PR TITLE
Don't treat server side GoAway as an error

### DIFF
--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -277,6 +277,8 @@ impl AdsClient {
                     || status.code() == tonic::Code::DeadlineExceeded
                     || (status.code() == tonic::Code::Unavailable
                         && status.message().contains("transport is closing"))
+                    || (status.code() == tonic::Code::Unavailable
+                        && status.message().contains("received prior goaway"))
                 {
                     debug!(
                         "XDS client terminated: {}, retrying in {:?}",


### PR DESCRIPTION
I'm occasionally seeing this kind of warnings:
```
2023-03-22T12:00:52.411100Z  WARN xds{id=4}: ztunnel::xds::client: XDS client error: gRPC error (The service is currently unavailable): closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, retrying in 160ms
``` 
which imo shouldn't be treated as an error and shouldn't get logged with normal level nor have error metric.