### PR TITLE
Various cleanup to ProxyState

### DIFF
--- a/src/proxy/dns.rs
+++ b/src/proxy/dns.rs
@@ -126,7 +126,7 @@ impl DnsStore {
     /// Find the workload for the client address.
     fn find_client(&self, client_addr: SocketAddr) -> Option<Workload> {
         let state = self.state.read().unwrap();
-        state.workloads.find_workload(&NetworkAddress {
+        state.workloads.find_address(&NetworkAddress {
             network: self.network.clone(),
             address: client_addr.ip(),
         })

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -397,7 +397,7 @@ impl Inbound {
         gateway_address: Option<&GatewayAddress>,
     ) -> bool {
         if let Some(gateway_address) = gateway_address {
-            let from_gateway = match state.lookup_address(&gateway_address.destination).await {
+            let from_gateway = match state.fetch_destination(&gateway_address.destination).await {
                 Some(address::Address::Workload(wl)) => Some(wl.identity()) == conn.src_identity,
                 Some(address::Address::Service(svc)) => {
                     for (ip, _ep) in svc.endpoints.iter() {
@@ -492,7 +492,7 @@ mod test {
         let w = mock_default_gateway_workload();
         let s = mock_default_gateway_service();
         let mut state = state::ProxyState::default();
-        if let Err(err) = state.workloads.insert_workload(w) {
+        if let Err(err) = state.workloads.insert(w) {
             panic!("received error inserting workload: {}", err);
         }
         state.services.insert(s);
@@ -549,6 +549,7 @@ mod test {
             workload_type: "deployment".to_string(),
             canonical_name: "app".to_string(),
             canonical_revision: "".to_string(),
+            hostname: "".to_string(),
             node: "".to_string(),
             status: Default::default(),
             cluster_id: "Kubernetes".to_string(),
@@ -575,6 +576,7 @@ mod test {
             workload_type: "deployment".to_string(),
             canonical_name: "".to_string(),
             canonical_revision: "".to_string(),
+            hostname: "".to_string(),
             node: "".to_string(),
             status: Default::default(),
             cluster_id: "Kubernetes".to_string(),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -374,14 +374,12 @@ impl OutboundConnection {
 
         let us = us.unwrap();
         // For case upstream server has enabled waypoint
-        match self.pi.state.find_waypoint(us.workload.clone()).await {
+        match self.pi.state.fetch_waypoint(us.workload.clone()).await {
             Ok(None) => {} // workload doesn't have a waypoint; this is fine
             Ok(Some(waypoint_us)) => {
                 let waypoint_workload = waypoint_us.workload;
-                let wp_socket_addr = SocketAddr::new(
-                    self.pi.state.choose_workload_ip(&waypoint_workload)?,
-                    waypoint_us.port,
-                );
+                let wp_socket_addr =
+                    SocketAddr::new(waypoint_workload.choose_ip()?, waypoint_us.port);
                 return Ok(Request {
                     // Always use HBONE here
                     protocol: Protocol::HBONE,
@@ -416,10 +414,7 @@ impl OutboundConnection {
             return Ok(Request {
                 protocol: Protocol::HBONE,
                 source: source_workload,
-                destination: SocketAddr::from((
-                    self.pi.state.choose_workload_ip(&us.workload)?,
-                    us.port,
-                )),
+                destination: SocketAddr::from((us.workload.choose_ip()?, us.port)),
                 destination_workload: Some(us.workload.clone()),
                 expected_identity: Some(us.workload.identity()),
                 gateway: SocketAddr::from((
@@ -439,10 +434,7 @@ impl OutboundConnection {
         Ok(Request {
             protocol: us.workload.protocol,
             source: source_workload,
-            destination: SocketAddr::from((
-                self.pi.state.choose_workload_ip(&us.workload)?,
-                us.port,
-            )),
+            destination: SocketAddr::from((us.workload.choose_ip()?, us.port)),
             destination_workload: Some(us.workload.clone()),
             expected_identity: Some(us.workload.identity()),
             gateway: us

--- a/src/state/policy.rs
+++ b/src/state/policy.rs
@@ -1,0 +1,79 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::rbac::{Authorization, RbacScope};
+use std::collections::{HashMap, HashSet};
+
+/// A WorkloadStore encapsulates all information about workloads in the mesh
+#[derive(serde::Serialize, Default, Debug)]
+pub struct PolicyStore {
+    /// policies maintains a mapping of ns/name to policy.
+    by_key: HashMap<String, Authorization>,
+
+    /// policies_by_namespace maintains a mapping of namespace (or "" for global) to policy names
+    by_namespace: HashMap<String, HashSet<String>>,
+}
+
+impl PolicyStore {
+    pub fn get<T: AsRef<str>>(&self, key: T) -> Option<&Authorization> {
+        self.by_key.get(key.as_ref())
+    }
+
+    pub fn get_by_namespace<T: AsRef<str>>(&self, namespace: T) -> Vec<String> {
+        self.by_namespace
+            .get(namespace.as_ref())
+            .into_iter()
+            .flatten()
+            .cloned()
+            .collect()
+    }
+
+    pub fn insert(&mut self, rbac: Authorization) {
+        let key = rbac.to_key();
+        match rbac.scope {
+            RbacScope::Global => {
+                self.by_namespace
+                    .entry("".to_string())
+                    .or_default()
+                    .insert(key.clone());
+            }
+            RbacScope::Namespace => {
+                self.by_namespace
+                    .entry(rbac.namespace.clone())
+                    .or_default()
+                    .insert(key.clone());
+            }
+            RbacScope::WorkloadSelector => {}
+        }
+        self.by_key.insert(key, rbac);
+    }
+
+    pub fn remove(&mut self, name: String) {
+        let Some(rbac) = self.by_key.remove(&name) else {
+            return;
+        };
+        if let Some(key) = match rbac.scope {
+            RbacScope::Global => Some("".to_string()),
+            RbacScope::Namespace => Some(rbac.namespace),
+            RbacScope::WorkloadSelector => None,
+        } {
+            if let Some(pl) = self.by_namespace.get_mut(&key) {
+                pl.remove(&name);
+                if pl.is_empty() {
+                    self.by_namespace.remove(&key);
+                }
+            }
+        }
+    }
+}

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -163,6 +163,7 @@ pub fn test_default_workload() -> Workload {
         workload_type: "deployment".to_string(),
         canonical_name: "".to_string(),
         canonical_revision: "".to_string(),
+        hostname: "".to_string(),
         node: "".to_string(),
         status: Default::default(),
         cluster_id: "Kubernetes".to_string(),


### PR DESCRIPTION
* Moving policies to separate `PolicyStore`. All member variables are now private.
* Making a clearer separation between `findXXX` methods which now belong to `ProxyState`, and `fetchXXX`, which belong to `DemandProxyState` and build on the `findXXX` versions.
* Adding `hostname` to `Workload` and adding support for finding workloads by hostname.