### PR TITLE
Add log level filter and on error dump HELP_STRING text

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -30,6 +30,7 @@ use hyper::{header::HeaderValue, header::CONTENT_TYPE, Request, Response};
 use pprof::protos::Message;
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::{net::SocketAddr, time::Duration};
 use tokio::time;
@@ -357,12 +358,25 @@ fn list_loggers() -> Response<Full<Bytes>> {
 }
 
 fn change_log_level(reset: bool, level: &str) -> Response<Full<Bytes>> {
-    match telemetry::set_level(reset, level) {
-        Ok(_) => list_loggers(),
-        Err(e) => plaintext_response(
-            hyper::StatusCode::METHOD_NOT_ALLOWED,
-            format!("failed to set new level: {e}\n{HELP_STRING}",),
-        ),
+    match tracing::level_filters::LevelFilter::from_str(level) {
+        Ok(level_filter) => {
+            // Valid level, continue processing
+            tracing::info!("Parsed level: {:?}", level_filter);
+            match telemetry::set_level(reset, level) {
+                Ok(_) => list_loggers(),
+                Err(e) => plaintext_response(
+                    hyper::StatusCode::METHOD_NOT_ALLOWED,
+                    format!("Failed to set new level: {}\n{}", e, HELP_STRING),
+                ),
+            }
+        },
+        Err(_) => {
+            // Invalid level provided
+            plaintext_response(
+                hyper::StatusCode::BAD_REQUEST,
+                format!("Invalid level provided: {}\n{}", level, HELP_STRING),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This PR addresses issue [#426](https://github.com/istio/ztunnel/issues/426). Specifically, part 1 of this [comment](https://github.com/istio/ztunnel/issues/426#issuecomment-1450476915).

The 3 parts in the comment were:
- validate log levels (HELP text on error)
- validate log names (HELP text on error)
- dump list of available loggers

This code relies on the [tracing](https://docs.rs/tracing/latest/tracing/#:~:text=A%20scoped%2C%20structured%20logging%20and%20diagnostics%20system.%20Overview,traditional%20log%20messages%20can%20often%20be%20quite%20challenging.) library to support part 1. Unfortunately, I wasn't able to figure out how to leverage the tracing library (not sure if that is possible) to filter log level names and dump list of available loggers while still leveraging the level filtering that tracing offers.

I'm open to suggestions on how to do part 2 and 3 if that is feasible for this PR.