### PR TITLE
Fix typos in doc/comment by https://github.com/crate-ci/typos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default = ["fips"]
 gperftools = ["dep:gperftools"]
 console = ["dep:console-subscriber"]
 fips = ["boring/fips", "hyper-boring/fips", "tokio-boring/fips"]
-testing = [] # Enables utilites supporting tests.
+testing = [] # Enables utilities supporting tests.
 
 [lib]
 path = "src/lib.rs"

--- a/proto/authorization.proto
+++ b/proto/authorization.proto
@@ -29,7 +29,7 @@ message Authorization {
   // The action to take if the request is matched with the rules.
   // Default is ALLOW if not specified.
   Action action = 4;
-  // Set of RBAC policy rules each containing its cluases (To, From, When).
+  // Set of RBAC policy rules each containing its clauses (To, From, When).
   // If at least one of the rules is matched the policy action will
   // take place.
   // Rules are OR-ed.

--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -69,7 +69,7 @@ message Service {
   // The target_port may be overridden on a per-workload basis.
   repeated Port ports = 5;
   // Optional; if set, the SAN to verify for TLS connections.
-  // Typically, this is not set and per-workload identity is used to verfiy
+  // Typically, this is not set and per-workload identity is used to verify
   repeated string subject_alt_names = 6;
 }
 

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -92,7 +92,7 @@ impl Socks5 {
     }
 }
 
-// hande will process a SOCKS5 connection. This supports a minimal subset of the protocol,
+// handle will process a SOCKS5 connection. This supports a minimal subset of the protocol,
 // sufficient to integrate with common clients:
 // - only unauthenticated requests
 // - only CONNECT, with IPv4 or IPv6

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -274,7 +274,7 @@ impl ParsedMetrics {
                 .map(|sample| {
                     match sample.value {
                         prometheus_parse::Value::Counter(f) => f,
-                        // TOOD(https://github.com/ccakes/prometheus-parse-rs/issues/5) remove this
+                        // TODO(https://github.com/ccakes/prometheus-parse-rs/issues/5) remove this
                         prometheus_parse::Value::Untyped(f) => f,
                         _ => panic!("query_sum({metric}) must be a counter"),
                     }

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -263,7 +263,7 @@ impl Config {
 ///
 /// The client works by accepting arbitrary handlers for types, configured by user.
 /// These handlers can do whatever they want with incoming responses, but are responsible for maintaining their own state.
-/// For example, if a usage wants to keep track of all Foo resources recieved, it needs to handle the add/removes in the configured handler.
+/// For example, if a usage wants to keep track of all Foo resources received, it needs to handle the add/removes in the configured handler.
 ///
 /// The client also supports on-demand lookup of resources; see demander() for more information.
 ///

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -768,7 +768,7 @@ mod namespaced {
                 let mut buf = ReadBuf::new(&mut buf);
 
                 let result = poll_fn(|cx| tcp_stream.poll_peek(cx, &mut buf)).await;
-                assert!(result.is_err()); // exepct a connection reset due to TLS SAN mismatch
+                assert!(result.is_err()); // expect a connection reset due to TLS SAN mismatch
                 assert_eq!(
                     result.err().unwrap().kind(),
                     std::io::ErrorKind::ConnectionReset


### PR DESCRIPTION
I fixed typos in comments and documentation, with the help of https://github.com/crate-ci/typos.