### PR TITLE
Set NODELAY when accepting H2 connections

### DIFF
--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -52,6 +52,7 @@ pub fn tls_server<T: CertProvider + Clone + 'static>(
                     None
                 }
                 Ok(s) => {
+                    s.get_ref().set_nodelay(true).unwrap();
                     debug!("TLS handshake succeeded");
                     Some(s)
                 }

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -52,11 +52,13 @@ pub fn tls_server<T: CertProvider + Clone + 'static>(
                     None
                 }
                 Ok(s) => {
-                    s.get_ref().set_nodelay(true).unwrap();
                     debug!("TLS handshake succeeded");
                     Some(s)
                 }
             }
+        }).map(|conn| {
+            conn.get_ref().set_nodelay(true).unwrap();
+            conn
         })
 }
 

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -56,7 +56,8 @@ pub fn tls_server<T: CertProvider + Clone + 'static>(
                     Some(s)
                 }
             }
-        }).map(|conn| {
+        })
+        .map(|conn| {
             conn.get_ref().set_nodelay(true).unwrap();
             conn
         })


### PR DESCRIPTION
Longest I've spent on a single line of code.

This change improves latency performance by 10-20x. We should set NODELAY because we are already setting it on one end of the H2 connection. Also, this [Will I need TCP_NODELAY for my HTTP/2 connections?](https://http2.github.io/faq/#will-i-need-tcp_nodelay-for-my-http2-connections).

Not sure if this is the correct place to do this. Feels more of a `hyper` thing than a TLS thing. I want to put it in here

https://github.com/istio/ztunnel/blob/be1e6d8d333b5dd26cf123babd1239eb5366f862/src/hyper_util.rs#L48

But, `conn` is of type `SslStream<TcpStream>` and I can't find a way to get the `TcpStream` out. I'm also happy to add a `set_nodelay` method to `SslStream` upstream.