### PR TITLE
Fix for DNS system forwarder

### DIFF
--- a/src/proxy/dns/proxy.rs
+++ b/src/proxy/dns/proxy.rs
@@ -118,8 +118,9 @@ async fn send_lookup_error<R: ResponseHandler>(
         LookupError::ResponseCode(code) => send_error(request, response_handle, code).await,
         LookupError::ResolveError(e) => {
             match e.kind() {
-                ResolveErrorKind::NoRecordsFound { .. } => {
-                    send_empty_response(request, response_handle).await
+                ResolveErrorKind::NoRecordsFound { response_code, .. } => {
+                    // Respond with the error code.
+                    send_error(request, response_handle, *response_code).await
                 }
                 _ => {
                     // TODO(nmittler): log?

--- a/src/proxy/dns/resolver.rs
+++ b/src/proxy/dns/resolver.rs
@@ -20,7 +20,7 @@ use trust_dns_server::server::Request;
 
 /// Similar to a TrustDNS `Authority`, although the resulting [Answer] indicates whether
 /// the response is authoritative. This makes the interface generally more composable and
-/// better supports a proxy use case, where some responses may be authoriative and others
+/// better supports a proxy use case, where some responses may be authoritative and others
 /// may not.
 #[async_trait::async_trait]
 pub trait Resolver: Sync + Send {
@@ -28,6 +28,7 @@ pub trait Resolver: Sync + Send {
 }
 
 /// Answer returned by a [Resolver].
+#[derive(Debug)]
 pub struct Answer {
     records: Vec<Record>,
     is_authoritative: bool,


### PR DESCRIPTION
Currently, if a DNS request is forwarded to the upstream resolver and fails with NXDomain, the client will see a successful response with no records.

This is due to the fact that the DNS system forwarder returns an error of type ResolveError, which was not being handled properly by the Handler.

This fixes the logic and adds tests for the system forwarder.

Fixes #600