### PR TITLE
Update Hyper to 1.0.0-rc4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "async-channel"
@@ -89,7 +89,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -100,7 +100,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -200,11 +200,11 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -215,6 +215,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -224,24 +225,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "boring"
-version = "2.1.0"
-source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#5185311af8addc6851a48bd5747ec634dbb72811"
+version = "3.0.4"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0-rc4#d5d8a21d88e254ad7c19f59301b97155d88e13c3"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "boring-sys",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
 name = "boring-sys"
-version = "2.1.0"
-source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#5185311af8addc6851a48bd5747ec634dbb72811"
+version = "3.0.4"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0-rc4#d5d8a21d88e254ad7c19f59301b97155d88e13c3"
 dependencies = [
  "bindgen",
  "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -351,7 +360,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap 1.9.3",
  "textwrap",
@@ -557,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "519b83cd10f5f6e969625a409f735182bea5558cd8b64c655806ceaae36f1999"
 
 [[package]]
 name = "either"
@@ -689,7 +698,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -705,6 +714,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -778,7 +803,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1053,13 +1078,12 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75264b2003a3913f118d35c586e535293b3e22e41f074930762929d071e092"
+checksum = "d280a71f348bcc670fc55b02b63c53a04ac0bf2daff2980795aeaf53edae10e6"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
  "http",
@@ -1075,13 +1099,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-boring"
-version = "3.0.0"
-source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#5185311af8addc6851a48bd5747ec634dbb72811"
+version = "3.0.4"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0-rc4#d5d8a21d88e254ad7c19f59301b97155d88e13c3"
 dependencies = [
  "antidote",
  "boring",
  "http",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "hyper-util",
  "linked_hash_set",
  "once_cell",
@@ -1106,15 +1130,15 @@ dependencies = [
 [[package]]
 name = "hyper-util"
 version = "0.0.0"
-source = "git+https://github.com/howardjohn/hyper-util?branch=h2-timer-expose-exec#b9eaeca869e1cf9dcf65426c748751ef0c0ef5e0"
+source = "git+https://github.com/howardjohn/hyper-util?branch=h2-timer-expose-exec-rc4#5ac239604435859c48969a2b1cb23a207197ad08"
 dependencies = [
  "futures-channel",
  "futures-util",
  "http",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "once_cell",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio",
  "tower",
  "tower-service",
@@ -1243,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "js-sys"
@@ -1490,7 +1514,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if",
  "libc",
@@ -1503,7 +1527,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -1649,7 +1673,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1773,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -1902,9 +1926,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -2028,7 +2052,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2112,7 +2136,7 @@ version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2122,15 +2146,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "same-file"
@@ -2149,9 +2173,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -2170,14 +2194,14 @@ checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "itoa",
  "ryu",
@@ -2209,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.23"
+version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6075b41c7e3b079e5f246eb6094a44850d3a4c25a67c581c80796c80134012"
+checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -2327,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2424,7 +2448,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2524,8 +2548,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-boring"
-version = "2.1.5"
-source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#5185311af8addc6851a48bd5747ec634dbb72811"
+version = "3.0.4"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0-rc4#d5d8a21d88e254ad7c19f59301b97155d88e13c3"
 dependencies = [
  "boring",
  "boring-sys",
@@ -2550,7 +2574,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2676,14 +2700,14 @@ dependencies = [
 
 [[package]]
 name = "tower-hyper-http-body-compat"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2373750972dd4efeef7ac0971cebd6597c6f3f98202bb5217763dcca99617d"
+checksum = "a7ea3e622710ee44a8255baa6fcb2a34d67450e2ffb48e5e58d5a7bd6ff55a21"
 dependencies = [
  "http",
  "http-body 0.4.5",
  "http-body 1.0.0-rc.2",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "pin-project-lite",
  "tower",
  "tower-service",
@@ -2722,7 +2746,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2868,9 +2892,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -2883,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "url"
@@ -2901,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 
 [[package]]
 name = "valuable"
@@ -2981,7 +3005,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -3003,7 +3027,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3181,7 +3205,7 @@ dependencies = [
  "http-body 1.0.0-rc.2",
  "http-body-util",
  "http-types",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "hyper-boring",
  "hyper-util",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,17 +31,17 @@ async-stream = "0.3.3"
 async-trait = "0.1.58"
 atty = "0.2"
 # Fork will be dropped once Hyper goes 1.0.0
-hyper-boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0" }
-boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0" }
-tokio-boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0" }
+hyper-boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0-rc4" }
+boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0-rc4" }
+tokio-boring = { git = "https://github.com/howardjohn/boring/", branch = "hyper-boring/adopt-hyper-1.0.0-rc4" }
 bytes = { version = "1", features = ["serde"] }
 console-subscriber = { version = "0.1.6", optional = true }
 drain = "0.1.1"
 futures = "0.3.12"
 gperftools = { version = "0.2.0", features = ["heap"], optional = true }
-hyper = { version = "1.0.0-rc.3", features = ["full"] }
+hyper = { version = "1.0.0-rc.4", features = ["full"] }
 # Pending https://github.com/hyperium/hyper-util/pull/25, https://github.com/hyperium/hyper-util/pull/24
-hyper-util = { git = "https://github.com/howardjohn/hyper-util", branch = "h2-timer-expose-exec", features = ["full"] }
+hyper-util = { git = "https://github.com/howardjohn/hyper-util", branch = "h2-timer-expose-exec-rc4", features = ["full"] }
 libc = "0.2.126"
 log = "0.4"
 once_cell = "1.16.0"
@@ -75,7 +75,7 @@ priority-queue = "1.3.0"
 http-body-util = "0.1.0-rc.2"
 http-body-04 = { package = "http-body", version = "0.4" }
 http-body-1 = { package = "http-body", version = "1.0.0-rc.2" }
-tower-hyper-http-body-compat = { version = "0", features = ["server", "http2"] }
+tower-hyper-http-body-compat = { version = "0.2" , features = ["server", "http2"] }
 futures-util = "0.3.26"
 chrono = "0.4.23"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -155,11 +155,11 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -170,6 +170,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -179,24 +180,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "boring"
-version = "2.1.0"
-source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#5185311af8addc6851a48bd5747ec634dbb72811"
+version = "3.0.4"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0-rc4#d5d8a21d88e254ad7c19f59301b97155d88e13c3"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "boring-sys",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
 name = "boring-sys"
-version = "2.1.0"
-source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#5185311af8addc6851a48bd5747ec634dbb72811"
+version = "3.0.4"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0-rc4#d5d8a21d88e254ad7c19f59301b97155d88e13c3"
 dependencies = [
  "bindgen",
  "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -309,7 +318,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
  "textwrap",
@@ -584,6 +593,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -913,13 +938,12 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75264b2003a3913f118d35c586e535293b3e22e41f074930762929d071e092"
+checksum = "d280a71f348bcc670fc55b02b63c53a04ac0bf2daff2980795aeaf53edae10e6"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
  "http",
@@ -935,13 +959,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-boring"
-version = "3.0.0"
-source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#5185311af8addc6851a48bd5747ec634dbb72811"
+version = "3.0.4"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0-rc4#d5d8a21d88e254ad7c19f59301b97155d88e13c3"
 dependencies = [
  "antidote",
  "boring",
  "http",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "hyper-util",
  "linked_hash_set",
  "once_cell",
@@ -954,15 +978,15 @@ dependencies = [
 [[package]]
 name = "hyper-util"
 version = "0.0.0"
-source = "git+https://github.com/howardjohn/hyper-util?branch=h2-timer-expose-exec#b9eaeca869e1cf9dcf65426c748751ef0c0ef5e0"
+source = "git+https://github.com/howardjohn/hyper-util?branch=h2-timer-expose-exec-rc4#5ac239604435859c48969a2b1cb23a207197ad08"
 dependencies = [
  "futures-channel",
  "futures-util",
  "http",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "once_cell",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio",
  "tower",
  "tower-service",
@@ -1299,7 +1323,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if",
  "libc",
@@ -1312,7 +1336,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -1807,7 +1831,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1879,7 +1903,7 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2242,8 +2266,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-boring"
-version = "2.1.5"
-source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0#5185311af8addc6851a48bd5747ec634dbb72811"
+version = "3.0.4"
+source = "git+https://github.com/howardjohn/boring/?branch=hyper-boring/adopt-hyper-1.0.0-rc4#d5d8a21d88e254ad7c19f59301b97155d88e13c3"
 dependencies = [
  "boring",
  "boring-sys",
@@ -2356,14 +2380,14 @@ dependencies = [
 
 [[package]]
 name = "tower-hyper-http-body-compat"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2373750972dd4efeef7ac0971cebd6597c6f3f98202bb5217763dcca99617d"
+checksum = "a7ea3e622710ee44a8255baa6fcb2a34d67450e2ffb48e5e58d5a7bd6ff55a21"
 dependencies = [
  "http",
  "http-body 0.4.5",
  "http-body 1.0.0-rc.2",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "pin-project-lite",
  "tower",
  "tower-service",
@@ -2851,7 +2875,7 @@ dependencies = [
  "http-body 1.0.0-rc.2",
  "http-body-util",
  "http-types",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "hyper-boring",
  "hyper-util",
  "ipnet",

--- a/src/hyper_util.rs
+++ b/src/hyper_util.rs
@@ -142,7 +142,7 @@ pub fn http1_server() -> http1::Builder {
     b
 }
 
-pub fn http2_client() -> client::conn::http2::Builder {
+pub fn http2_client() -> client::conn::http2::Builder<TokioExecutor> {
     let mut b = client::conn::http2::Builder::new(TokioExecutor);
     b.timer(TokioTimer);
     b
@@ -231,7 +231,7 @@ impl<S> Server<S> {
                         .header_read_timeout(Duration::from_secs(2))
                         .max_buf_size(8 * 1024)
                         .serve_connection(
-                            socket,
+                            hyper_util::rt::TokioIo::new(socket),
                             hyper::service::service_fn(move |req| {
                                 let state = state.clone();
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -207,7 +207,7 @@ pub async fn copy_hbone(
     transferred_bytes: BytesTransferred<'_>,
 ) -> Result<(), Error> {
     use tokio::io::AsyncWriteExt;
-    let (mut ri, mut wi) = tokio::io::split(upgraded);
+    let (mut ri, mut wi) = tokio::io::split(hyper_util::rt::TokioIo::new(upgraded));
     let (mut ro, mut wo) = stream.split();
 
     let (mut sent, mut received): (u64, u64) = (0, 0);

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -115,7 +115,7 @@ impl Inbound {
                     .initial_connection_window_size(self.cfg.connection_window_size)
                     .max_frame_size(self.cfg.frame_size)
                     .serve_connection(
-                        socket,
+                        hyper_util::rt::TokioIo::new(socket),
                         service_fn(move |req| {
                             Self::serve_connect(
                                 state.clone(),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -275,7 +275,7 @@ impl OutboundConnection {
                     tcp_stream.set_nodelay(true)?; // TODO: this is backwards of expectations
                     let tls_stream = connect_tls(connector, tcp_stream).await?;
                     let (request_sender, connection) = builder
-                        .handshake(tls_stream)
+                        .handshake(::hyper_util::rt::TokioIo::new(tls_stream))
                         .await
                         .map_err(Error::HttpHandshake)?;
                     // spawn a task to poll the connection and drive the HTTP state

--- a/src/test_helpers/ca.rs
+++ b/src/test_helpers/ca.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::StreamExt;
+use hyper_util::rt::TokioIo;
 
 use tokio::sync::watch;
 
@@ -64,7 +65,7 @@ impl CaServer {
                 let srv = srv.clone();
                 if let Err(err) = crate::hyper_util::http2_server()
                     .serve_connection(
-                        socket,
+                        TokioIo::new(socket),
                         tower_hyper_http_body_compat::TowerService03HttpServiceAsHyper1HttpService::new(srv)
                     )
                     .await

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -23,6 +23,7 @@ use std::{cmp, io};
 use hyper::server::conn::http2;
 use hyper::service::service_fn;
 use hyper::Response;
+use hyper_util::rt::TokioIo;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::Instant;
@@ -203,14 +204,14 @@ impl HboneTestServer {
         while let Some(socket) = tls_stream.next().await {
             if let Err(err) = http2::Builder::new(TokioExecutor)
                 .serve_connection(
-                    socket,
+                    TokioIo::new(socket),
                     service_fn(move |req| async move {
                         info!("waypoint: received request");
                         let mode = mode;
                         tokio::task::spawn(async move {
                             match hyper::upgrade::on(req).await {
                                 Ok(upgraded) => {
-                                    let (mut ri, mut wi) = tokio::io::split(upgraded);
+                                    let (mut ri, mut wi) = tokio::io::split(TokioIo::new(upgraded));
                                     // Signal we are the waypoint so tests can validate this
                                     wi.write_all(b"waypoint\n").await.unwrap();
                                     handle_stream(mode, &mut ri, &mut wi).await;

--- a/src/test_helpers/xds.rs
+++ b/src/test_helpers/xds.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use futures::Stream;
 use futures::StreamExt;
 use hyper::server::conn::http2;
+use hyper_util::rt::TokioIo;
 use prometheus_client::registry::Registry;
 use tokio::sync::{mpsc, watch};
 use tokio_stream::wrappers::ReceiverStream;
@@ -74,7 +75,7 @@ impl AdsServer {
                 let srv = srv.clone();
                 if let Err(err) = http2::Builder::new(TokioExecutor)
                     .serve_connection(
-                        socket,
+                        TokioIo::new(socket),
                         tower_hyper_http_body_compat::TowerService03HttpServiceAsHyper1HttpService::new(srv)
                     )
                     .await

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -23,6 +23,7 @@ mod namespaced {
     use std::time::Duration;
 
     use hyper::Method;
+    use hyper_util::rt::TokioIo;
     use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadBuf};
     use tokio::net::TcpStream;
     use tokio::time::timeout;
@@ -479,7 +480,8 @@ mod namespaced {
                 let tls_stream = tokio_boring::connect(connector, "", tcp_stream)
                     .await
                     .unwrap();
-                let (mut request_sender, connection) = builder.handshake(tls_stream).await.unwrap();
+                let (mut request_sender, connection) =
+                    builder.handshake(TokioIo::new(tls_stream)).await.unwrap();
                 // spawn a task to poll the connection and drive the HTTP state
                 tokio::spawn(async move {
                     if let Err(e) = connection.await {
@@ -538,7 +540,8 @@ mod namespaced {
                 let tls_stream = tokio_boring::connect(connector, "", tcp_stream)
                     .await
                     .unwrap();
-                let (mut request_sender, connection) = builder.handshake(tls_stream).await.unwrap();
+                let (mut request_sender, connection) =
+                    builder.handshake(TokioIo::new(tls_stream)).await.unwrap();
                 // spawn a task to poll the connection and drive the HTTP state
                 tokio::spawn(async move {
                     if let Err(e) = connection.await {


### PR DESCRIPTION
This is 1 step closer to 1.0.0....

The main change is they made their own Read/Write types, so we need to
wrap a bunch of things in `TokioIo`. NBD.
