### PR TITLE
xds: fix removals

### DIFF
--- a/src/xds.rs
+++ b/src/xds.rs
@@ -132,7 +132,6 @@ impl ProxyStateUpdater {
     }
 
     pub fn remove(&self, xds_name: &String) {
-        debug!("handling delete {}", xds_name);
         let mut state = self.state.write().unwrap();
 
         // remove workload by UID; if xds_name is a service then this will no-op
@@ -230,7 +229,10 @@ impl Handler<XdsWorkload> for ProxyStateUpdater {
         let handle = |res: XdsUpdate<XdsWorkload>| {
             match res {
                 XdsUpdate::Update(w) => self.insert_workload(w.resource)?,
-                XdsUpdate::Remove(name) => self.remove(&name),
+                XdsUpdate::Remove(name) => {
+                    debug!("handling delete {}", name);
+                    self.remove(&name)
+                }
             }
             Ok(())
         };
@@ -243,7 +245,10 @@ impl Handler<XdsAddress> for ProxyStateUpdater {
         let handle = |res: XdsUpdate<XdsAddress>| {
             match res {
                 XdsUpdate::Update(w) => self.insert_address(w.resource)?,
-                XdsUpdate::Remove(name) => self.remove(&name),
+                XdsUpdate::Remove(name) => {
+                    debug!("handling delete {}", name);
+                    self.remove(&name)
+                }
             }
             Ok(())
         };

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -195,7 +195,9 @@ impl State {
                     type_url: resp.type_url.clone(),
                 };
                 debug!("received delete resource {k}");
-                self.known_resources.remove(res);
+                if let Some(rm) = self.known_resources.get_mut(&resp.type_url) {
+                    rm.remove(&k.name);
+                }
                 self.notify_on_demand(&k);
                 k.name
             })
@@ -615,6 +617,7 @@ impl AdsClient {
         info!(
             type_url = type_url, // this is a borrow, it's OK
             size = response.resources.len(),
+            removes = response.removed_resources.len(),
             "received response"
         );
         let handler_response: Result<(), Vec<RejectedConfig>> =


### PR DESCRIPTION
We were using the wrong key for the map, so removals never happened.
This is something that can be easily tested, but we need a bit of
scaffolding I don't have bandwidth to cover right now. I will open an
issue and try to get it covered.

Also, our update logic is delete+add, and we log that -- this gives
super confusing logs. Make it so we only log 'delete' on real removals.
