### PR TITLE
bench script

### DIFF
--- a/scripts/benchtest.sh
+++ b/scripts/benchtest.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+set -eux
+
+REPORT_PATH="out/rust/criterion/"
+
+git checkout $PULL_BASE_SHA
+cargo bench --profile dev -- --quick # FIXME: dev for faster compilation, quick for faster runs
+
+git checkout $PULL_PULL_SHA
+cargo bench --profile dev -- --quick # FIXME: dev for faster compilation, quick for faster runs
+
+cp -r $REPORT_PATH $ARTIFACTS

--- a/scripts/benchtest.sh
+++ b/scripts/benchtest.sh
@@ -3,10 +3,10 @@ set -eux
 
 REPORT_PATH="out/rust/criterion/"
 
-git checkout $PULL_BASE_SHA
+git checkout "$PULL_BASE_SHA"
 cargo bench -- --save-baseline master
 
-git checkout $PULL_PULL_SHA
+git checkout "$PULL_PULL_SHA"
 cargo bench -- --baseline-lenient master
 
-cp -r $REPORT_PATH $ARTIFACTS
+cp -r "$REPORT_PATH" "$ARTIFACTS"

--- a/scripts/benchtest.sh
+++ b/scripts/benchtest.sh
@@ -4,9 +4,9 @@ set -eux
 REPORT_PATH="out/rust/criterion/"
 
 git checkout $PULL_BASE_SHA
-cargo bench --profile dev -- --quick # FIXME: dev for faster compilation, quick for faster runs
+cargo bench -- --save-baseline master
 
 git checkout $PULL_PULL_SHA
-cargo bench --profile dev -- --quick # FIXME: dev for faster compilation, quick for faster runs
+cargo bench -- --baseline-lenient master
 
 cp -r $REPORT_PATH $ARTIFACTS


### PR DESCRIPTION
Adds a script to compare performance across two different tests. The end goal is to run this as a prow command. Would it be better to have the commit SHAs be argument of the scripts? I'm unsure as to how that would pan out in the prow command.

Relevant PR: https://github.com/istio/test-infra/pull/4777

Update: Using environment variables seems like the way to go.