### PR TITLE
Initial DNS proxy implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,12 +19,18 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -49,9 +55,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "async-channel"
@@ -66,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -77,13 +83,13 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -94,7 +100,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -116,9 +122,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.12"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -127,7 +133,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body 0.4.5",
- "hyper 0.14.25",
+ "hyper 0.14.26",
  "itoa",
  "matchit",
  "memchr",
@@ -144,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -169,7 +175,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -185,6 +191,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bindgen"
@@ -234,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -282,24 +294,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -308,15 +320,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -324,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -335,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -356,49 +368,39 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "concurrent-queue"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "console-api"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.9.2",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+checksum = "57ab2224a0311582eb03adba4caaf18644f7b1f10a760803a803b9b605187fc7"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -412,7 +414,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -420,15 +422,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
+checksum = "2c76f98bdfc7f66172e6c7065f981ebb576ffc903fe4c0561d9f0c2509226dc6"
 dependencies = [
  "cfg-if",
 ]
@@ -482,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -503,69 +505,31 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
+name = "data-encoding"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.10",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.10",
-]
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "debugid"
@@ -604,14 +568,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
-name = "errno"
-version = "0.2.8"
+name = "endian-type"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -669,12 +651,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -701,7 +683,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -712,18 +694,18 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -736,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -746,15 +728,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -763,15 +745,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -784,32 +766,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -836,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -847,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -876,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -947,6 +929,17 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
 
 [[package]]
 name = "http"
