### PR TITLE
Update ondemand dns metric name

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -164,7 +164,7 @@ pub struct Config {
     pub proxy_args: String,
 
     // System dns resolver config used for on-demand ztunnel dns resolution
-    pub dns_resolver_config: ResolverConfig,
+    pub dns_resolver_cfg: ResolverConfig,
 
     // System dns resolver opts used for on-demand ztunnel dns resolution
     pub dns_resolver_opts: ResolverOpts,
@@ -273,7 +273,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
     };
 
     use trust_dns_resolver::system_conf::read_system_conf;
-    let (cfg, opts) = read_system_conf().unwrap();
+    let (dns_resolver_cfg, dns_resolver_opts) = read_system_conf().unwrap();
 
     validate_config(Config {
         proxy: parse_default(ENABLE_PROXY, true)?,
@@ -347,8 +347,8 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
 
         enable_original_source: parse(ENABLE_ORIG_SRC)?,
         proxy_args: parse_args(),
-        dns_resolver_config: cfg,
-        dns_resolver_opts: opts,
+        dns_resolver_cfg,
+        dns_resolver_opts,
     })
 }
 

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -30,7 +30,7 @@ pub struct Metrics {
     pub sent_bytes: Family<CommonTrafficLabels, Counter>,
 
     // on-demand DNS is not a part of DNS proxy, but part of ztunnel proxy itself
-    pub on_demand_dns_cache_hits: Family<OnDemandDnsLabels, Counter>,
+    pub on_demand_dns: Family<OnDemandDnsLabels, Counter>,
     pub on_demand_dns_cache_misses: Family<OnDemandDnsLabels, Counter>,
 }
 
@@ -312,16 +312,16 @@ impl Metrics {
             "The size of total bytes sent during response in case of a TCP connection",
             sent_bytes.clone(),
         );
-        let on_demand_dns_cache_hits = Family::default();
+        let on_demand_dns = Family::default();
         registry.register(
-            "on_demand_dns_cache_hits",
-            "The total number of cache hits for on-demand DNS",
-            on_demand_dns_cache_hits.clone(),
+            "on_demand_dns",
+            "The total number of requests that used on-demand DNS",
+            on_demand_dns.clone(),
         );
         let on_demand_dns_cache_misses = Family::default();
         registry.register(
             "on_demand_dns_cache_misses",
-            "The total number of cache misses for on-demand DNS",
+            "The total number of cache misses for requests on-demand DNS",
             on_demand_dns_cache_misses.clone(),
         );
 
@@ -330,7 +330,7 @@ impl Metrics {
             connection_close,
             received_bytes,
             sent_bytes,
-            on_demand_dns_cache_hits,
+            on_demand_dns,
             on_demand_dns_cache_misses,
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -625,7 +625,7 @@ impl ProxyStateManager {
             state: DemandProxyState {
                 state,
                 demand,
-                dns_resolver_cfg: config.dns_resolver_config,
+                dns_resolver_cfg: config.dns_resolver_cfg,
                 dns_resolver_opts: config.dns_resolver_opts,
             },
         })

--- a/src/state.rs
+++ b/src/state.rs
@@ -321,15 +321,9 @@ impl DemandProxyState {
             .with_source(src_workload);
         let workload_uid = workload.uid.to_owned();
         let hostname = workload.hostname.to_owned();
+        metrics.as_ref().on_demand_dns.get_or_create(&labels).inc();
         let rdns = match state.get_ips_for_hostname(&workload.hostname) {
-            Some(r) => {
-                metrics
-                    .as_ref()
-                    .on_demand_dns_cache_hits
-                    .get_or_create(&labels)
-                    .inc();
-                r
-            }
+            Some(r) => r,
             None => {
                 metrics
                     .as_ref()

--- a/src/state.rs
+++ b/src/state.rs
@@ -330,6 +330,8 @@ impl DemandProxyState {
                     .on_demand_dns_cache_misses
                     .get_or_create(&labels)
                     .inc();
+                // TODO: optimize so that if multiple requests to the same hostname come in at the same time,
+                // we don't start more than one background on-demand DNS task
                 Self::resolve_on_demand_dns(self.to_owned(), workload).await;
                 // try to get it again
                 let updated_rdns = state.get_ips_for_hostname(&hostname);

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -116,7 +116,7 @@ pub async fn add_nip_io_nameserver(mut cfg: config::Config) -> config::Config {
             trust_nx_responses: false,
             bind_addr: None,
         };
-        cfg.dns_resolver_config.add_name_server(name_server);
+        cfg.dns_resolver_cfg.add_name_server(name_server);
     }
     cfg
 }

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -225,7 +225,7 @@ async fn test_vip_request() {
 
 fn on_demand_dns_assertions(metrics: ParsedMetrics) {
     for metric in &[
-        ("istio_on_demand_dns_cache_hits_total"),
+        ("istio_on_demand_dns_total"),
         ("istio_on_demand_dns_cache_misses_total"),
     ] {
         let m = metrics.query(metric, &Default::default());
@@ -236,8 +236,15 @@ fn on_demand_dns_assertions(metrics: ParsedMetrics) {
             "expected metric {metric} to have len(1)"
         );
         let value = m.unwrap()[0].value.clone();
+        let expected = match *metric {
+            "istio_on_demand_dns_total" => prometheus_parse::Value::Untyped(2.0),
+            "istio_on_demand_dns_cache_misses_total" => prometheus_parse::Value::Untyped(1.0),
+            &_ => {
+                panic!("dev error; unexpected metric");
+            }
+        };
         assert!(
-            value == prometheus_parse::Value::Untyped(1.0),
+            value == expected,
             "expected metric {metric} to be 1, was {:?}",
             value
         );


### PR DESCRIPTION
Align better with prometheus best practices for naming https://prometheus.io/docs/practices/naming/

use `_total` and `..._cache_misses_total` rather than `..._cache_hits_total` and `..._cache_misses_total`