### PR TITLE
Set label destination_service_name and destination_service_namespace to L4 metrics

### DIFF
--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -205,6 +205,9 @@ impl From<&ConnectionOpen> for CommonTrafficLabels {
             request_protocol: RequestProtocol::tcp,
             response_flags: ResponseFlags::none,
             connection_security_policy: c.connection_security_policy,
+            destination_service: c.destination_service.clone().into(),
+            destination_service_name: c.destination_service_name.clone().into(),
+            destination_service_namespace: c.destination_service_namespace.clone().into(),
             ..CommonTrafficLabels::new()
                 // Intentionally before with_source; source is more reliable
                 .with_derived_source(c.derived_source.as_ref())

--- a/src/state.rs
+++ b/src/state.rs
@@ -16,7 +16,7 @@ use crate::identity::SecretManager;
 use crate::proxy;
 use crate::proxy::{Error, OnDemandDnsLabels};
 use crate::state::policy::PolicyStore;
-use crate::state::service::ServiceStore;
+use crate::state::service::{Service, ServiceStore};
 use crate::state::workload::{
     address::Address, gatewayaddress::Destination, network_addr, NamespacedHostname,
     NetworkAddress, Protocol, WaypointError, Workload, WorkloadStore,
@@ -41,11 +41,12 @@ pub mod policy;
 pub mod service;
 pub mod workload;
 
-#[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize)]
 pub struct Upstream {
     pub workload: Workload,
     pub port: u16,
     pub sans: Vec<String>,
+    pub destination_service: Option<Arc<Service>>,
 }
 
 impl fmt::Display for Upstream {
@@ -165,6 +166,7 @@ impl ProxyState {
                 workload: wl,
                 port: *target_port,
                 sans: svc.subject_alt_names.clone(),
+                destination_service: Some(Arc::new(svc)),
             };
             return Some(us);
         }
@@ -176,6 +178,7 @@ impl ProxyState {
                 workload: wl,
                 port: addr.port(),
                 sans: Vec::new(),
+                destination_service: None,
             };
             return Some(us);
         }


### PR DESCRIPTION
Fixes [#46169](https://github.com/istio/istio/issues/46169)

With this PR, we can see `Service Nodes` graph in kiali.