### PR TITLE
inbound_passthrough: use own address as source

### DIFF
--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -108,8 +108,14 @@ impl InboundPassthrough {
             };
             // Spoofing the source IP only works when the destination or the source are on our node.
             // In this case, the source and the destination might both be remote, so we need to disable it.
+            
+            // The destination zTunnel is now the client zTunnel. We can't impersonate the client,
+            // so use the zTunnel's own IP.
             oc.pi.cfg.enable_original_source = Some(false);
-            return oc.proxy_to(inbound, source.ip(), orig, false).await;
+            let Some(proxy_ip) = oc.pi.cfg.local_ip else {
+               return Err(Error::UnknownSource(source.ip())); 
+            };
+            return oc.proxy_to(inbound, proxy_ip, orig, false).await;
         }
 
         // We enforce RBAC only for non-hairpin cases. This is because we may not be able to properly


### PR DESCRIPTION
https://github.com/istio/istio/issues/44530

Inbound passthrough shouldn't present the identity of a non-captured client (even if we have the right to impersonate). 
For now this presents the zTunnel's own identity. We could instead have a dedicated "mesh external" identity. 


---

Tested with different combinations of cross-node/same-node. 
Can probably unskip some ITs. 

```
NAME                                       READY   STATUS    RESTARTS   AGE    IP            NODE                          NOMINATED NODE   READINESS GATES
uncaptured-v1-6c45fd786-nbtw7              1/1     Running   0          31m    10.244.2.37   istio-testing-worker          <none>           <none>
uncaptured-v2-598d5bd96b-jb667             1/1     Running   0          109s   10.244.1.45   istio-testing-worker2         <none>           <none>
waypoint-istio-waypoint-865f484b4b-wt4md   1/1     Running   0          79m    10.244.1.12   istio-testing-worker2         <none>           <none>
waypoint-v1-674fbc9f99-kcm5k               1/1     Running   0          75m    10.244.0.9    istio-testing-control-plane   <none>           <none>
waypoint-v2-64b9b54b5c-lg28x               1/1     Running   0          79m    10.244.1.9    istio-testing-worker2         <none>           <none>
```

```
❯ k -n echo exec uncaptured-v1-6c45fd786-nbtw7 -- client waypoint --count 4 | grep Hostname
[0 body] Hostname=waypoint-v2-64b9b54b5c-lg28x
[1 body] Hostname=waypoint-v2-64b9b54b5c-lg28x
[2 body] Hostname=waypoint-v1-674fbc9f99-kcm5k
[3 body] Hostname=waypoint-v1-674fbc9f99-kcm5k
❯ k -n echo exec uncaptured-v2-598d5bd96b-jb667 -- client waypoint --count 4 | grep Hostname
[0 body] Hostname=waypoint-v2-64b9b54b5c-lg28x
[1 body] Hostname=waypoint-v2-64b9b54b5c-lg28x
[2 body] Hostname=waypoint-v1-674fbc9f99-kcm5k
[3 body] Hostname=waypoint-v2-64b9b54b5c-lg28x
```
