### PR TITLE
remove use of new_socket_addr() in dns server tests

### DIFF
--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -716,7 +716,7 @@ mod tests {
     use crate::metrics;
     use crate::test_helpers::dns::{
         a, aaaa, cname, ip, ipv4, ipv6, n, new_message, new_tcp_client, new_udp_client,
-        send_request, server_request, socket_addr,
+        send_request, server_request,
     };
     use crate::test_helpers::helpers::subscribe;
     use crate::test_helpers::{new_proxy_state, test_default_workload};
@@ -1104,12 +1104,20 @@ mod tests {
 
         // Create and start the proxy.
         let domain = "cluster.local".to_string();
-        let addr = new_socket_addr().await;
         let state = state();
         let forwarder = forwarder();
-        let proxy = Server::new(domain, addr, NW1, state, forwarder, test_metrics())
-            .await
-            .unwrap();
+        let proxy = Server::new(
+            domain,
+            SocketAddr::from_str("127.0.0.1:0")
+                .expect("parsing hardcoded address should never fail"),
+            NW1,
+            state,
+            forwarder,
+            test_metrics(),
+        )
+        .await
+        .unwrap();
+        let addr = proxy.address();
         tokio::spawn(proxy.run());
 
         let mut tcp_client = new_tcp_client(addr).await;
@@ -1193,12 +1201,20 @@ mod tests {
 
         // Create and start the server.
         let domain = "cluster.local".to_string();
-        let addr = new_socket_addr().await;
         let state = state();
         let forwarder = Arc::new(SystemForwarder::new().unwrap());
-        let server = Server::new(domain, addr, NW1, state, forwarder, test_metrics())
-            .await
-            .unwrap();
+        let server = Server::new(
+            domain,
+            SocketAddr::from_str("127.0.0.1:0")
+                .expect("parsing hardcoded address should never fail"),
+            NW1,
+            state,
+            forwarder,
+            test_metrics(),
+        )
+        .await
+        .unwrap();
+        let addr = server.address();
         tokio::spawn(server.run());
 
         let mut tcp_client = new_tcp_client(addr).await;
@@ -1322,11 +1338,6 @@ mod tests {
             ],
             ips: HashMap::from([(n("www.bing.com."), vec![ip("1.1.1.1")])]),
         })
-    }
-
-    async fn new_socket_addr() -> SocketAddr {
-        let s = UdpSocket::bind(socket_addr("127.0.0.1:0")).await.unwrap();
-        s.local_addr().unwrap()
     }
 
     fn state() -> DemandProxyState {


### PR DESCRIPTION
Removes `new_socket_addr()` which creates a race condition that can cause test flakes.

`new_socket_addr()` binds to a free port, captures the resulting address and returns it but then drops the resulting socket. If the socket isn't cleaned up prior to `Server::new(...)` attempting to bind (or another concurrent test has bound to that port) it can cause a panic resulting in an error like:

```
thread 'test_tcp_request' panicked at 'called `Result::unwrap()` on an `Err` value: failed to bind to address 127.0.0.1:45366: Address already in use (os error 98)', /home/prow/go/src/istio.io/ztunnel/src/test_helpers/app.rs:73:10
```