### PR TITLE
sample changes to proto

### DIFF
--- a/examples/localhost.yaml
+++ b/examples/localhost.yaml
@@ -22,7 +22,7 @@ workloads:
       80: 8080
 policies:
   - action: Allow
-    groups:
+    rules:
     - - - not_destination_ports:
           - 9999
     name: deny-9999

--- a/proto/authorization.proto
+++ b/proto/authorization.proto
@@ -45,13 +45,14 @@ message Rule {
 message Clause {
   // The logical behavior between the matches (if there are more than one)
   //  MatchBehavior match_behavior = 1;
+  // Matches are OR-ed
   // Match is a generic form of the authz policy's expressions contained in To, From and When.
   repeated Match matches = 2;
 }
 
 message Match {
-  // Values of specific type are ORed
-  // If multiple types are set, they are ANDed
+  // Values of specific type are OR-ed
+  // If multiple types are set, they are AND-ed
 
   repeated StringMatch namespaces = 1;
   repeated StringMatch not_namespaces = 2;

--- a/proto/authorization.proto
+++ b/proto/authorization.proto
@@ -29,22 +29,23 @@ message Authorization {
   // The action to take if the request is matched with the rules.
   // Default is ALLOW if not specified.
   Action action = 4;
-  // Set of RBAC policy groups each containing its rules.
-  // If at least one of the groups is matched the policy action will
+  // Set of RBAC policy rules each containing its cluases (To, From, When).
+  // If at least one of the rules is matched the policy action will
   // take place.
-  // Groups are OR-ed.
-  repeated Group groups = 5;
+  // Rules are OR-ed.
+  repeated Rule rules = 5;
 }
 
-message Group {
-  // Rules are AND-ed
+message Rule {
+  // Clauses are AND-ed
   // This is a generic form of the authz policy's to, from and when
-  repeated Rules rules = 1;
+  repeated Clause clauses = 1;
 }
 
-message Rules {
+message Clause {
   // The logical behavior between the matches (if there are more than one)
   //  MatchBehavior match_behavior = 1;
+  // Match is a generic form of the authz policy's expressions contained in To, From and When.
   repeated Match matches = 2;
 }
 


### PR DESCRIPTION
Quick example of proposed changes for #500 so we have something tangible to look at.

TLDR:

- `groups` was changed to `rules` to align with the user-facing API and a rule now contains `clauses` which is my name for a generic representation of "to, from, when".
- `match` was left the same for now. I think that's pretty reasonable. Other idea was to call it `expression` but that's not really more descriptive.

I do realize this will conflict with #495 and will need some rework once that merges.