### PR TITLE
Less noisy workload deletion

### DIFF
--- a/src/workload.rs
+++ b/src/workload.rs
@@ -1176,7 +1176,9 @@ impl WorkloadStore {
             return;
         }
         let parts = xds_name.split_once('/');
-        if parts.is_none() {
+        // check count != 1 to avoid trying to delete obvious workload UIDs as a service,
+        // which can result in noisy logs when new workloads are added (we remove -> add)
+        if parts.is_none() || xds_name.matches('/').count() != 1 {
             // we don't have ns/hostname xds primary key for service
             warn!(
                 "tried to remove service keyed by {} but it did not have the expected ns/hostname format",

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -1190,7 +1190,7 @@ impl WorkloadStore {
         }
 
         let parts = xds_name.split_once('/');
-        if parts.is_none() || xds_name.matches('/').count() != 1 {
+        if parts.is_none() {
             // we don't have namespace/hostname xds primary key for service
             warn!(
                 "tried to remove service keyed by {} but it did not have the expected namespace/hostname format",

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -1178,7 +1178,7 @@ impl WorkloadStore {
         let parts = xds_name.split_once('/');
         if parts.is_none() {
             // we don't have ns/hostname xds primary key for service
-            trace!(
+            warn!(
                 "tried to remove service keyed by {} but it did not have the expected ns/hostname format",
                 xds_name
             );


### PR DESCRIPTION
This fixes noisy and misleading warning logs, although the behavior is not actually buggy.

For example:
```
2023-05-26T15:19:15.913384Z  INFO xds{id=1}: ztunnel::xds::client: received response type_url="type.googleapis.com/istio.workload.Address" size=27
2023-05-26T15:19:15.914854Z  WARN xds{id=1}: ztunnel::workload: tried to remove service keyed by Kubernetes//v1/pod/kube-system/kube-dns-autoscaler-5f56f8997c-f8jlz but it was not found
2023-05-26T15:19:15.915163Z  WARN xds{id=1}: ztunnel::workload: tried to remove service keyed by Kubernetes//v1/pod/kube-system/kube-dns-5b5dfcd97b-n7krd but it was not found
2023-05-26T15:19:15.915394Z  WARN xds{id=1}: ztunnel::workload: tried to remove service keyed by Kubernetes//v1/pod/istio-system/istiod-cb5bccc75-8998g but it was not found
2023-05-26T15:19:15.915561Z  WARN xds{id=1}: ztunnel::workload: tried to remove service keyed by Kubernetes//v1/pod/kube-system/event-exporter-gke-755c4b4d97-f2mjf but it was not found
2023-05-26T15:19:15.915741Z  WARN xds{id=1}: ztunnel::workload: tried to remove service keyed by Kubernetes//v1/pod/kube-system/konnectivity-agent-59544fbdc7-26cs2 but it was not found
```

is misleading because things are working as expected (no reason to warn); we removed a workload successfully. there's no reason to try to remove as a service too