### PR TITLE
add a logs message when starting dns server

### DIFF
--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -88,6 +88,7 @@ impl Server {
         let mut server = ServerFuture::new(handler);
         info!(
             address=%addr,
+            component="dns",
             "starting local DNS server",
         );
         // Bind and register the UDP socket.

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -86,7 +86,10 @@ impl Server {
             metrics,
         )));
         let mut server = ServerFuture::new(handler);
-        info!("starting local DNS server on {}", addr);
+        info!(
+            address=%addr,
+            "starting local DNS server",
+        );
         // Bind and register the UDP socket.
         let udp_socket = UdpSocket::bind(addr)
             .await

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -24,7 +24,7 @@ use once_cell::sync::Lazy;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use tokio::net::{TcpListener, UdpSocket};
-use tracing::warn;
+use tracing::{info, warn};
 use trust_dns_proto::error::ProtoErrorKind;
 use trust_dns_proto::op::ResponseCode;
 use trust_dns_proto::rr::{Name, RData, Record, RecordType};
@@ -86,7 +86,7 @@ impl Server {
             metrics,
         )));
         let mut server = ServerFuture::new(handler);
-
+        info!("starting local DNS server on {}", addr);
         // Bind and register the UDP socket.
         let udp_socket = UdpSocket::bind(addr)
             .await


### PR DESCRIPTION
there's a similar message in pilot-agent when we start a dns server, but currently none for ztunnel.  Unless the ztunnel is handling an actual dns request, there's no sign that the server is actually running

Sample log message:
```
2023-07-19T14:01:29.401806Z  INFO ztunnel::dns::server: starting local DNS server on [::]:15053
```

tldr; debugged a problem with ztunnel dns, and ended up being related to iptables instead