### PR TITLE
Add cluster_id to AuthSource Token to support multicluster authentication

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -289,7 +289,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             None => ProxyMode::Shared,
         },
         local_ip: parse(INSTANCE_IP)?,
-        cluster_id,
+        cluster_id: cluster_id.clone(),
 
         xds_address,
         xds_root_cert,
@@ -300,7 +300,10 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         proxy_metadata: pc.proxy_metadata,
 
         fake_ca,
-        auth: identity::AuthSource::Token(PathBuf::from(r"./var/run/secrets/tokens/istio-token")),
+        auth: identity::AuthSource::Token(
+            PathBuf::from(r"./var/run/secrets/tokens/istio-token"),
+            cluster_id,
+        ),
 
         num_worker_threads: parse_default(
             ZTUNNEL_WORKER_THREADS,

--- a/src/identity/auth.rs
+++ b/src/identity/auth.rs
@@ -21,6 +21,7 @@ use tonic::{Code, Request, Status};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AuthSource {
+    // JWT authentication source which contains the token file path and the cluster id.
     Token(PathBuf, String),
 }
 

--- a/src/identity/auth.rs
+++ b/src/identity/auth.rs
@@ -21,13 +21,13 @@ use tonic::{Code, Request, Status};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AuthSource {
-    Token(PathBuf),
+    Token(PathBuf, String),
 }
 
 impl AuthSource {
     pub fn load(&self) -> io::Result<Vec<u8>> {
         match self {
-            AuthSource::Token(path) => {
+            AuthSource::Token(path, _) => {
                 let t = std::fs::read(path)?;
 
                 if t.is_empty() {
@@ -58,6 +58,16 @@ impl Interceptor for AuthSource {
             })?;
 
         request.metadata_mut().insert("authorization", token);
+
+        match self {
+            AuthSource::Token(_, cluster_id) => {
+                if !cluster_id.is_empty() {
+                    let id = AsciiMetadataValue::try_from(cluster_id.as_bytes().to_vec())
+                        .map_err(|e| Status::new(Code::Unauthenticated, e.to_string()))?;
+                    request.metadata_mut().insert("clusterid", id);
+                }
+            }
+        }
         Ok(request)
     }
 }

--- a/src/test_helpers/ca.rs
+++ b/src/test_helpers/ca.rs
@@ -76,7 +76,10 @@ impl CaServer {
         let client = CaClient::new(
             "https://".to_string() + &server_addr.to_string(),
             root_cert,
-            AuthSource::Token(PathBuf::from(r"src/test_helpers/fake-jwt")),
+            AuthSource::Token(
+                PathBuf::from(r"src/test_helpers/fake-jwt"),
+                "Kubernetes".to_string(),
+            ),
             true,
         )
         .unwrap();


### PR DESCRIPTION
Istiod uses `third-party-jwt` to authenticate ztunnel, [extractClusterID](https://github.com/istio/istio/blob/c62932476b70066d844b5fc1f8eac60aaa82e259/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go#L112) from ztunnel's request metadata, and then call the apiserver of the corresponding cluster according to the extracted `clusterid` for jwt token validation (see [ValidateK8sJwt](https://github.com/istio/istio/blob/c62932476b70066d844b5fc1f8eac60aaa82e259/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go#L153) ).

Currently, there is no `clusterid` in ztunnel's metadata, so will use the primary cluster's apiserver to validate ([see this](https://github.com/istio/istio/blob/c62932476b70066d844b5fc1f8eac60aaa82e259/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go#L173-L175)). In a multi-cluster environment, we need to add `clusterid` to the metadata of ztunnel. 

This PR adds `clusterid` to ztunnel's request metadata.