### PR TITLE
Add tests for change_log_level

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -440,13 +440,15 @@ async fn handle_gprof_heap(_req: Request<Incoming>) -> Response<Full<Bytes>> {
 
 #[cfg(test)]
 mod tests {
+    use super::change_log_level;
     use super::dump_certs;
     use super::handle_config_dump;
     use super::ConfigDump;
+    use crate::admin::HELP_STRING;
     use crate::config::construct_config;
     use crate::config::ProxyConfig;
     use crate::identity;
-    use crate::test_helpers::new_proxy_state;
+    use crate::test_helpers::{new_proxy_state, helpers};
     use crate::xds::istio::security::string_match::MatchType as XdsMatchType;
     use crate::xds::istio::security::Address as XdsAddress;
     use crate::xds::istio::security::Authorization as XdsAuthorization;
@@ -813,5 +815,141 @@ mod tests {
         assert!(
             resp_str.contains(r#"waypoint":{"destination":"defaultnw/127.0.0.10","port":15008}"#)
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_change_log_level_empty() {
+        helpers::initialize_telemetry();
+        let resp = change_log_level(true, &"");
+        let resp_bytes = resp
+            .body()
+            .clone()
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_data()
+            .unwrap();
+        let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
+        assert_eq!(resp_str, "current log level is info\n");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_change_log_level_invalid_log_level() {
+        helpers::initialize_telemetry();
+        let resp = change_log_level(true, &"invalid_level");
+        let resp_bytes = resp
+            .body()
+            .clone()
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_data()
+            .unwrap();
+        let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
+        assert!(resp_str.contains(HELP_STRING));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_change_log_level_debug() {
+        helpers::initialize_telemetry();
+        let resp = change_log_level(true, &"debug");
+        let resp_bytes = resp
+            .body()
+            .clone()
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_data()
+            .unwrap();
+        let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
+        assert_eq!(resp_str, "current log level is debug\n");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_change_log_level_warn() {
+        helpers::initialize_telemetry();
+        let resp = change_log_level(true, &"warn");
+        let resp_bytes = resp
+            .body()
+            .clone()
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_data()
+            .unwrap();
+        let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
+        assert_eq!(resp_str, "current log level is warn\n");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_change_log_level_error() {
+        helpers::initialize_telemetry();
+        let resp = change_log_level(true, &"error");
+        let resp_bytes = resp
+            .body()
+            .clone()
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_data()
+            .unwrap();
+        let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
+        assert_eq!(resp_str, "current log level is error\n");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_change_log_level_trace() {
+        helpers::initialize_telemetry();
+        let resp = change_log_level(true, &"trace");
+        let resp_bytes = resp
+            .body()
+            .clone()
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_data()
+            .unwrap();
+        let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
+        assert!(resp_str.contains("current log level is trace"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_change_log_level_info() {
+        helpers::initialize_telemetry();
+        let resp = change_log_level(true, &"info");
+        let resp_bytes = resp
+            .body()
+            .clone()
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_data()
+            .unwrap();
+        let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
+        assert!(resp_str.contains("current log level is info"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_change_log_level_off() {
+        helpers::initialize_telemetry();
+        let resp = change_log_level(true, &"off");
+        let resp_bytes = resp
+            .body()
+            .clone()
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_data()
+            .unwrap();
+        let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
+        assert!(resp_str.contains("current log level is off"));
     }
 }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -448,7 +448,7 @@ mod tests {
     use crate::config::construct_config;
     use crate::config::ProxyConfig;
     use crate::identity;
-    use crate::test_helpers::{new_proxy_state, helpers};
+    use crate::test_helpers::{helpers, new_proxy_state};
     use crate::xds::istio::security::string_match::MatchType as XdsMatchType;
     use crate::xds::istio::security::Address as XdsAddress;
     use crate::xds::istio::security::Authorization as XdsAuthorization;

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -820,7 +820,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_change_log_level_empty() {
         helpers::initialize_telemetry();
-        let resp = change_log_level(true, &"");
+        let resp = change_log_level(true, "");
         let resp_bytes = resp
             .body()
             .clone()
@@ -837,7 +837,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_change_log_level_invalid_log_level() {
         helpers::initialize_telemetry();
-        let resp = change_log_level(true, &"invalid_level");
+        let resp = change_log_level(true, "invalid_level");
         let resp_bytes = resp
             .body()
             .clone()
@@ -854,7 +854,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_change_log_level_debug() {
         helpers::initialize_telemetry();
-        let resp = change_log_level(true, &"debug");
+        let resp = change_log_level(true, "debug");
         let resp_bytes = resp
             .body()
             .clone()
@@ -871,7 +871,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_change_log_level_warn() {
         helpers::initialize_telemetry();
-        let resp = change_log_level(true, &"warn");
+        let resp = change_log_level(true, "warn");
         let resp_bytes = resp
             .body()
             .clone()
@@ -888,7 +888,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_change_log_level_error() {
         helpers::initialize_telemetry();
-        let resp = change_log_level(true, &"error");
+        let resp = change_log_level(true, "error");
         let resp_bytes = resp
             .body()
             .clone()
@@ -905,7 +905,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_change_log_level_trace() {
         helpers::initialize_telemetry();
-        let resp = change_log_level(true, &"trace");
+        let resp = change_log_level(true, "trace");
         let resp_bytes = resp
             .body()
             .clone()
@@ -922,7 +922,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_change_log_level_info() {
         helpers::initialize_telemetry();
-        let resp = change_log_level(true, &"info");
+        let resp = change_log_level(true, "info");
         let resp_bytes = resp
             .body()
             .clone()
@@ -939,7 +939,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_change_log_level_off() {
         helpers::initialize_telemetry();
-        let resp = change_log_level(true, &"off");
+        let resp = change_log_level(true, "off");
         let resp_bytes = resp
             .body()
             .clone()

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -361,7 +361,7 @@ fn change_log_level(reset: bool, level: &str) -> Response<Full<Bytes>> {
     match tracing::level_filters::LevelFilter::from_str(level) {
         Ok(level_filter) => {
             // Valid level, continue processing
-            tracing::debug!("Parsed level: {:?}", level_filter);
+            tracing::info!("Parsed level: {:?}", level_filter);
             match telemetry::set_level(reset, level) {
                 Ok(_) => list_loggers(),
                 Err(e) => plaintext_response(

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -365,7 +365,7 @@ fn change_log_level(reset: bool, level: &str) -> Response<Full<Bytes>> {
             match telemetry::set_level(reset, level) {
                 Ok(_) => list_loggers(),
                 Err(e) => plaintext_response(
-                    hyper::StatusCode::METHOD_NOT_ALLOWED,
+                    hyper::StatusCode::BAD_REQUEST,
                     format!("Failed to set new level: {}\n{}", e, HELP_STRING),
                 ),
             }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -361,7 +361,7 @@ fn change_log_level(reset: bool, level: &str) -> Response<Full<Bytes>> {
     match tracing::level_filters::LevelFilter::from_str(level) {
         Ok(level_filter) => {
             // Valid level, continue processing
-            tracing::info!("Parsed level: {:?}", level_filter);
+            tracing::debug!("Parsed level: {:?}", level_filter);
             match telemetry::set_level(reset, level) {
                 Ok(_) => list_loggers(),
                 Err(e) => plaintext_response(


### PR DESCRIPTION
This PR is a follow-up for comments left on [PR #557](https://github.com/istio/ztunnel/pull/557).

The following changes were made:
- changed level for `"Parsed level: {:?}"` message to debug instead of info. cc/ @keithmattix 
- changed status code for other error in `change_log_level` to also be BAD_REQUEST. cc/ @howardjohn 
- add unit tests for `change_log_level`. cc/ @GregHanson 