### PR TITLE
reduce number of buffers used when handling hbone traffic

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -178,8 +178,7 @@ pub async fn copy_hbone(
 
     let client_to_server = async {
         let mut ri = tokio::io::BufReader::with_capacity(HBONE_BUFFER_SIZE, &mut ri);
-        let mut wo = tokio::io::BufWriter::with_capacity(HBONE_BUFFER_SIZE, &mut wo);
-        let res = tokio::io::copy(&mut ri, &mut wo).await;
+        let res = tokio::io::copy_buf(&mut ri, &mut wo).await;
         trace!(?res, "hbone -> tcp");
         received = res?;
         wo.shutdown().await
@@ -187,8 +186,7 @@ pub async fn copy_hbone(
 
     let server_to_client = async {
         let mut ro = tokio::io::BufReader::with_capacity(HBONE_BUFFER_SIZE, &mut ro);
-        let mut wi = tokio::io::BufWriter::with_capacity(HBONE_BUFFER_SIZE, &mut wi);
-        let res = tokio::io::copy(&mut ro, &mut wi).await;
+        let res = tokio::io::copy_buf(&mut ro, &mut wi).await;
         trace!(?res, "tcp -> hbone");
         sent = res?;
         wi.shutdown().await


### PR DESCRIPTION
I noticed that tokio::io::[copy](https://docs.rs/tokio/latest/tokio/io/fn.copy.html) uses an 8k heap-allocated buffer to copy the data. The documentation suggests that if you want to control the size of the buffer being used which I believe we do you may use tokio::io::[copy_buf](https://docs.rs/tokio/latest/tokio/io/fn.copy_buf.html) which doesn't allocate it's own buffer and instead makes use of the reader's inner buffer.