### PR TITLE
add connection denied metrics for RBAC decisions in zTunnel

### DIFF
--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -757,7 +757,7 @@ mod namespaced {
         assert_eq!([WAYPOINT_MESSAGE, BODY].concat(), buf);
     }
 
-    async fn fail_write_stream(stream: &mut TcpStream) -> () {
+    async fn fail_write_stream(stream: &mut TcpStream) {
         const BODY: &[u8] = b"hello world";
         stream.write_all(BODY).await.unwrap();
         let mut buf = [0; BODY.len() * 2];


### PR DESCRIPTION
Add `istio_tcp_connection_denied_total` metrics for `rbac` decisions made by the `zTunnel`.

This PR adds metrics using the current `CommonTrafficLabels` when `rbac` decisions are made.
Also it adds tests to `namespaced.rs` to exercise the RBAC as well as the metrics.