### PR TITLE
Fail if using DNS with on-demand

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,7 @@ const DEFAULT_SELFTERM_DEADLINE: Duration = Duration::from_secs(5);
 const DEFAULT_CLUSTER_ID: &str = "Kubernetes";
 
 const ISTIO_META_PREFIX: &str = "ISTIO_META_";
+const DNS_CAPTURE_METADATA: &str = "DNS_CAPTURE";
 
 /// Fetch the XDS/CA root cert file path based on below constants
 const XDS_ROOT_CA_ENV: &str = "XDS_ROOT_CA";
@@ -104,8 +105,9 @@ pub struct Config {
     pub inbound_addr: SocketAddr,
     pub inbound_plaintext_addr: SocketAddr,
     pub outbound_addr: SocketAddr,
-    /// The socket address for the DNS proxy.
-    /// Only applies if `ISTIO_META_DNS_CAPTURE` is enabled.
+    /// If true, a DNS proxy will be used.
+    pub dns_proxy: bool,
+    /// The socket address for the DNS proxy. Only applies if `dns_proxy` is true.
     pub dns_proxy_addr: SocketAddr,
 
     /// The network of the node this ztunnel is running on.
@@ -255,7 +257,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         RootCert::Static(Bytes::from(ca_root_cert_provider))
     };
 
-    Ok(Config {
+    validate_config(Config {
         window_size: 4 * 1024 * 1024,
         connection_window_size: 4 * 1024 * 1024,
         frame_size: 1024 * 1024,
@@ -276,6 +278,11 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             IpAddr::V6(Ipv6Addr::UNSPECIFIED),
             DEFAULT_READINESS_PORT, // There is no config for this in ProxyConfig currently
         ),
+
+        dns_proxy: pc
+            .proxy_metadata
+            .get(DNS_CAPTURE_METADATA)
+            .map_or(false, |value| value.to_lowercase() == "true"),
 
         socks5_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 15080),
         inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15008),
@@ -321,6 +328,16 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         enable_original_source: parse(ENABLE_ORIG_SRC)?,
         proxy_args: parse_args(),
     })
+}
+
+fn validate_config(cfg: Config) -> Result<Config, Error> {
+    if cfg.dns_proxy && cfg.xds_on_demand {
+        Err(Error::ProxyConfig(anyhow!(
+            "DNS proxy does not currently support on-demand mode"
+        )))
+    } else {
+        Ok(cfg)
+    }
 }
 
 // tries to parse the URI so we can fail early

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -125,14 +125,7 @@ impl Proxy {
 }
 
 async fn new_dns_proxy(pi: ProxyInputs) -> Result<Option<dns::DnsProxy>, Error> {
-    // Determine whether we should enable DNS from proxy metadata.
-    const DNS_CAPTURE_METADATA: &str = "ISTIO_META_DNS_CAPTURE";
-    let dns_enabled = pi
-        .cfg
-        .proxy_metadata
-        .get(DNS_CAPTURE_METADATA)
-        .map_or(false, |val| val.trim().to_lowercase() == "true");
-    if dns_enabled {
+    if pi.cfg.dns_proxy {
         Ok(Some(
             dns::DnsProxy::new(
                 pi.cfg.dns_proxy_addr,


### PR DESCRIPTION
The DNS proxy does not currently support on-demand mode (see #577).

For now, just explicitly fail at startup if the user tried enabling both options.