### PR TITLE
Remove global TERMINATION_GRACE_PERIOD

### DIFF
--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -126,8 +126,7 @@ async fn test_shutdown_drain() {
 async fn test_shutdown_forced_drain() {
     helpers::initialize_telemetry();
 
-    let mut cfg = test_config();
-    cfg.termination_grace_period = Duration::from_millis(10);
+    let cfg = test_config();
 
     let cert_manager = new_secret_manager(Duration::from_secs(10));
     let app = ztunnel::app::build_with_cert(cfg, cert_manager.clone())


### PR DESCRIPTION
- We do not need or want a ztunnel-level termination grace duration setting. 
  - Otherwise we have to always make sure to synchronize it to be LESS-THAN whatever the platform-level process manager (K8S, systemd, whatever) termination grace period is.
  - It doesn't actually buy us anything to have this setting, since downstream connections can _only_ be gracefully terminated by clients, not ztunnel (all ztunnel can do is RST, which is send-and-forget and immediate), and upstream connections made by ztunnel should be immediately terminated as a matter of course.
  - L7/HTTP/2 has GOAWAY but `ztunnel` is a TCP proxy and currently implements no functionality where this would be useful.
- ztunnel should begin draining on SIGTERM, and keep draining until either all connections are drained or a more insistent TERM signal arrives.
- The only exception to this is the corner case when ztunnel is acting as its _own_ process manager - e.g. it self-terminates. For this, the existing hardcoded constant is used, since `/quitquitquit` on the admin API is arguably an escape hatch hack and not something that should be used as a matter of course, or that needs external config.

Issue ref: https://github.com/istio/ztunnel/issues/519

Istio sibling PR: https://github.com/istio/istio/pull/44813