@@ -1033,9 +1026,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1101,7 +1094,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.25",
+ "hyper 0.14.26",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1127,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1141,19 +1134,29 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1186,13 +1189,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2 0.5.3",
+ "widestring",
+ "windows-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -1221,9 +1236,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1242,9 +1257,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -1254,15 +1269,6 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1282,15 +1288,27 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "local-ip-address"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2815836665de176ba66deaa449ada98fdf208d84730d1a84a22cbeed6151a6fa"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys",
+]
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1298,12 +1316,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
- "cfg-if",
+ "linked-hash-map",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -1352,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -1381,15 +1411,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.6"
+name = "miniz_oxide"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1399,6 +1437,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "netns-rs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1469,15 @@ checksum = "23541694f1d7d18cd1a0da3a1352a6ea48b01cbb4a8e7a6e547963823fd5276e"
 dependencies = [
  "nix 0.23.2",
  "thiserror",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -1454,16 +1526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,18 +1546,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -1505,9 +1567,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "overload"
@@ -1517,9 +1579,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -1533,15 +1595,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1552,9 +1614,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -1568,22 +1630,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1600,15 +1662,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1619,15 +1681,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
@@ -1673,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca9c6be70d989d21a136eb86c2d83e4b328447fac4a88dace2143c179c86267"
+checksum = "fff39edfcaec0d64e8d0da38564fad195d2d51b680940295fcc307366e101e61"
 dependencies = [
  "autocfg",
  "indexmap",
@@ -1707,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -1751,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1761,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -1783,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1796,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
@@ -1829,12 +1891,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.26"
+name = "quick-error"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -1896,7 +1974,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -1942,22 +2020,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1966,7 +2044,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1976,10 +2054,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.22"
+name = "regex-syntax"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -1998,16 +2092,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2038,12 +2132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,29 +2139,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",
@@ -2105,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.19"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2167,12 +2255,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8d618c6641ae355025c449427f9e96b98abf99a772be3cef6708d15c77147a"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2223,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.10"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2240,40 +2328,32 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
+ "windows-sys",
 ]
 
 [[package]]
 name = "test-case"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679b019fb241da62cc449b33b224d19ebe1c6767b495569765115dd7f7f9fba4"
+checksum = "2a1d6e7bde536b0412f20765b76e921028059adfd1b90d8974d33fd3c91b25df"
 dependencies = [
  "test-case-macros",
 ]
 
 [[package]]
 name = "test-case-core"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dc21b5887f4032c4656502d085dc28f2afbb686f25f216472bb0526f4b1b88"
+checksum = "d10394d5d1e27794f772b6fc854c7e91a2dc26e2cbf807ad523370c2a59c0cee"
 dependencies = [
  "cfg-if",
  "proc-macro-error",
@@ -2284,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "test-case-macros"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3786898e0be151a96f730fd529b0e8a10f5990fa2a7ea14e37ca27613c05190"
+checksum = "eeb9a44b1c6a54c1ba58b152797739dba2a83ca74e18168a68c980eb142f9404"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2328,7 +2408,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2351,6 +2431,22 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+dependencies = [
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "tinytemplate"
@@ -2391,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2406,7 +2502,7 @@ dependencies = [
  "socket2 0.4.9",
  "tokio-macros",
  "tracing",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2431,20 +2527,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2453,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2466,6 +2562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tonic"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,28 +2578,49 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
  "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.5",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio-stream",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.2",
  "bytes",
  "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body 0.4.5",
- "hyper 0.14.25",
+ "hyper 0.14.26",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -2573,33 +2699,23 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -2615,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2629,6 +2745,96 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trust-dns-client"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c408c32e6a9dbb38037cece35740f2cf23c875d8ca134d33631cec83f74d3fe"
+dependencies = [
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-util",
+ "lazy_static",
+ "radix_trie",
+ "rand 0.8.5",
+ "thiserror",
+ "time 0.3.22",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.2.3",
+ "ipnet",
+ "lazy_static",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "lru-cache",
+ "parking_lot",
+ "resolv-conf",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
+name = "trust-dns-server"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99022f9befa6daec2a860be68ac28b1f0d9d7ccf441d8c5a695e35a58d88840d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "enum-as-inner",
+ "futures-executor",
+ "futures-util",
+ "serde",
+ "thiserror",
+ "time 0.3.22",
+ "tokio",
+ "toml",
+ "tracing",
+ "trust-dns-client",
+ "trust-dns-proto",
+ "trust-dns-resolver",
 ]
 
 [[package]]
@@ -2645,9 +2851,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -2659,34 +2865,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unsafe-libyaml"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.4.0",
  "percent-encoding",
  "serde",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 
 [[package]]
 name = "valuable"
@@ -2718,11 +2918,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -2746,9 +2945,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2756,24 +2955,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2781,28 +2980,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2818,6 +3017,12 @@ dependencies = [
  "libc",
  "once_cell",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -2852,42 +3057,27 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2900,45 +3090,55 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]
 
 [[package]]
 name = "ztunnel"
@@ -2970,6 +3170,7 @@ dependencies = [
  "ipnet",
  "itertools",
  "libc",
+ "local-ip-address",
  "log",
  "matches",
  "netns-rs",
@@ -2987,7 +3188,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "socket2 0.5.1",
+ "socket2 0.5.3",
  "test-case",
  "textnonce",
  "thiserror",
@@ -2995,11 +3196,16 @@ dependencies = [
  "tokio",
  "tokio-boring",
  "tokio-stream",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
  "tower",
  "tower-hyper-http-body-compat",
  "tracing",
  "tracing-subscriber",
+ "trust-dns-client",
+ "trust-dns-proto",
+ "trust-dns-resolver",
+ "trust-dns-server",
  "url",
+ "ztunnel",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ default = ["fips"]
 gperftools = ["dep:gperftools"]
 console = ["dep:console-subscriber"]
 fips = ["boring/fips", "hyper-boring/fips", "tokio-boring/fips"]
+testing = [] # Enables utilites supporting tests.
 
 [lib]
 path = "src/lib.rs"
@@ -78,6 +79,12 @@ tower-hyper-http-body-compat = { version = "0", features = ["server", "http2"] }
 futures-util = "0.3.26"
 chrono = "0.4.23"
 
+# DNS
+trust-dns-client = "0.22.0"
+trust-dns-proto = "0.22.0"
+trust-dns-resolver = "0.22.0"
+trust-dns-server = { version = "0.22.1", features = [ "trust-dns-resolver" ] }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1.0"
 
@@ -100,8 +107,12 @@ lto = false
 incremental = true
 
 [dev-dependencies]
+# Enable testing utils on this crate.
+ztunnel = { version = "0.0.0", path = ".", features = [ "testing" ] }
+
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 diff = "0.1.13"
+local-ip-address = "0.5.3"
 matches = "0.1.9"
 test-case = "3.0.0"
 #debug = true

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -19,12 +19,18 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -49,9 +55,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "arbitrary"
@@ -89,7 +95,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -100,7 +106,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -195,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -246,24 +252,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -272,15 +278,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -299,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -328,16 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,9 +350,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
+checksum = "2c76f98bdfc7f66172e6c7065f981ebb576ffc903fe4c0561d9f0c2509226dc6"
 dependencies = [
  "cfg-if",
 ]
@@ -420,69 +416,31 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
+name = "data-encoding"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.13",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.13",
-]
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "debugid"
@@ -515,6 +473,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,7 +498,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -592,7 +568,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -603,9 +579,9 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -681,7 +657,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -727,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -738,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -756,9 +732,9 @@ checksum = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd"
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -824,6 +800,17 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
 
 [[package]]
 name = "http"
@@ -904,9 +891,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -984,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -998,19 +985,29 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1043,13 +1040,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2 0.5.3",
+ "widestring",
+ "windows-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -1087,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1108,9 +1117,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1134,15 +1143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,15 +1159,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1175,12 +1175,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
- "cfg-if",
+ "linked-hash-map",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -1190,6 +1202,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -1217,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -1241,14 +1259,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1265,6 +1282,15 @@ checksum = "23541694f1d7d18cd1a0da3a1352a6ea48b01cbb4a8e7a6e547963823fd5276e"
 dependencies = [
  "nix 0.23.2",
  "thiserror",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -1313,16 +1339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,18 +1359,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -1364,9 +1380,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "overload"
@@ -1392,15 +1408,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1411,9 +1427,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -1427,22 +1443,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1459,9 +1475,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1472,15 +1488,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
@@ -1526,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca9c6be70d989d21a136eb86c2d83e4b328447fac4a88dace2143c179c86267"
+checksum = "fff39edfcaec0d64e8d0da38564fad195d2d51b680940295fcc307366e101e61"
 dependencies = [
  "autocfg",
  "indexmap",
@@ -1536,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -1580,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1590,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -1612,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1625,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
@@ -1658,12 +1674,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.26"
+name = "quick-error"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -1725,7 +1757,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -1771,15 +1803,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -1789,13 +1812,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1804,7 +1827,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1814,10 +1837,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.22"
+name = "regex-syntax"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -1836,16 +1875,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1870,12 +1909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,29 +1916,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1999,12 +2032,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8d618c6641ae355025c449427f9e96b98abf99a772be3cef6708d15c77147a"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2055,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.13"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2066,24 +2099,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2119,7 +2144,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2142,6 +2167,22 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+dependencies = [
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "tinytemplate"
@@ -2182,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2196,7 +2237,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.4.9",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2211,20 +2252,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2233,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2243,6 +2284,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2346,20 +2396,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2378,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2392,6 +2442,96 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trust-dns-client"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c408c32e6a9dbb38037cece35740f2cf23c875d8ca134d33631cec83f74d3fe"
+dependencies = [
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-util",
+ "lazy_static",
+ "radix_trie",
+ "rand 0.8.5",
+ "thiserror",
+ "time 0.3.22",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.2.3",
+ "ipnet",
+ "lazy_static",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "lru-cache",
+ "parking_lot",
+ "resolv-conf",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
+name = "trust-dns-server"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99022f9befa6daec2a860be68ac28b1f0d9d7ccf441d8c5a695e35a58d88840d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "enum-as-inner",
+ "futures-executor",
+ "futures-util",
+ "serde",
+ "thiserror",
+ "time 0.3.22",
+ "tokio",
+ "toml",
+ "tracing",
+ "trust-dns-client",
+ "trust-dns-proto",
+ "trust-dns-resolver",
 ]
 
 [[package]]
@@ -2408,9 +2548,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -2422,12 +2562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,21 +2569,21 @@ checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.4.0",
  "percent-encoding",
  "serde",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 
 [[package]]
 name = "valuable"
@@ -2475,11 +2609,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -2503,9 +2636,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2513,24 +2646,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2538,28 +2671,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2575,6 +2708,12 @@ dependencies = [
  "libc",
  "once_cell",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -2613,16 +2752,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2631,22 +2761,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2655,20 +2770,14 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2678,21 +2787,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2702,21 +2799,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2726,27 +2811,25 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]
 
 [[package]]
 name = "ztunnel"
@@ -2790,7 +2873,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "socket2 0.5.1",
+ "socket2 0.5.3",
  "textnonce",
  "thiserror",
  "tls-listener",
@@ -2803,6 +2886,10 @@ dependencies = [
  "tower-hyper-http-body-compat",
  "tracing",
  "tracing-subscriber",
+ "trust-dns-client",
+ "trust-dns-proto",
+ "trust-dns-resolver",
+ "trust-dns-server",
  "url",
 ]
 
@@ -2811,7 +2898,7 @@ name = "ztunnel-fuzz"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "hyper 0.14.25",
+ "hyper 0.14.26",
  "libfuzzer-sys",
  "prost",
  "ztunnel",

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -760,7 +760,7 @@ mod tests {
             // ..Default::default() // intentionally don't default. we want all fields populated
         };
 
-        let proxy_state = new_proxy_state(vec![wl], vec![svc], vec![auth]).unwrap();
+        let proxy_state = new_proxy_state(&[wl], &[svc], &[auth]);
 
         let default_config = construct_config(ProxyConfig::default())
             .expect("could not build Config without ProxyConfig");

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@ const DEFAULT_WORKER_THREADS: u16 = 2;
 const DEFAULT_ADMIN_PORT: u16 = 15000;
 const DEFAULT_READINESS_PORT: u16 = 15021;
 const DEFAULT_STATS_PORT: u16 = 15020;
+const DEFAULT_DNS_PORT: u16 = 15053;
 const DEFAULT_SELFTERM_DEADLINE: Duration = Duration::from_secs(5);
 const DEFAULT_CLUSTER_ID: &str = "Kubernetes";
 
@@ -103,6 +104,9 @@ pub struct Config {
     pub inbound_addr: SocketAddr,
     pub inbound_plaintext_addr: SocketAddr,
     pub outbound_addr: SocketAddr,
+    /// The socket address for the DNS proxy.
+    /// Only applies if `ISTIO_META_DNS_CAPTURE` is enabled.
+    pub dns_proxy_addr: SocketAddr,
 
     /// The network of the node this ztunnel is running on.
     pub network: String,
@@ -277,6 +281,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15008),
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15006),
         outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15001),
+        dns_proxy_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), DEFAULT_DNS_PORT),
 
         network: parse(NETWORK)?.unwrap_or_default(),
         local_node: parse(NODE_NAME)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod app;
 pub mod baggage;
 pub mod cert_fetcher;
 pub mod config;
+pub mod hyper_util;
 pub mod identity;
 pub mod metrics;
 pub mod proxy;
@@ -32,5 +33,5 @@ pub mod tls;
 pub mod version;
 pub mod xds;
 
-pub mod hyper_util;
+#[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;

--- a/src/proxy/dns.rs
+++ b/src/proxy/dns.rs
@@ -1,0 +1,1172 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod forwarder;
+pub mod name_util;
+pub mod proxy;
+pub mod resolver;
+
+use crate::config::ProxyMode;
+use crate::proxy::dns::name_util::trim_domain;
+use crate::proxy::dns::resolver::{Answer, Resolver};
+use crate::proxy::Error;
+use crate::state::service::Service;
+use crate::state::workload::{NetworkAddress, Workload};
+use crate::state::ProxyState;
+use itertools::Itertools;
+use log::warn;
+use once_cell::sync::Lazy;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::collections::HashSet;
+use std::net::{IpAddr, SocketAddr};
+use std::ops::Deref;
+use std::str::FromStr;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use tokio::net::{TcpListener, UdpSocket};
+use trust_dns_proto::error::ProtoErrorKind;
+use trust_dns_proto::op::ResponseCode;
+use trust_dns_proto::rr::{Name, RData, Record, RecordType};
+use trust_dns_resolver::system_conf::read_system_conf;
+use trust_dns_server::authority::LookupError;
+use trust_dns_server::server::Request;
+use trust_dns_server::ServerFuture;
+
+const DEFAULT_TCP_REQUEST_TIMEOUT: u64 = 5;
+const DEFAULT_TTL_SECONDS: u32 = 30;
+
+static SVC_CLUSTER_LOCAL: Lazy<Name> = Lazy::new(|| Name::from_str("svc.cluster.local").unwrap());
+static CLUSTER_LOCAL: Lazy<Name> = Lazy::new(|| Name::from_str("cluster.local").unwrap());
+
+/// A proxy that serves known hostnames from ztunnel data structures. Unknown hosts are
+/// forwarded to an upstream resolver.
+pub(super) struct DnsProxy {
+    addr: SocketAddr,
+    server: ServerFuture<proxy::Proxy>,
+}
+
+impl DnsProxy {
+    /// Creates a new proxy.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - The socket address on which to run the DNS proxy.
+    /// * `network` - The network of the current node.
+    /// * `state` - The state of this proxy.
+    /// * `forwarder` - The forwarder to use for requests not handled by this proxy.
+    pub(super) async fn new<S: AsRef<str>>(
+        addr: SocketAddr,
+        network: S,
+        state: Arc<RwLock<ProxyState>>,
+        forwarder: Arc<dyn Forwarder>,
+    ) -> Result<Self, Error> {
+        // Create the DNS server, backed by ztunnel data structures.
+        let handler = proxy::Proxy::new(Arc::new(DnsStore {
+            state,
+            network: network.as_ref().to_string(),
+            forwarder,
+        }));
+        let mut server = ServerFuture::new(handler);
+
+        // Bind and register the UDP socket.
+        let udp_socket = UdpSocket::bind(addr)
+            .await
+            .map_err(|e| Error::Bind(addr, e))?;
+        server.register_socket(udp_socket);
+
+        // Bind and register the TCP socket.
+        let tcp_listener = TcpListener::bind(addr)
+            .await
+            .map_err(|e| Error::Bind(addr, e))?;
+        server.register_listener(
+            tcp_listener,
+            Duration::from_secs(DEFAULT_TCP_REQUEST_TIMEOUT),
+        );
+
+        Ok(Self { addr, server })
+    }
+
+    /// Returns the address to which this DNS proxy is bound.
+    pub(super) fn address(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Runs this DNS proxy to completion.
+    pub async fn run(self) {
+        // TODO(nmittler): Do we need to use drain?
+        if let Err(e) = self.server.block_until_done().await {
+            match e.kind() {
+                ProtoErrorKind::NoError => (),
+                _ => warn!("DNS server shutdown error: {e}"),
+            }
+        }
+    }
+}
+
+/// A DNS [Resolver] backed by the ztunnel [ProxyState].
+struct DnsStore {
+    network: String,
+    state: Arc<RwLock<ProxyState>>,
+    forwarder: Arc<dyn Forwarder>,
+}
+
+impl DnsStore {
+    /// Find the workload for the client address.
+    fn find_client(&self, client_addr: SocketAddr) -> Option<Workload> {
+        let state = self.state.read().unwrap();
+        state.workloads.find_workload(&NetworkAddress {
+            network: self.network.clone(),
+            address: client_addr.ip(),
+        })
+    }
+
+    /// Enumerates the possible aliases for the requested hostname
+    fn get_aliases(&self, client: &Workload, name: &Name) -> Vec<Alias> {
+        let mut out = Vec::new();
+        let mut added = HashSet::new();
+
+        let mut add_alias = |alias: Alias| {
+            if !added.contains(&alias.name) {
+                added.insert(alias.name.clone());
+                out.push(alias);
+            }
+        };
+
+        // Insert the requested name.
+        add_alias(Alias {
+            name: name.clone(),
+            stripped: None,
+        });
+
+        // If the name can be expanded to a k8s FQDN, add that as well.
+        if let Some(kube_fqdn) = to_kube_fqdn(client, name) {
+            add_alias(Alias {
+                name: kube_fqdn,
+                stripped: None,
+            });
+        }
+
+        // Strip the search domains from the requested host and add aliases.
+        for search_domain in self.forwarder.search_domains(client) {
+            if let Some(stripped_name) = trim_domain(name, &search_domain) {
+                // Insert an alias for a stripped search domain.
+                add_alias(Alias {
+                    name: stripped_name.clone(),
+                    stripped: Some(Stripped {
+                        name: stripped_name.clone(),
+                        search_domain: search_domain.clone(),
+                    }),
+                });
+
+                // If the name can be expanded to a k8s FQDN, add that as well.
+                if let Some(kube_fqdn) = to_kube_fqdn(client, &stripped_name) {
+                    add_alias(Alias {
+                        name: kube_fqdn,
+                        stripped: Some(Stripped {
+                            name: stripped_name.clone(),
+                            search_domain: search_domain.clone(),
+                        }),
+                    });
+                }
+            }
+        }
+
+        out
+    }
+
+    fn find_service(&self, client: &Workload, requested_name: &Name) -> Option<ServiceMatch> {
+        // Lock the workload store for the duration of this function, since we're calling it
+        // in a loop.
+        let state = self.state.read().unwrap();
+
+        // Iterate over all possible aliases for the requested hostname from the perspective of
+        // the client (e.g. <svc>, <svc>.<ns>, <svc>.<ns>.svc, <svc>.<ns>.svc.cluster.local).
+        for alias in self.get_aliases(client, requested_name) {
+            // For each alias, try matching against all possible wildcards.
+            //
+            // For example, if the alias is 'www.example.com`, we'll try to match in the
+            // following order:
+            //
+            //   'www.example.com' (the alias, itself)
+            //   '*.example.com'
+            //   '*.com'
+            for mut search_name in get_wildcards(&alias.name) {
+                // Convert the name to a string for lookup, removing the trailing '.'.
+                search_name.set_fqdn(false);
+                let search_name_str = search_name.to_string();
+                search_name.set_fqdn(true);
+
+                if let Some(services) = state.services.get_by_host(&search_name_str) {
+                    // We found a match. We always return `Some` result, even if there
+                    // are zero records returned.
+
+                    // Get the service matching the client namespace. If no match exists, just
+                    // return the first service.
+                    let service = services
+                        .iter()
+                        .find_or_first(|service| service.namespace == client.namespace)
+                        .cloned()
+                        // Should never be empty, since we delete the Vec when it's empty.
+                        .unwrap();
+
+                    return Some(ServiceMatch {
+                        service,
+                        name: search_name,
+                        alias,
+                    });
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Gets the list of addresses of the requested record type from the service.
+    fn get_addresses(
+        &self,
+        client: &Workload,
+        service: &Service,
+        record_type: RecordType,
+    ) -> Vec<IpAddr> {
+        let mut addrs = Vec::new();
+
+        // TODO(https://github.com/istio/ztunnel/issues/554): Add support for headless services.
+        if !service.vips.is_empty() {
+            // Add service VIPs that are callable from the client.
+            for network_addr in &service.vips {
+                if is_record_type(&network_addr.address, record_type)
+                    && client.network == network_addr.network
+                {
+                    addrs.push(network_addr.address)
+                }
+            }
+        }
+
+        // Randomize the order of the returned addresses.
+        addrs.shuffle(&mut thread_rng());
+
+        addrs
+    }
+}
+
+#[async_trait::async_trait]
+impl Resolver for DnsStore {
+    async fn lookup(&self, request: &Request) -> Result<Answer, LookupError> {
+        // Find the client workload.
+        let client = match self.find_client(request.src()) {
+            None => return Err(LookupError::ResponseCode(ResponseCode::ServFail)),
+            Some(client) => client,
+        };
+
+        // Make sure the request is for IP records. Anything else, we forward.
+        let record_type = request.query().query_type();
+        if !is_record_type_supported(record_type) {
+            return self.forwarder.forward(&client, request).await;
+        }
+
+        // Find the service for the requested host.
+        let requested_name = Name::from(request.query().name().clone());
+        let Some(service_match) = self.find_service(&client, &requested_name) else {
+            // Unknown host. Forward to the upstream resolver.
+            return self.forwarder.forward(&client, request).await;
+        };
+
+        // Get the addresses for the service.
+        let addresses = self.get_addresses(&client, &service_match.service, record_type);
+
+        // From this point on, we are the authority for the response.
+        let is_authoritative = true;
+
+        if addresses.is_empty() {
+            // Lookup succeeded, but no records were returned. This is not NXDOMAIN, since we
+            // found the host. Just return an empty set of records.
+            return Ok(Answer::new(Vec::default(), is_authoritative));
+        }
+
+        // Create a vec to hold the output records.
+        let mut records = Vec::new();
+
+        // Assume that we'll just use the requested name as the record name.
+        let mut ip_record_name = requested_name.clone();
+
+        // If the service was found by stripping off one of the search domains, create a
+        // CNAME record to map to the appropriate canonical name.
+        if let Some(stripped) = service_match.alias.stripped {
+            if service_match.name.is_wildcard() {
+                // The match is a wildcard...
+
+                // Create a CNAME record that maps from the wildcard with the search domain to
+                // the wildcard without it.
+                let cname_record_name = service_match
+                    .name
+                    .clone()
+                    .append_domain(&stripped.search_domain)
+                    .unwrap();
+                let canonical_name = service_match.name;
+                records.push(cname_record(cname_record_name, canonical_name));
+
+                // For wildcards, continue using the original requested hostname for IP records.
+            } else {
+                // The match is NOT a wildcard...
+
+                // Create a CNAME record to map from the requested name -> stripped name.
+                let canonical_name = stripped.name;
+                records.push(cname_record(requested_name.clone(), canonical_name.clone()));
+
+                // Also use the stripped name as the IP record name.
+                ip_record_name = canonical_name;
+            }
+        }
+
+        // Add the IP records.
+        ip_records(ip_record_name, addresses, &mut records);
+
+        Ok(Answer::new(records, is_authoritative))
+    }
+}
+
+/// An alias for the requested hostname.
+struct Alias {
+    /// The name to be used in the search.
+    name: Name,
+
+    /// If `Some`, indicates that this alias was generated from the requested host that
+    /// was stripped of
+    stripped: Option<Stripped>,
+}
+
+/// Created for an alias generated by stripping a search domain from the requested host.
+struct Stripped {
+    /// The requested hostname with the `search_domain` removed.
+    name: Name,
+
+    /// The search domain that was removed from the requested host to generate `name`.
+    search_domain: Name,
+}
+
+/// Returned when a service was successfully found for the requested hostname.
+struct ServiceMatch {
+    /// The hostname that was used to find the service. This is identical to the
+    /// service hostname, except that it is an FQDN [Name].
+    name: Name,
+
+    /// The alias that produced the `match_name`.
+    alias: Alias,
+
+    /// The service that was found.
+    service: Service,
+}
+
+/// Converts the requested hostname into a Kubernetes FQDN of the form
+/// `name.ns.svc.cluster.local`. Returns `None` if no conversion was possible.
+fn to_kube_fqdn(client: &Workload, name: &Name) -> Option<Name> {
+    // TODO(nmittler): Do we need to support user-defined cluster domains?
+    let iter = name.iter();
+    match iter.len() {
+        1 => {
+            // Only one label in the name. Assume the client is calling a service by name
+            // within the same namespace. Append "<ns>.svc.cluster.local".
+            Some(
+                name.clone()
+                    .append_label(client.namespace.as_bytes())
+                    .unwrap()
+                    .append_domain(SVC_CLUSTER_LOCAL.deref())
+                    .unwrap(),
+            )
+        }
+        2 => {
+            // Assume the client is calling the service by "name.ns".
+            // Append "svc.cluster.local".
+            Some(
+                name.clone()
+                    .append_domain(SVC_CLUSTER_LOCAL.deref())
+                    .unwrap(),
+            )
+        }
+        3 => {
+            // Assume the client is calling "name.ns.svc". Check to make sure the last
+            // label is "svc".
+            let svc = iter.rev().next().unwrap();
+            if svc == b"svc" {
+                // Append "cluster.local".
+                Some(name.clone().append_domain(CLUSTER_LOCAL.deref()).unwrap())
+            } else {
+                None
+            }
+        }
+        _ => {
+            // Everything else is either already an FQDN or not a valid kubernetes hostname.
+            None
+        }
+    }
+}
+
+/// Creates the list of wildcard searches to try for the given hostname. The list
+/// will begin with the requested hostname, followed by wildcards of decreasing
+/// specificity. For example, a request of 'svc1.ns1.svc.cluster.local` will return
+/// ['svc1.ns1.svc.cluster.local`, '*.ns1.svc.cluster.local`, '*.svc.cluster.local`,
+/// '*.cluster.local`, '*.local`].
+fn get_wildcards(name: &Name) -> Vec<Name> {
+    let mut out = vec![name.clone()];
+
+    let mut name = name.clone();
+    while name.num_labels() > 1 {
+        // Replace the first label with a wildcard (e.g. www.example.com -> *.example.com).
+        out.push(name.clone().into_wildcard());
+
+        // Remove the first label.
+        name = name.base_name();
+    }
+
+    out
+}
+
+fn is_record_type_supported(record_type: RecordType) -> bool {
+    matches!(record_type, RecordType::A | RecordType::AAAA)
+}
+
+fn is_record_type(addr: &IpAddr, record_type: RecordType) -> bool {
+    match addr {
+        IpAddr::V4(_) => record_type == RecordType::A,
+        IpAddr::V6(_) => record_type == RecordType::AAAA,
+    }
+}
+
+fn to_record(name: Name, rdata: RData) -> Record {
+    Record::from_rdata(name, DEFAULT_TTL_SECONDS, rdata)
+}
+
+fn cname_record(name: Name, canonical_name: Name) -> Record {
+    to_record(name, RData::CNAME(canonical_name))
+}
+
+fn ip_records(name: Name, addrs: Vec<IpAddr>, out: &mut Vec<Record>) {
+    for addr in addrs {
+        match addr {
+            IpAddr::V4(addr) => out.push(to_record(name.clone(), RData::A(addr))),
+            IpAddr::V6(addr) => out.push(to_record(name.clone(), RData::AAAA(addr))),
+        }
+    }
+}
+
+/// Forwards a request to an upstream resolver.
+#[async_trait::async_trait]
+pub(super) trait Forwarder: Send + Sync {
+    /// Returns the list of resolver search domains for the client.
+    fn search_domains(&self, client: &Workload) -> Vec<Name>;
+
+    /// Forwards the request from the client.
+    async fn forward(&self, client: &Workload, request: &Request) -> Result<Answer, LookupError>;
+}
+
+/// Creates the appropriate DNS forwarder for the proxy mode.
+pub(super) fn forwarder_for_mode(proxy_mode: ProxyMode) -> Result<Arc<dyn Forwarder>, Error> {
+    Ok(match proxy_mode {
+        ProxyMode::Shared => {
+            // TODO(https://github.com/istio/ztunnel/issues/555): Use pod settings if available.
+            Arc::new(SystemForwarder::new()?)
+        }
+        ProxyMode::Dedicated => Arc::new(SystemForwarder::new()?),
+    })
+}
+
+/// DNS forwarder that uses the system resolver config in `/etc/resolv.conf`.
+/// When running in dedicated (sidecar) proxy mode, this will be the same resolver configuration
+/// that would have been used by the client. For shared proxy mode, this will be the resolver
+/// configuration for the ztunnel DaemonSet (i.e. node-level resolver settings).
+struct SystemForwarder {
+    search_domains: Vec<Name>,
+    resolver: Arc<dyn Resolver>,
+}
+
+impl SystemForwarder {
+    fn new() -> Result<Self, Error> {
+        // Get the resolver config from /etc/resolv.conf.
+        let (cfg, opts) = read_system_conf()?;
+
+        // Extract the search domains from the config.
+        let search_domains = cfg.search().to_vec();
+
+        // Create the resolver.
+        let resolver = Arc::new(
+            forwarder::Forwarder::new(cfg, opts).map_err(|e| Error::Generic(Box::new(e)))?,
+        );
+
+        Ok(Self {
+            search_domains,
+            resolver,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Forwarder for SystemForwarder {
+    fn search_domains(&self, _: &Workload) -> Vec<Name> {
+        self.search_domains.clone()
+    }
+
+    async fn forward(&self, _: &Workload, request: &Request) -> Result<Answer, LookupError> {
+        self.resolver.lookup(request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::dns::{
+        a, aaaa, cname, ip, ipv4, ipv6, n, new_message, new_tcp_client, new_udp_client,
+        send_request, server_request, socket_addr,
+    };
+    use crate::test_helpers::helpers::subscribe;
+    use crate::test_helpers::{new_proxy_state, test_default_workload};
+    use crate::xds::istio::workload::NetworkAddress as XdsNetworkAddress;
+    use crate::xds::istio::workload::Port as XdsPort;
+    use crate::xds::istio::workload::Service as XdsService;
+    use crate::xds::istio::workload::Workload as XdsWorkload;
+    use bytes::Bytes;
+    use std::cmp::Ordering;
+    use std::collections::HashMap;
+    use std::net::{SocketAddrV4, SocketAddrV6};
+    use trust_dns_server::server::Protocol;
+
+    const NS1: &str = "ns1";
+    const NS2: &str = "ns2";
+    const NW1: &str = "nw1";
+    const NW2: &str = "nw2";
+
+    #[test]
+    fn test_to_kube_fqdn() {
+        struct Case {
+            host: &'static str,
+            client_namespace: &'static str,
+            expected: Option<Name>,
+        }
+
+        let cases: &[Case] = &[
+            Case {
+                // Expand single label values to namespace of the client.
+                host: "name",
+                client_namespace: "ns1",
+                expected: Some(n("name.ns1.svc.cluster.local.")),
+            },
+            Case {
+                host: "name.",
+                client_namespace: "ns1",
+                expected: Some(n("name.ns1.svc.cluster.local.")),
+            },
+            Case {
+                host: "name.ns2",
+                client_namespace: "ns1",
+                expected: Some(n("name.ns2.svc.cluster.local.")),
+            },
+            Case {
+                host: "name.ns2.svc.",
+                client_namespace: "ns1",
+                expected: Some(n("name.ns2.svc.cluster.local.")),
+            },
+            Case {
+                // Invalid short-form for a k8s host.
+                host: "name.ns2.svc.cluster.",
+                client_namespace: "ns1",
+                expected: None,
+            },
+            Case {
+                // The request is already a k8s FQDN.
+                host: "name.ns2.svc.cluster.local",
+                client_namespace: "ns1",
+                expected: None,
+            },
+            Case {
+                // Non-k8s
+                host: "www.google.com.",
+                client_namespace: "ns1",
+                expected: None,
+            },
+        ];
+
+        for c in cases {
+            let mut wl = test_default_workload();
+            wl.namespace = c.client_namespace.into();
+
+            let actual = to_kube_fqdn(&wl, &n(c.host));
+            assert_eq!(c.expected, actual);
+        }
+    }
+
+    #[test]
+    fn test_get_wildcards() {
+        let actual = get_wildcards(&n("svc1."));
+        let expected: Vec<Name> = vec![n("svc1.")];
+        assert_eq!(expected, actual);
+
+        let actual = get_wildcards(&n("svc1.ns1.svc.cluster.local."));
+        let expected: Vec<Name> = vec![
+            n("svc1.ns1.svc.cluster.local."),
+            n("*.ns1.svc.cluster.local."),
+            n("*.svc.cluster.local."),
+            n("*.cluster.local."),
+            n("*.local."),
+        ];
+        assert_eq!(expected, actual);
+    }
+
+    // TODO(nmittler): Test headless services (https://github.com/istio/ztunnel/issues/554).
+    // TODO(nmittler): Test truncation once fixed (https://github.com/bluejekyll/trust-dns/issues/1973).
+    #[tokio::test]
+    async fn lookup() {
+        let _guard = subscribe();
+
+        struct Case {
+            name: &'static str,
+            host: &'static str,
+            query_type: RecordType,
+            expect_code: ResponseCode,
+            expect_authoritative: bool,
+            expect_records: Vec<Record>,
+        }
+
+        impl Default for Case {
+            fn default() -> Self {
+                Self {
+                    name: "",
+                    host: "",
+                    query_type: RecordType::A,
+                    expect_code: ResponseCode::NoError,
+                    expect_authoritative: true,
+                    expect_records: vec![],
+                }
+            }
+        }
+
+        let cases = [
+            Case {
+                name: "failure: unsupported record type will forward",
+                host: "productpage.ns1.",
+                query_type: RecordType::NS,
+                expect_authoritative: false, // Forwarded.
+                expect_code: ResponseCode::NXDomain,
+                ..Default::default()
+            },
+            Case {
+                name: "success: non k8s host in local cache",
+                host: "www.google.com",
+                expect_records: vec![a(n("www.google.com."), ipv4("1.1.1.1"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: non k8s host with search namespace yields cname+A record",
+                host: "www.google.com.ns1.svc.cluster.local.",
+                expect_records: vec![
+                    cname(n("www.google.com.ns1.svc.cluster.local."), n("www.google.com.")),
+                    a(n("www.google.com."), ipv4("1.1.1.1"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: non k8s host not in local cache",
+                host: "www.bing.com",
+                expect_authoritative: false,
+                expect_records: vec![
+                    a(n("www.bing.com."), ipv4("1.1.1.1"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: k8s host - fqdn",
+                host: "productpage.ns1.svc.cluster.local.",
+                expect_records: vec![
+                    a(n("productpage.ns1.svc.cluster.local."), ipv4("9.9.9.9"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: k8s host - name.namespace",
+                host: "productpage.ns1.",
+                expect_records: vec![
+                    a(n("productpage.ns1."), ipv4("9.9.9.9"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: k8s host - shortname",
+                host: "productpage.",
+                expect_records: vec![
+                    a(n("productpage."), ipv4("9.9.9.9"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: k8s host (name.namespace) with search namespace yields cname+A record",
+                host: "productpage.ns1.ns1.svc.cluster.local.",
+                expect_records: vec![
+                    cname(n("productpage.ns1.ns1.svc.cluster.local."), n("productpage.ns1.")),
+                    a(n("productpage.ns1."), ipv4("9.9.9.9"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: AAAA query for IPv4 k8s host (name.namespace) with search namespace",
+                host: "productpage.ns1.ns1.svc.cluster.local.",
+                query_type: RecordType::AAAA,
+                expect_records: vec![],
+                ..Default::default()
+            },
+            Case {
+                name: "success: k8s host - non local namespace - name.namespace",
+                host: "example.ns2.",
+                expect_records: vec![
+                    a(n("example.ns2."), ipv4("10.10.10.10"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: k8s host - non local namespace - fqdn",
+                host: "example.ns2.svc.cluster.local.",
+                expect_records: vec![
+                    a(n("example.ns2.svc.cluster.local."), ipv4("10.10.10.10"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: k8s host - non local namespace - name.namespace.svc",
+                host: "example.ns2.svc.",
+                expect_records: vec![
+                    a(n("example.ns2.svc."), ipv4("10.10.10.10"))],
+                ..Default::default()
+            },
+            Case {
+                name: "failure: k8s host - non local namespace - shortname",
+                host: "example.",
+                expect_authoritative: false, // Forwarded.
+                expect_code: ResponseCode::NXDomain,
+                ..Default::default()
+            },
+            Case {
+                name: "success: remote cluster k8s svc - same ns and different domain - fqdn",
+                host: "details.ns2.svc.cluster.remote.",
+                expect_records: vec![
+                    a(n("details.ns2.svc.cluster.remote."), ipv4("11.11.11.11")),
+                    a(n("details.ns2.svc.cluster.remote."), ipv4("12.12.12.12")),
+                    a(n("details.ns2.svc.cluster.remote."), ipv4("13.13.13.13")),
+                    a(n("details.ns2.svc.cluster.remote."), ipv4("14.14.14.14"))],
+                ..Default::default()
+            },
+            Case {
+                name: "failure: remote cluster k8s svc - same ns and different domain - name.namespace",
+                host: "details.ns2.",
+                expect_authoritative: false, // Forwarded.
+                expect_code: ResponseCode::NXDomain,
+                ..Default::default()
+            },
+            Case {
+                name: "success: TypeA query returns A records only",
+                host: "dual.localhost.",
+                expect_records: vec![
+                    a(n("dual.localhost."), ipv4("2.2.2.2"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: TypeA query returns A records only",
+                host: "dual.localhost.",
+                expect_records: vec![
+                    a(n("dual.localhost."), ipv4("2.2.2.2"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: TypeAAAA query returns AAAA records only",
+                host: "dual.localhost.",
+                query_type: RecordType::AAAA,
+                expect_records: vec![
+                    aaaa(n("dual.localhost."), ipv6("2001:db8:0:0:0:ff00:42:8329"))],
+                ..Default::default()
+            },
+            Case {
+                // This is not a NXDOMAIN, but empty response
+                name: "success: Error response if only AAAA records exist for typeA",
+                host: "ipv6.localhost.",
+                ..Default::default()
+            },
+            Case {
+                // This is not a NXDOMAIN, but empty response
+                name: "success: Error response if only A records exist for typeAAAA",
+                host: "ipv4.localhost.",
+                query_type: RecordType::AAAA,
+                ..Default::default()
+            },
+            Case {
+                name: "success: wild card returns A record correctly",
+                host: "foo.wildcard.",
+                expect_records: vec![
+                    a(n("foo.wildcard."), ipv4("10.10.10.10"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: specific wild card returns A record correctly",
+                host: "a.b.wildcard.",
+                expect_records: vec![
+                    a(n("a.b.wildcard."), ipv4("11.11.11.11"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: wild card with domain returns A record correctly",
+                host: "foo.svc.mesh.company.net.",
+                expect_records: vec![
+                    a(n("foo.svc.mesh.company.net."), ipv4("10.1.2.3"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: wild card with namespace with domain returns A record correctly",
+                host: "foo.foons.svc.mesh.company.net.",
+                expect_records: vec![
+                    a(n("foo.foons.svc.mesh.company.net."), ipv4("10.1.2.3"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: wild card with search domain returns A record correctly",
+                host: "foo.svc.mesh.company.net.ns1.svc.cluster.local.",
+                expect_records: vec![
+                    cname(n("*.svc.mesh.company.net.ns1.svc.cluster.local."), n("*.svc.mesh.company.net.")),
+                    a(n("foo.svc.mesh.company.net.ns1.svc.cluster.local."), ipv4("10.1.2.3"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: no vip on client network returns no records",
+                host: "nw2-only.ns1.svc.cluster.local.",
+                expect_records: vec![],
+                ..Default::default()
+            },
+            Case {
+                name: "success: return vip for client network only",
+                host: "both-networks.ns1.svc.cluster.local.",
+                expect_records: vec![
+                    a(n("both-networks.ns1.svc.cluster.local."), ipv4("21.21.21.21"))],
+                ..Default::default()
+            },
+        ];
+
+        // Create and start the proxy.
+        let addr = new_socket_addr().await;
+        let state = state();
+        let forwarder = forwarder();
+        let proxy = DnsProxy::new(addr, NW1, state, forwarder).await.unwrap();
+        tokio::spawn(proxy.run());
+
+        let mut tcp_client = new_tcp_client(addr).await;
+        let mut udp_client = new_udp_client(addr).await;
+
+        // Lookup the server from the client.
+        for c in cases {
+            for (protocol, client) in [("tcp", &mut tcp_client), ("udp", &mut udp_client)] {
+                let name = format!("[{protocol}] {}", c.name);
+                let resp = send_request(client, n(c.host), c.query_type).await;
+                assert_eq!(c.expect_authoritative, resp.authoritative(), "{}", name);
+                assert_eq!(c.expect_code, resp.response_code(), "{}", name);
+
+                if c.expect_code == ResponseCode::NoError {
+                    let mut actual = resp.answers().to_vec();
+
+                    // The IP records in an authoritative response will be randomly sorted to
+                    // accommodate DNS-based load balancing. If the response is authoritative,
+                    // sort the IP records so that we can directly compare them to the expected.
+                    if c.expect_authoritative {
+                        sort_records(&mut actual);
+                    }
+                    assert_eq!(c.expect_records, actual, "{}", name);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_client_should_fail() {
+        let _guard = subscribe();
+
+        // Create the DNS store.
+        let state = state();
+        let forwarder = forwarder();
+        let store = DnsStore {
+            network: NW1.to_string(),
+            state,
+            forwarder,
+        };
+
+        let bad_client_ip = ip("5.5.5.5");
+        let req = req(n("www.google.com"), bad_client_ip, RecordType::A);
+        match store.lookup(&req).await {
+            Ok(_) => panic!("expected error"),
+            Err(e) => {
+                if let Some(resp_code) = e.as_response_code() {
+                    assert_eq!(ResponseCode::ServFail, *resp_code);
+                } else {
+                    panic!("unexpected error: {:?}", e)
+                }
+            }
+        }
+    }
+
+    // #[tokio::test]
+    // async fn large_response() {
+    //     // Create and start the proxy with an an empty state. The forwarder is configured to
+    //     // return a large response.
+    //     let addr = new_socket_addr().await;
+    //     let state = new_proxy_state(&[local_workload()], &[], &[]).state;
+    //     let forwarder = Arc::new(FakeForwarder {
+    //         search_domains: vec![],
+    //         ips: HashMap::from([(n("large.com."), new_large_response())]),
+    //     });
+    //     let proxy = DnsProxy::new(addr, NW1, state, forwarder).await.unwrap();
+    //     tokio::spawn(proxy.run());
+    //
+    //     let mut tcp_client = new_tcp_client(addr).await;
+    //
+    //     let resp = send_with_max_size(&mut tcp_client, n("large.com."), RecordType::A, 20).await;
+    //     //resp.answers()[0].
+    //     //let resp = send_request(&mut tcp_client, n("large.com."), RecordType::A).await;
+    //     //assert!(resp.truncated());
+    //     println!("{:?}", resp);
+    // }
+
+    /// Sort the IP records so that we can directly compare them to the expected. The resulting
+    /// list will contain CNAME first, followed by A, and then by AAAA. Within each record type,
+    /// records will be sorted in ascending order by their string representation.
+    fn sort_records(records: &mut [Record]) {
+        let rtype_priority = |rtype: RecordType| -> u8 {
+            match rtype {
+                RecordType::A => 2,
+                RecordType::AAAA => 3,
+                _ => 1,
+            }
+        };
+
+        records.sort_by(|a, b| {
+            // First, sort by record type.
+            match rtype_priority(a.record_type()).cmp(&rtype_priority(b.record_type())) {
+                Ordering::Less => Ordering::Less,
+                Ordering::Greater => Ordering::Greater,
+                Ordering::Equal => {
+                    // Within the same record type, sort them by their string
+                    // representations.
+                    a.to_string().cmp(&b.to_string())
+                }
+            }
+        });
+    }
+
+    // fn new_large_response() -> Vec<Record> {
+    //     let mut out = Vec::new();
+    //     for i in 0..64 {
+    //         out.push(a(n("aaaaaaaaaaaa.aaaaaa."), ipv4(format!("240.0.0.{i}"))));
+    //     }
+    //     out
+    // }
+
+    fn req(host: Name, client_ip: IpAddr, query_type: RecordType) -> Request {
+        let socket_addr = match client_ip {
+            IpAddr::V4(addr) => SocketAddr::V4(SocketAddrV4::new(addr, 80)),
+            IpAddr::V6(addr) => SocketAddr::V6(SocketAddrV6::new(addr, 80, 0, 0)),
+        };
+
+        server_request(&new_message(host, query_type), socket_addr, Protocol::Udp)
+    }
+
+    fn forwarder() -> Arc<dyn Forwarder> {
+        Arc::new(FakeForwarder {
+            // Use the standard search domains for Kubernetes.
+            search_domains: vec![
+                n("ns1.svc.cluster.local"),
+                n("svc.cluster.local"),
+                n("cluster.local"),
+            ],
+            ips: HashMap::from([(n("www.bing.com."), vec![ip("1.1.1.1")])]),
+        })
+    }
+
+    async fn new_socket_addr() -> SocketAddr {
+        let s = UdpSocket::bind(socket_addr("127.0.0.1:0")).await.unwrap();
+        s.local_addr().unwrap()
+    }
+
+    fn state() -> Arc<RwLock<ProxyState>> {
+        let services = vec![
+            xds_external_service("www.google.com", &[na(NW1, "1.1.1.1")]),
+            xds_service("productpage", NS1, &[na(NW1, "9.9.9.9")]),
+            xds_service("example", NS2, &[na(NW1, "10.10.10.10")]),
+            with_fqdn(
+                "details.ns2.svc.cluster.remote",
+                xds_service(
+                    "details",
+                    NS2,
+                    &[
+                        na(NW1, "11.11.11.11"),
+                        na(NW1, "12.12.12.12"),
+                        na(NW1, "13.13.13.13"),
+                        na(NW1, "14.14.14.14"),
+                    ],
+                ),
+            ),
+            // IPv4-only, IPv6-only, dual stack.
+            xds_external_service("ipv4.localhost", &[na(NW1, "2.2.2.2")]),
+            xds_external_service("ipv6.localhost", &[na(NW1, "2001:db8:0:0:0:ff00:42:8329")]),
+            xds_external_service(
+                "dual.localhost",
+                &[na(NW1, "2.2.2.2"), na(NW1, "2001:db8:0:0:0:ff00:42:8329")],
+            ),
+            // Wildcards.
+            xds_external_service("*.wildcard", &[na(NW1, "10.10.10.10")]),
+            xds_external_service("*.b.wildcard", &[na(NW1, "11.11.11.11")]),
+            xds_external_service("*.svc.mesh.company.net", &[na(NW1, "10.1.2.3")]),
+            // VIP on different/multiple networks.
+            xds_service("nw2-only", NS1, &[na(NW2, "20.20.20.20")]),
+            xds_service(
+                "both-networks",
+                NS1,
+                &[na(NW1, "21.21.21.21"), na(NW2, "22.22.22.22")],
+            ),
+        ];
+
+        let workloads = vec![
+            // Just add a workload for the local machine that resides in NS1 on NW1.
+            local_workload(),
+        ];
+
+        new_proxy_state(&workloads, &services, &[]).state
+    }
+
+    fn na<S1: AsRef<str>, S2: AsRef<str>>(network: S1, addr: S2) -> NetworkAddress {
+        NetworkAddress {
+            network: network.as_ref().to_string(),
+            address: ip(addr),
+        }
+    }
+
+    /// Creates a workload for the local machine that resides in NS1 on NW1.
+    fn local_workload() -> XdsWorkload {
+        xds_workload("client", NS1, NW1, &local_ips())
+    }
+
+    fn local_ips() -> Vec<IpAddr> {
+        local_ip_address::list_afinet_netifas()
+            .unwrap()
+            .iter()
+            .map(|(_, addr)| *addr)
+            .collect_vec()
+    }
+
+    fn kube_fqdn<S1: AsRef<str>, S2: AsRef<str>>(name: S1, ns: S2) -> String {
+        format!("{}.{}.svc.cluster.local", name.as_ref(), ns.as_ref())
+    }
+
+    fn addr_bytes(addr: IpAddr) -> Vec<u8> {
+        match addr {
+            IpAddr::V4(addr) => addr.octets().to_vec(),
+            IpAddr::V6(addr) => addr.octets().to_vec(),
+        }
+    }
+
+    fn with_fqdn<S: AsRef<str>>(fqdn: S, mut svc: XdsService) -> XdsService {
+        svc.hostname = fqdn.as_ref().to_string();
+        svc
+    }
+
+    fn xds_service<S1: AsRef<str>, S2: AsRef<str>>(
+        name: S1,
+        ns: S2,
+        vips: &[NetworkAddress],
+    ) -> XdsService {
+        XdsService {
+            name: name.as_ref().to_string(),
+            namespace: ns.as_ref().to_string(),
+            hostname: kube_fqdn(name, ns),
+            addresses: vips
+                .iter()
+                .map(|vip| XdsNetworkAddress {
+                    network: vip.network.clone(),
+                    address: addr_bytes(vip.address),
+                })
+                .collect(),
+            ports: vec![XdsPort {
+                service_port: 80,
+                target_port: 80,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn xds_external_service<S: AsRef<str>>(hostname: S, addrs: &[NetworkAddress]) -> XdsService {
+        with_fqdn(
+            hostname.as_ref(),
+            xds_service(hostname.as_ref(), NS1, addrs),
+        )
+    }
+
+    fn xds_workload(name: &str, ns: &str, nw: &str, ips: &[IpAddr]) -> XdsWorkload {
+        XdsWorkload {
+            addresses: ips
+                .iter()
+                .map(|ip| Bytes::copy_from_slice(&addr_bytes(*ip)))
+                .collect(),
+            uid: name.to_string(),
+            name: name.to_string(),
+            namespace: ns.to_string(),
+            trust_domain: "cluster.local".to_string(),
+            network: nw.to_string(),
+            workload_name: name.to_string(),
+            canonical_name: name.to_string(),
+            node: name.to_string(),
+            cluster_id: "Kubernetes".to_string(),
+            // virtual_ips: HashMap::from([(
+            //     vip(svc, ns, nw).to_string(),
+            //     XdsPortList {
+            //         ports: vec![XdsPort {
+            //             service_port: 80,
+            //             target_port: 8080,
+            //         }],
+            //     },
+            // )]),
+            ..Default::default()
+        }
+    }
+
+    struct FakeForwarder {
+        search_domains: Vec<Name>,
+        ips: HashMap<Name, Vec<IpAddr>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Forwarder for FakeForwarder {
+        fn search_domains(&self, _: &Workload) -> Vec<Name> {
+            self.search_domains.clone()
+        }
+
+        async fn forward(&self, _: &Workload, request: &Request) -> Result<Answer, LookupError> {
+            let name = request.query().name().into();
+            let Some(ips) = self.ips.get(&name) else {
+                // Not found.
+                return Err(LookupError::ResponseCode(ResponseCode::NXDomain))
+            };
+
+            let mut out = Vec::new();
+            let rtype = request.query().query_type();
+            for ip in ips {
+                match ip {
+                    IpAddr::V4(ip) => {
+                        if rtype == RecordType::A {
+                            out.push(a(request.query().name().into(), *ip));
+                        }
+                    }
+                    IpAddr::V6(ip) => {
+                        if rtype == RecordType::AAAA {
+                            out.push(aaaa(request.query().name().into(), *ip));
+                        }
+                    }
+                }
+            }
+
+            return Ok(Answer::new(out, false));
+        }
+    }
+}

--- a/src/proxy/dns/forwarder.rs
+++ b/src/proxy/dns/forwarder.rs
@@ -1,0 +1,75 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::proxy::dns::resolver::{Answer, Resolver};
+use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+use trust_dns_resolver::error::ResolveError;
+use trust_dns_resolver::{TokioAsyncResolver, TokioHandle};
+use trust_dns_server::authority::LookupError;
+use trust_dns_server::server::Request;
+
+/// A forwarding [Resolver] that delegates requests to an upstream [TokioAsyncResolver].
+pub struct Forwarder(TokioAsyncResolver);
+
+impl Forwarder {
+    /// Creates a new [Forwarder] from the provided resolver configuration.
+    pub fn new(cfg: ResolverConfig, opts: ResolverOpts) -> Result<Self, ResolveError> {
+        let resolver = TokioAsyncResolver::new(cfg, opts, TokioHandle)?;
+        Ok(Self(resolver))
+    }
+}
+
+#[async_trait::async_trait]
+impl Resolver for Forwarder {
+    async fn lookup(&self, request: &Request) -> Result<Answer, LookupError> {
+        // TODO(nmittler): Should we allow requests to the upstream resolver to be authoritative?
+        let name = request.query().name();
+        let rr_type = request.query().query_type();
+        self.0
+            .lookup(name, rr_type)
+            .await
+            .map(Answer::from)
+            .map_err(LookupError::from)
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(unix, target_os = "windows"))]
+mod tests {
+    use crate::proxy::dns::resolver::Resolver;
+    use crate::test_helpers::dns::{a_request, n, socket_addr, system_forwarder};
+    use crate::test_helpers::helpers::subscribe;
+    use trust_dns_proto::rr::RecordType;
+    use trust_dns_server::server::Protocol;
+
+    #[tokio::test]
+    async fn forward_google_com() {
+        let _guard = subscribe();
+
+        let f = system_forwarder();
+
+        // Lookup a host.
+        let req = a_request(
+            n("www.google.com"),
+            socket_addr("1.1.1.1:80"),
+            Protocol::Udp,
+        );
+        let answer = f.lookup(&req).await.unwrap();
+        assert!(!answer.is_authoritative());
+
+        let record = answer.record_iter().next().unwrap();
+        assert_eq!(n("www.google.com."), *record.name());
+        assert_eq!(RecordType::A, record.rr_type());
+    }
+}

--- a/src/proxy/dns/name_util.rs
+++ b/src/proxy/dns/name_util.rs
@@ -1,0 +1,82 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use trust_dns_proto::rr::Name;
+
+/// Returns true if the given name ends with the labels provided by the domain iterator.
+// TODO(nmittler): Consider upstreaming to TrustDNS.
+pub fn has_domain(name: &Name, domain: &Name) -> bool {
+    if domain.is_wildcard() || name.num_labels() <= domain.num_labels() {
+        return false;
+    }
+
+    let name_iter = name.iter();
+    let domain_iter = domain.iter();
+
+    // Skip ahead to the start of the domain.
+    let num_skip = name_iter.len() - domain_iter.len();
+    let name_iter = name_iter.skip(num_skip);
+
+    // Compare the remaining elements.
+    name_iter.eq(domain_iter)
+}
+
+/// Trims the domain labels from the name. Returns `Some` if the domain was found and removed.
+// TODO(nmittler): Consider upstreaming to TrustDNS.
+pub fn trim_domain(name: &Name, domain: &Name) -> Option<Name> {
+    if has_domain(name, domain) {
+        // Create a Name from the labels leading up to the domain.
+        let iter = name.iter();
+        let num_labels = iter.len() - domain.num_labels() as usize;
+        Some(Name::from_labels(iter.take(num_labels)).unwrap())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::dns::n;
+    use trust_dns_proto::rr::Name;
+
+    #[test]
+    fn test_has_domain() {
+        assert!(has_domain(&n("name.ns.svc.cluster.local"), &domain()));
+
+        assert!(!has_domain(&n("name.ns.a.different.domain"), &domain()));
+
+        assert!(!has_domain(&n("cluster.com"), &domain()));
+    }
+
+    #[test]
+    fn test_trim_domain() {
+        assert_eq!(
+            Some(n("name.ns")),
+            trim_domain(&n("name.ns.svc.cluster.local"), &domain())
+        );
+
+        assert_eq!(
+            None,
+            trim_domain(&n("name.ns.a.different.domain"), &domain())
+        );
+
+        // Can't trim if nothing left.
+        assert_eq!(None, trim_domain(&n("svc.cluster.local"), &domain()));
+    }
+
+    fn domain() -> Name {
+        n("svc.cluster.local")
+    }
+}

--- a/src/proxy/dns/proxy.rs
+++ b/src/proxy/dns/proxy.rs
@@ -1,0 +1,312 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::proxy::dns::resolver::{Answer, Resolver};
+use std::sync::Arc;
+use tracing::{error, warn};
+use trust_dns_proto::op::{Edns, Header, MessageType, OpCode, ResponseCode};
+use trust_dns_proto::rr::Record;
+use trust_dns_resolver::error::ResolveErrorKind;
+use trust_dns_server::authority::{LookupError, MessageResponse, MessageResponseBuilder};
+use trust_dns_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
+
+/// A Trust-DNS [ResponseHandler] that proxies all DNS requests.
+///
+/// A proxy is fundamentally different than an `Authority` in TrustDNS, since the answers may
+/// or may not be authoritative based on whether they are served locally or forwarded. It is
+/// for this reason that we can't implement the proxy using existing TrustDNS server structures
+/// `Catalog` and `Authority`.
+// TODO(nmittler): Consider upstreaming this to TrustDNS
+pub struct Proxy {
+    resolver: Arc<dyn Resolver>,
+}
+
+impl Proxy {
+    /// Creates a new request handler for the resolver.
+    pub fn new(resolver: Arc<dyn Resolver>) -> Self {
+        Self { resolver }
+    }
+
+    async fn lookup<R: ResponseHandler>(
+        &self,
+        request: &Request,
+        response_handle: R,
+    ) -> ResponseInfo {
+        match self.resolver.lookup(request).await {
+            Ok(answer) => send_lookup(request, response_handle, answer).await,
+            Err(e) => send_lookup_error(request, response_handle, e).await,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler for Proxy {
+    async fn handle_request<R: ResponseHandler>(
+        &self,
+        request: &Request,
+        response_handle: R,
+    ) -> ResponseInfo {
+        match request.message_type() {
+            MessageType::Query => match request.op_code() {
+                OpCode::Query => self.lookup(request, response_handle).await,
+                _ => {
+                    warn!("unimplemented op_code: {:?}", request.op_code());
+                    send_error(request, response_handle, ResponseCode::NotImp).await
+                }
+            },
+            MessageType::Response => {
+                warn!("got a response as a request from id: {}", request.id());
+                send_error(request, response_handle, ResponseCode::FormErr).await
+            }
+        }
+    }
+}
+
+async fn send_lookup<R: ResponseHandler>(
+    request: &Request,
+    response_handle: R,
+    answer: Answer,
+) -> ResponseInfo {
+    let mut response_header = Header::response_from_request(request.header());
+
+    // We are the authority here, since we control DNS for known hostnames
+    response_header.set_authoritative(answer.is_authoritative());
+    response_header.set_recursion_available(true);
+
+    // Create the response builder.
+    let mut builder = MessageResponseBuilder::from_message_request(request);
+
+    // Set EDNS if supplied in the request.
+    if let Some(edns) = response_edns(request) {
+        builder.edns(edns);
+    }
+
+    // Build the response.
+    let response = builder.build(
+        response_header,
+        answer.record_iter(),
+        None.iter(),
+        None.iter(),
+        None.iter(),
+    );
+
+    // Send the response.
+    send_response(response, response_handle).await
+}
+
+async fn send_lookup_error<R: ResponseHandler>(
+    request: &Request,
+    response_handle: R,
+    e: LookupError,
+) -> ResponseInfo {
+    match e {
+        LookupError::NameExists => {
+            // This is an error, since the hostname was resolved. Just return no records.
+            send_empty_response(request, response_handle).await
+        }
+        LookupError::ResponseCode(code) => send_error(request, response_handle, code).await,
+        LookupError::ResolveError(e) => {
+            match e.kind() {
+                ResolveErrorKind::NoRecordsFound { .. } => {
+                    send_empty_response(request, response_handle).await
+                }
+                _ => {
+                    // TODO(nmittler): log?
+                    send_error(request, response_handle, ResponseCode::ServFail).await
+                }
+            }
+        }
+        LookupError::Io(_) => {
+            // TODO(nmittler): log?
+            send_error(request, response_handle, ResponseCode::ServFail).await
+        }
+        _ => send_error(request, response_handle, ResponseCode::ServFail).await,
+    }
+}
+
+/// Sends an error response back to the client.
+async fn send_error<R: ResponseHandler>(
+    request: &Request,
+    response_handle: R,
+    code: ResponseCode,
+) -> ResponseInfo {
+    let response =
+        MessageResponseBuilder::from_message_request(request).error_msg(request.header(), code);
+
+    send_response(response, response_handle).await
+}
+
+/// Sends an empty response to the [ResponseHandler].
+async fn send_empty_response<R: ResponseHandler>(
+    request: &Request,
+    response_handle: R,
+) -> ResponseInfo {
+    let empty =
+        MessageResponseBuilder::from_message_request(request).build_no_records(*request.header());
+    send_response(empty, response_handle).await
+}
+
+/// Sends the response to the [ResponseHandler] and handles any errors.
+async fn send_response<'a, R: ResponseHandler>(
+    response: MessageResponse<
+        '_,
+        'a,
+        impl Iterator<Item = &'a Record> + Send + 'a,
+        impl Iterator<Item = &'a Record> + Send + 'a,
+        impl Iterator<Item = &'a Record> + Send + 'a,
+        impl Iterator<Item = &'a Record> + Send + 'a,
+    >,
+    mut response_handle: R,
+) -> ResponseInfo {
+    let result = response_handle.send_response(response).await;
+
+    match result {
+        Err(e) => {
+            error!("request error: {}", e);
+            let mut header = Header::new();
+            header.set_response_code(ResponseCode::ServFail);
+            header.into()
+        }
+        Ok(info) => info,
+    }
+}
+
+/// Creates an appropriate response [Edns], if one was available in the request.
+fn response_edns(request: &Request) -> Option<Edns> {
+    if let Some(req_edns) = request.edns() {
+        let mut resp_edns: Edns = Edns::new();
+        resp_edns.set_max_payload(req_edns.max_payload().max(512));
+        resp_edns.set_version(req_edns.version());
+        resp_edns.set_dnssec_ok(req_edns.dnssec_ok());
+
+        Some(resp_edns)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(unix, target_os = "windows"))]
+mod tests {
+    use crate::proxy::dns::proxy::Proxy;
+    use crate::proxy::dns::resolver::{Answer, Resolver};
+    use crate::test_helpers::dns::{a, a_request, n, socket_addr};
+    use crate::test_helpers::helpers::subscribe;
+    use std::net::Ipv4Addr;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio::sync::mpsc::Sender;
+    use trust_dns_proto::op::{Message, MessageType, OpCode, ResponseCode};
+    use trust_dns_proto::rr::{Name, Record, RecordType};
+    use trust_dns_proto::serialize::binary::BinEncoder;
+    use trust_dns_server::authority::LookupError;
+    use trust_dns_server::authority::MessageResponse;
+    use trust_dns_server::server::{
+        Protocol, Request, RequestHandler, ResponseHandler, ResponseInfo,
+    };
+
+    #[tokio::test]
+    async fn record_found() {
+        let _guard = subscribe();
+
+        let p = Proxy::new(Arc::new(FakeResolver {}));
+
+        // Lookup a host.
+        let req = a_request(n("fake.com"), socket_addr("1.1.1.1:80"), Protocol::Udp);
+
+        let (sender, mut receiver) = mpsc::channel(1);
+        let _ = p
+            .handle_request(&req, FakeResponseHandler::new(512, sender))
+            .await;
+
+        let resp = receiver.recv().await.unwrap();
+
+        // Check basic response header info.
+        assert_eq!(req.id(), resp.id());
+        assert_eq!(MessageType::Response, resp.message_type());
+        assert_eq!(OpCode::Query, resp.op_code());
+        assert_eq!(ResponseCode::NoError, resp.response_code());
+
+        // Check flags.
+        assert!(!resp.authoritative());
+        assert!(!resp.authentic_data());
+        assert!(!resp.checking_disabled());
+        assert!(resp.recursion_available());
+        assert!(resp.recursion_desired());
+        assert!(!resp.truncated());
+
+        // Check that we have an answer for the request host.
+        let answers = resp.answers();
+        assert!(!answers.is_empty());
+        assert_eq!(n("fake.com."), *answers[0].name());
+        assert_eq!(RecordType::A, answers[0].rr_type());
+
+        let expected = a(n("fake.com."), Ipv4Addr::new(127, 0, 0, 1));
+        assert_eq!(expected, *answers.iter().next().unwrap());
+    }
+
+    struct FakeResolver();
+
+    #[async_trait::async_trait]
+    impl Resolver for FakeResolver {
+        async fn lookup(&self, request: &Request) -> Result<Answer, LookupError> {
+            let name = Name::from(request.query().name().clone());
+            let records = vec![a(name, Ipv4Addr::new(127, 0, 0, 1))];
+            Ok(Answer::new(records, false))
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct FakeResponseHandler {
+        max_size: u16,
+        sender: Sender<Message>,
+    }
+
+    impl FakeResponseHandler {
+        pub fn new(max_size: u16, sender: Sender<Message>) -> Self {
+            Self { max_size, sender }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ResponseHandler for FakeResponseHandler {
+        async fn send_response<'a>(
+            &mut self,
+            response: MessageResponse<
+                '_,
+                'a,
+                impl Iterator<Item = &'a Record> + Send + 'a,
+                impl Iterator<Item = &'a Record> + Send + 'a,
+                impl Iterator<Item = &'a Record> + Send + 'a,
+                impl Iterator<Item = &'a Record> + Send + 'a,
+            >,
+        ) -> std::io::Result<ResponseInfo> {
+            // Create the encoder.
+            let mut buf = Vec::with_capacity(self.max_size as usize);
+            let mut encoder = BinEncoder::new(&mut buf);
+            encoder.set_max_size(self.max_size);
+
+            // Serialize the response.
+            let response_info = response.destructive_emit(&mut encoder)?;
+
+            // Deserialize back into the response message.
+            let msg = Message::from_vec(&buf)?;
+
+            // Send the message to the consumer.
+            self.sender.send(msg).await.unwrap();
+
+            Ok(response_info)
+        }
+    }
+}

--- a/src/proxy/dns/resolver.rs
+++ b/src/proxy/dns/resolver.rs
@@ -1,0 +1,73 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::slice::Iter;
+use trust_dns_proto::rr::Record;
+use trust_dns_resolver::lookup::Lookup;
+use trust_dns_server::authority::LookupError;
+use trust_dns_server::server::Request;
+
+/// Similar to a TrustDNS `Authority`, although the resulting [Answer] indicates whether
+/// the response is authoritative. This makes the interface generally more composable and
+/// better supports a proxy use case, where some responses may be authoriative and others
+/// may not.
+#[async_trait::async_trait]
+pub trait Resolver: Sync + Send {
+    async fn lookup(&self, request: &Request) -> Result<Answer, LookupError>;
+}
+
+/// Answer returned by a [Resolver].
+pub struct Answer {
+    records: Vec<Record>,
+    is_authoritative: bool,
+}
+
+impl Answer {
+    pub fn new(records: Vec<Record>, is_authoritative: bool) -> Self {
+        Self {
+            records,
+            is_authoritative,
+        }
+    }
+
+    /// Returns an iterator over the records returned by the [Resolver].
+    pub fn record_iter(&self) -> RecordIter<'_> {
+        RecordIter(self.records.iter())
+    }
+
+    /// Indicates whether the [Resolver] is the authority for the returned records.
+    pub fn is_authoritative(&self) -> bool {
+        self.is_authoritative
+    }
+}
+
+impl From<Lookup> for Answer {
+    fn from(value: Lookup) -> Self {
+        Self {
+            records: value.records().to_vec(),
+            is_authoritative: false, // Non-authoritative, since results came from upstream resolver.
+        }
+    }
+}
+
+/// Borrowed view of set of [`Record`]s returned from an [Answer].
+pub struct RecordIter<'a>(Iter<'a, Record>);
+
+impl<'a> Iterator for RecordIter<'a> {
+    type Item = &'a Record;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -547,7 +547,7 @@ mod tests {
             node: "local-node".to_string(),
             ..Default::default()
         };
-        let state = new_proxy_state(vec![source, waypoint, xds], vec![], vec![]).unwrap();
+        let state = new_proxy_state(&[source, waypoint, xds], &[], &[]);
         let outbound = OutboundConnection {
             pi: ProxyInputs {
                 cert_manager: identity::mock::new_secret_manager(Duration::from_secs(10)),

--- a/src/state.rs
+++ b/src/state.rs
@@ -72,7 +72,7 @@ pub struct ProxyState {
 #[derive(serde::Serialize, Debug, Clone)]
 pub struct DemandProxyState {
     #[serde(flatten)]
-    state: Arc<RwLock<ProxyState>>,
+    pub state: Arc<RwLock<ProxyState>>,
 
     /// If present, used to request on-demand updates for workloads.
     #[serde(skip_serializing)]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -35,6 +35,7 @@ use tracing::trace;
 
 pub mod app;
 pub mod ca;
+pub mod dns;
 pub mod helpers;
 pub mod tcp;
 pub mod xds;
@@ -265,21 +266,21 @@ where
 }
 
 pub fn new_proxy_state(
-    xds_workloads: Vec<XdsWorkload>,
-    xds_services: Vec<XdsService>,
-    xds_authorizations: Vec<XdsAuthorization>,
-) -> anyhow::Result<DemandProxyState> {
+    xds_workloads: &[XdsWorkload],
+    xds_services: &[XdsService],
+    xds_authorizations: &[XdsAuthorization],
+) -> DemandProxyState {
     let state = Arc::new(RwLock::new(ProxyState::default()));
     let updater = ProxyStateUpdater::new_no_fetch(state.clone());
 
     for w in xds_workloads {
-        updater.insert_workload(w)?;
+        updater.insert_workload(w.clone()).unwrap();
     }
     for s in xds_services {
-        updater.insert_service(s)?;
+        updater.insert_service(s.clone()).unwrap();
     }
     for a in xds_authorizations {
-        updater.insert_authorization(a)?;
+        updater.insert_authorization(a.clone()).unwrap();
     }
-    Ok(DemandProxyState::new(state, None))
+    DemandProxyState::new(state, None)
 }

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -1,0 +1,207 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::proxy::dns::forwarder::Forwarder;
+use futures_util::ready;
+use futures_util::stream::{Stream, StreamExt};
+use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::net::{TcpStream, UdpSocket};
+use trust_dns_client::client::{AsyncClient, ClientHandle};
+use trust_dns_client::error::ClientError;
+use trust_dns_proto::error::{ProtoError, ProtoErrorKind};
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
+use trust_dns_proto::op::{Edns, Message, MessageType, OpCode, Query};
+use trust_dns_proto::rr::{DNSClass, Name, RData, Record, RecordType};
+use trust_dns_proto::serialize::binary::BinDecodable;
+use trust_dns_proto::tcp::TcpClientStream;
+use trust_dns_proto::udp::UdpClientStream;
+use trust_dns_proto::xfer::{DnsRequest, DnsRequestOptions, DnsResponse};
+use trust_dns_proto::DnsHandle;
+use trust_dns_server::authority::MessageRequest;
+use trust_dns_server::server::{Protocol, Request};
+
+const TTL: u32 = 5;
+
+/// A short-hand helper for constructing a [Name].
+pub fn n<S: AsRef<str>>(name: S) -> Name {
+    Name::from_utf8(name).unwrap()
+}
+
+/// Creates an A record for the name and IP.
+pub fn a(name: Name, addr: Ipv4Addr) -> Record {
+    Record::from_rdata(name, TTL, RData::A(addr))
+}
+
+/// Creates an AAAA record for the name and IP.
+pub fn aaaa(name: Name, addr: Ipv6Addr) -> Record {
+    Record::from_rdata(name, TTL, RData::AAAA(addr))
+}
+
+/// Creates a CNAME record for the given canonical name.
+pub fn cname(name: Name, canonical_name: Name) -> Record {
+    Record::from_rdata(name, TTL, RData::CNAME(canonical_name))
+}
+
+#[cfg(any(unix, target_os = "windows"))]
+/// Creates a [Forwarder] that uses the system configuration (e.g. /etc/resolv.conf).
+pub fn system_forwarder() -> Forwarder {
+    use trust_dns_resolver::system_conf::read_system_conf;
+    let (cfg, opts) = read_system_conf().unwrap();
+    Forwarder::new(cfg, opts).unwrap()
+}
+
+/// Creates a new DNS client that establishes a TCP connection to the nameserver at the given
+/// address.
+pub async fn new_tcp_client(addr: SocketAddr) -> AsyncClient {
+    let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TcpStream>>::new(addr);
+    let (client, bg) = AsyncClient::new(Box::new(stream), sender, None)
+        .await
+        .unwrap();
+
+    // Run the client exchange in the background.
+    tokio::spawn(bg);
+
+    client
+}
+
+/// Creates a new DNS client that establishes a UDP connection to the nameserver at the given address.
+pub async fn new_udp_client(addr: SocketAddr) -> AsyncClient {
+    let stream = UdpClientStream::<UdpSocket>::new(addr);
+    let (client, bg) = AsyncClient::connect(stream).await.unwrap();
+
+    // Run the client exchange in the background.
+    tokio::spawn(bg);
+
+    client
+}
+
+/// Sends a request via the client.
+pub async fn send_request<C: ClientHandle>(
+    client: &mut C,
+    name: Name,
+    rr_type: RecordType,
+) -> DnsResponse {
+    client.query(name, DNSClass::IN, rr_type).await.unwrap()
+}
+
+/// Sends a request with the given maximum response payload size.
+pub async fn send_with_max_size(
+    client: &mut AsyncClient,
+    name: Name,
+    rr_type: RecordType,
+    max_payload: u16,
+) -> DnsResponse {
+    // Build the request message.
+    let mut message: Message = Message::new();
+    message
+        .add_query({
+            let mut query = Query::query(name, rr_type);
+            query.set_query_class(DNSClass::IN);
+            query
+        })
+        .set_id(rand::random::<u16>())
+        .set_message_type(MessageType::Query)
+        .set_op_code(OpCode::Query)
+        .set_recursion_desired(true)
+        .set_edns({
+            let mut edns = Edns::new();
+            edns.set_max_payload(max_payload).set_version(0);
+            edns
+        });
+
+    // client.send(message).first_answer().await.unwrap()
+
+    let mut options = DnsRequestOptions::default();
+    options.use_edns = true;
+    ClientResponse(client.send(DnsRequest::new(message, options)))
+        .await
+        .unwrap()
+}
+
+/// Copied from Trust-DNS async_client code to allow construction here.
+struct ClientResponse<R>(pub(crate) R)
+where
+    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static;
+
+impl<R> Future for ClientResponse<R>
+where
+    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static,
+{
+    type Output = Result<DnsResponse, ClientError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(
+            match ready!(self.0.poll_next_unpin(cx)) {
+                Some(r) => r,
+                None => Err(ProtoError::from(ProtoErrorKind::Timeout)),
+            }
+            .map_err(ClientError::from),
+        )
+    }
+}
+
+/// Constructs a new [Message] of type [MessageType::Query];
+pub fn new_message(name: Name, rr_type: RecordType) -> Message {
+    let mut msg = Message::new();
+    msg.set_id(123);
+    msg.set_message_type(MessageType::Query);
+    msg.set_recursion_desired(true);
+    msg.add_query(Query::query(name, rr_type));
+    msg
+}
+
+/// Converts the given [Message] into a server-side [Request] with dummy values for
+/// the client IP and protocol.
+pub fn server_request(msg: &Message, client_addr: SocketAddr, protocol: Protocol) -> Request {
+    // Serialize the message.
+    let wire_bytes = msg.to_vec().unwrap();
+
+    // Deserialize into a server-side request.
+    let msg_request = MessageRequest::from_bytes(&wire_bytes).unwrap();
+
+    Request::new(msg_request, client_addr, protocol)
+}
+
+/// Creates a A-record [Request] for the given name.
+pub fn a_request(name: Name, client_addr: SocketAddr, protocol: Protocol) -> Request {
+    server_request(&new_message(name, RecordType::A), client_addr, protocol)
+}
+
+/// Creates a AAAA-record [Request] for the given name.
+pub fn aaaa_request(name: Name, client_addr: SocketAddr, protocol: Protocol) -> Request {
+    server_request(&new_message(name, RecordType::AAAA), client_addr, protocol)
+}
+
+/// Helper for parsing a [SocketAddr] string.
+pub fn socket_addr<S: AsRef<str>>(socket_addr: S) -> SocketAddr {
+    socket_addr.as_ref().parse().unwrap()
+}
+
+/// Helper for parsing a [IpAddr] string.
+pub fn ip<S: AsRef<str>>(addr: S) -> IpAddr {
+    addr.as_ref().parse().unwrap()
+}
+
+/// Helper for parsing a [Ipv4Addr] string.
+pub fn ipv4<S: AsRef<str>>(addr: S) -> Ipv4Addr {
+    addr.as_ref().parse().unwrap()
+}
+
+/// Helper for parsing a [Ipv6Addr] string.
+pub fn ipv6<S: AsRef<str>>(addr: S) -> Ipv6Addr {
+    addr.as_ref().parse().unwrap()
+}

--- a/src/test_helpers/helpers.rs
+++ b/src/test_helpers/helpers.rs
@@ -19,6 +19,14 @@ use std::process::Command;
 use std::time::Instant;
 use tracing::debug;
 
+/// Sets the tracing subscriber to get tracing level from the 'RUST_LOG' env var.
+pub fn subscribe() -> tracing::subscriber::DefaultGuard {
+    let sub = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .finish();
+    tracing::subscriber::set_default(sub)
+}
+
 // Ensure that the `tracing` stack is only initialised once using `once_cell`
 static TRACING: Lazy<()> = Lazy::new(telemetry::setup_logging);
 

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::IpAddr;
-use std::time::Duration;
-
-use bytes::BufMut;
-use itertools::Itertools;
-use tracing::info;
-
 use crate::config::ConfigSource;
 use crate::state::service::{Endpoint, Service};
 use crate::state::workload::{gatewayaddress, Workload};
@@ -27,6 +20,11 @@ use crate::test_helpers::netns::{Namespace, Resolver};
 use crate::test_helpers::*;
 use crate::xds::{LocalConfig, LocalWorkload};
 use crate::{config, identity, proxy};
+use bytes::BufMut;
+use itertools::Itertools;
+use std::net::IpAddr;
+use std::time::Duration;
+use tracing::info;
 
 /// WorkloadManager provides an interface to deploy "workloads" as part of a test. Each workload
 /// runs in its own isolated network namespace, simulating a real environment. Redirection in the "host network"
@@ -98,6 +96,10 @@ impl WorkloadManager {
                     outbound: helpers::with_ip(app.proxy_addresses.outbound, ip),
                     inbound: helpers::with_ip(app.proxy_addresses.inbound, ip),
                     socks5: helpers::with_ip(app.proxy_addresses.socks5, ip),
+                    dns_proxy: app
+                        .proxy_addresses
+                        .dns_proxy
+                        .map(|dns_proxy| helpers::with_ip(dns_proxy, ip)),
                 },
                 readiness_address: helpers::with_ip(app.readiness_address, ip),
                 cert_manager,


### PR DESCRIPTION
This copies much of the logic from Istio, however it also supports a multi-tenant proxy.

## New crate

The new `istio-dns` crate extends the Trust-DNS API to specifically support the DNS proxy use case. The existing Trust-DNS `Catalog` does not allow an `Authority` to conditionally indicate its answers as authoritative, which is something that a proxy needs to do. The code here was written with the intent of eventually upstreaming to Trust-DNS.

## Host aliases

Within ztunnel, a new `dns` package implements the `istio-dns` `Resolver`, and serves DNS directly from the `WorkloadStore`.

The logic for handling host aliases has been somewhat inverted from Istio. Istio pre-generated aliases for each client and added entries for all possible hosts to the lookup table.

However, in shared proxy mode we have to handle the problem that some host aliases are client-specific (e.g. just service-name without namespace). To account for this, we dynamically run the alias logic in reverse, trying to figure out the FQDN from the requested hostname. This means that no additional entries for aliases were necessary in the `WorkloadStore`.

## Forwarding

Ztunnel dns uses one of two types of DNS forwarders, depending on if shared or dedicated mode. When in shared mode, it needs to use the configuration for the client pod in order to forward to the appropriate upstream resolver.

Fixes https://github.com/istio/ztunnel/issues/487