### PR TITLE
inbound passthrough always denies when there is a waypoint

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -170,6 +170,9 @@ pub enum Error {
     #[error("unknown source: {0}")]
     UnknownSource(IpAddr),
 
+    #[error("unauthenticated source: {0}")]
+    UnauthenticatedSource(IpAddr),
+
     #[error("unknown waypoint: {0}")]
     UnknownWaypoint(String),
 


### PR DESCRIPTION
Until we make a proper decision around whether to hairpin, we should not sometimes do it if the IP is in-cluster and the identity happens to exist on the node.

https://github.com/istio/istio/issues/44530