### PR TITLE
metrics: report Service from inbound side as well

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -410,10 +410,10 @@ pub async fn relay(
     }
 }
 
-// pick_upstream_service selects an upstream service for inbound metrics.
+// guess_inbound_service selects an upstream service for inbound metrics.
 // There may be many services for a single workload. We find the the first one with an applicable port
 // as a best guess.
-pub fn pick_upstream_service(
+pub fn guess_inbound_service(
     conn: &Connection,
     upstream_service: Vec<Service>,
     dest: &Workload,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -419,7 +419,6 @@ pub fn pick_upstream_service(
     dest: &Workload,
 ) -> Option<ServiceDescription> {
     let dport = conn.dst.port();
-    error!("upstream service... {upstream_service:?}");
     let netaddr = network_addr(&dest.network, conn.dst.ip());
     let euid = endpoint_uid(&dest.uid, Some(&netaddr));
     upstream_service
@@ -430,6 +429,8 @@ pub fn pick_upstream_service(
                     // TargetPort directly matches
                     return true;
                 }
+                // The service itself didn't have a explicit TargetPort match, but an endpoint might.
+                // This happens when there is a named port (in Kubernetes, anyways).
                 if s.endpoints.get(&euid).and_then(|e| e.port.get(sport)) == Some(&dport) {
                     // Named port matched
                     return true;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -21,18 +21,23 @@ use std::{fmt, io};
 use boring::error::ErrorStack;
 use drain::Watch;
 use hyper::{header, Request};
-use inbound::Inbound;
+
 use rand::Rng;
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::time::timeout;
 use tracing::{error, trace, warn, Instrument};
+
+use inbound::Inbound;
+pub use metrics::*;
 
 use crate::identity::SecretManager;
 use crate::metrics::Recorder;
 use crate::proxy::inbound_passthrough::InboundPassthrough;
 use crate::proxy::outbound::Outbound;
 use crate::proxy::socks5::Socks5;
-use crate::state::workload::Workload;
+use crate::rbac::Connection;
+use crate::state::service::{endpoint_uid, Service, ServiceDescription};
+use crate::state::workload::{network_addr, Workload};
 use crate::state::DemandProxyState;
 use crate::{config, identity, socket, tls};
 
@@ -44,8 +49,6 @@ mod outbound;
 mod pool;
 mod socks5;
 mod util;
-
-pub use metrics::*;
 
 pub struct Proxy {
     inbound: Inbound,
@@ -405,6 +408,37 @@ pub async fn relay(
         }
         Err(e) => Err(Error::Io(e)),
     }
+}
+
+// pick_upstream_service selects an upstream service for inbound metrics.
+// There may be many services for a single workload. We find the the first one with an applicable port
+// as a best guess.
+pub fn pick_upstream_service(
+    conn: &Connection,
+    upstream_service: Vec<Service>,
+    dest: &Workload,
+) -> Option<ServiceDescription> {
+    let dport = conn.dst.port();
+    error!("upstream service... {upstream_service:?}");
+    let netaddr = network_addr(&dest.network, conn.dst.ip());
+    let euid = endpoint_uid(&dest.uid, Some(&netaddr));
+    upstream_service
+        .iter()
+        .find(|s| {
+            for (sport, tport) in s.ports.iter() {
+                if tport == &dport {
+                    // TargetPort directly matches
+                    return true;
+                }
+                if s.endpoints.get(&euid).and_then(|e| e.port.get(sport)) == Some(&dport) {
+                    // Named port matched
+                    return true;
+                }
+                // no match
+            }
+            false
+        })
+        .map(ServiceDescription::from)
 }
 
 #[cfg(test)]

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -338,7 +338,7 @@ impl Inbound {
                     revision: baggage.revision,
                     ..Default::default()
                 };
-                let ds = proxy::pick_upstream_service(&conn, upstream_service, &upstream);
+                let ds = proxy::guess_inbound_service(&conn, upstream_service, &upstream);
                 let connection_metrics = ConnectionOpen {
                     reporter: Reporter::destination,
                     source,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -25,6 +25,7 @@ use http_body_util::Empty;
 use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
+
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, error, info, instrument, trace, trace_span, warn, Instrument};
 
@@ -39,6 +40,7 @@ use crate::proxy::metrics::{ConnectionOpen, Metrics, Reporter};
 use crate::proxy::{metrics, ProxyInputs, TraceParent, BAGGAGE_HEADER, TRACEPARENT_HEADER};
 use crate::rbac::Connection;
 use crate::socket::to_canonical;
+
 use crate::state::workload::{address, GatewayAddress, NetworkAddress, Workload};
 use crate::state::DemandProxyState;
 use crate::tls::TlsError;
@@ -272,7 +274,7 @@ impl Inbound {
                     network: conn.dst_network.to_string(), // dst must be on our network
                     address: addr.ip(),
                 };
-                let Some(upstream) = state.fetch_workload(&dst_network_addr).await else {
+                let Some((upstream, upstream_service)) = state.fetch_workload_services(&dst_network_addr).await else {
                     info!(%conn, "unknown destination");
                     return Ok(Response::builder()
                         .status(StatusCode::NOT_FOUND)
@@ -329,20 +331,21 @@ impl Inbound {
                 };
 
                 let derived_source = metrics::DerivedWorkload {
-                    identity: conn.src_identity,
+                    identity: conn.src_identity.clone(),
                     cluster_id: baggage.cluster_id,
                     namespace: baggage.namespace,
                     workload_name: baggage.workload_name,
                     revision: baggage.revision,
                     ..Default::default()
                 };
+                let ds = proxy::pick_upstream_service(&conn, upstream_service, &upstream);
                 let connection_metrics = ConnectionOpen {
                     reporter: Reporter::destination,
                     source,
                     derived_source: Some(derived_source),
                     destination: Some(upstream),
                     connection_security_policy: metrics::SecurityPolicy::mutual_tls,
-                    destination_service: None,
+                    destination_service: ds,
                 };
                 let status_code = match Self::handle_inbound(
                     Hbone(req),

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -157,7 +157,7 @@ impl InboundPassthrough {
             identity: conn.src_identity.clone(),
             ..Default::default()
         };
-        let ds = proxy::pick_upstream_service(&conn, upstream_service, &upstream);
+        let ds = proxy::guess_inbound_service(&conn, upstream_service, &upstream);
         let connection_metrics = metrics::ConnectionOpen {
             reporter: Reporter::destination,
             source: source_workload,

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -93,7 +93,7 @@ impl InboundPassthrough {
             network: pi.cfg.network.clone(), // inbound request must be on our network
             address: orig.ip(),
         };
-        let Some(upstream) = pi.state.fetch_workload(&network_addr).await else {
+        let Some((upstream, upstream_service)) = pi.state.fetch_workload_services(&network_addr).await else {
             return Err(Error::UnknownDestination(orig.ip()))
         };
         if upstream.waypoint.is_some() {
@@ -154,16 +154,17 @@ impl InboundPassthrough {
             None
         };
         let derived_source = metrics::DerivedWorkload {
-            identity: conn.src_identity,
+            identity: conn.src_identity.clone(),
             ..Default::default()
         };
+        let ds = proxy::pick_upstream_service(&conn, upstream_service, &upstream);
         let connection_metrics = metrics::ConnectionOpen {
             reporter: Reporter::destination,
             source: source_workload,
             derived_source: Some(derived_source),
             destination: Some(upstream),
             connection_security_policy: metrics::SecurityPolicy::unknown,
-            destination_service: None,
+            destination_service: ds,
         };
         let _connection_close = pi
             .metrics

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -202,7 +202,7 @@ impl OutboundConnection {
                 } else {
                     metrics::SecurityPolicy::unknown
                 },
-                destination_service: None, // TODO: in Envoy, we guess the destination service for inbound
+                destination_service: req.destination_service,
             };
             return Inbound::handle_inbound(
                 InboundConnect::DirectPath(stream),

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -155,14 +155,17 @@ mod namespaced {
             &metrics,
             &HashMap::from([
                 ("reporter".to_string(), "destination".to_string()),
-                ("destination_service".to_string(), "unknown".to_string()),
+                (
+                    "destination_service".to_string(),
+                    "server1.default.svc.cluster.local".to_string(),
+                ),
                 (
                     "destination_service_name".to_string(),
-                    "unknown".to_string(),
+                    "server1".to_string(),
                 ),
                 (
                     "destination_service_namespace".to_string(),
-                    "unknown".to_string(),
+                    "default".to_string(),
                 ),
             ]),
         )


### PR DESCRIPTION
This mirrors Envoy implementation and is required for correct
dashboards/kiali/etc.

Basically we try to guess the Service since we cannot really know; same
as Envoy.
