### PR TITLE
Waypoint workload IP cannot match tcp workload

### DIFF
--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -107,7 +107,7 @@ pub fn test_config() -> config::Config {
 pub const TEST_WORKLOAD_SOURCE: &str = "127.0.0.2";
 pub const TEST_WORKLOAD_HBONE: &str = "127.0.0.3";
 pub const TEST_WORKLOAD_TCP: &str = "127.0.0.4";
-pub const TEST_WORKLOAD_WAYPOINT: &str = "127.0.0.4";
+pub const TEST_WORKLOAD_WAYPOINT: &str = "127.0.0.5";
 pub const TEST_VIP: &str = "127.10.0.1";
 pub const TEST_SERVICE_NAMESPACE: &str = "default";
 pub const TEST_SERVICE_NAME: &str = "local-vip";


### PR DESCRIPTION
`TEST_WORKLOAD_TCP` and `TEST_WORKLOAD_WAYPOINT` both had the same IP, so both workloads had the same network address.

This is an disallowed configuration in ambient (IPs are unique per network) so this PR updates the test so the IPs are distinct.