### PR TITLE
Make proxy cache updates consistent

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -35,7 +35,7 @@ use std::convert::Into;
 use std::default::Default;
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 use tracing::{debug, trace, warn};
 
 use trust_dns_resolver::config::*;
@@ -199,17 +199,17 @@ impl ProxyState {
 #[derive(serde::Serialize, Debug, Clone)]
 pub struct DemandProxyState {
     #[serde(flatten)]
-    pub state: Arc<RwLock<ProxyState>>,
+    state: Arc<RwLock<ProxyState>>,
 
     /// If present, used to request on-demand updates for workloads.
     #[serde(skip_serializing)]
     demand: Option<Demander>,
 
     #[serde(skip_serializing)]
-    pub dns_resolver_cfg: ResolverConfig,
+    dns_resolver_cfg: ResolverConfig,
 
     #[serde(skip_serializing)]
-    pub dns_resolver_opts: ResolverOpts,
+    dns_resolver_opts: ResolverOpts,
 }
 
 impl DemandProxyState {
@@ -229,10 +229,6 @@ impl DemandProxyState {
 
     pub fn read(&self) -> RwLockReadGuard<'_, ProxyState> {
         self.state.read().unwrap()
-    }
-
-    pub fn write(&self) -> RwLockWriteGuard<'_, ProxyState> {
-        self.state.write().unwrap()
     }
 
     pub async fn assert_rbac(&self, conn: &rbac::Connection) -> bool {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -22,9 +22,11 @@ use crate::state::workload::{
 };
 use crate::state::{DemandProxyState, ProxyState};
 use crate::xds::istio::security::Authorization as XdsAuthorization;
+use crate::xds::istio::workload::address;
+use crate::xds::istio::workload::Address as XdsAddress;
 use crate::xds::istio::workload::Service as XdsService;
 use crate::xds::istio::workload::Workload as XdsWorkload;
-use crate::xds::{LocalConfig, LocalWorkload, ProxyStateUpdater};
+use crate::xds::{Handler, LocalConfig, LocalWorkload, ProxyStateUpdater, XdsResource, XdsUpdate};
 use bytes::{BufMut, Bytes};
 use http_body_util::{BodyExt, Full};
 use hyper::Response;
@@ -403,13 +405,32 @@ pub fn new_proxy_state(
     let updater = ProxyStateUpdater::new_no_fetch(state.clone());
 
     for w in xds_workloads {
-        updater.insert_workload(w.clone()).unwrap();
+        let res = XdsResource {
+            name: w.name.clone(),
+            resource: XdsAddress {
+                r#type: Some(address::Type::Workload(w.clone())),
+            },
+        };
+        let handler = &updater as &dyn Handler<XdsAddress>;
+        handler.handle(vec![XdsUpdate::Update(res)]).unwrap();
     }
     for s in xds_services {
-        updater.insert_service(s.clone()).unwrap();
+        let res = XdsResource {
+            name: s.name.clone(),
+            resource: XdsAddress {
+                r#type: Some(address::Type::Service(s.clone())),
+            },
+        };
+        let handler = &updater as &dyn Handler<XdsAddress>;
+        handler.handle(vec![XdsUpdate::Update(res)]).unwrap();
     }
     for a in xds_authorizations {
-        updater.insert_authorization(a.clone()).unwrap();
+        let res = XdsResource {
+            name: a.name.clone(),
+            resource: a.clone(),
+        };
+        let handler = &updater as &dyn Handler<XdsAuthorization>;
+        handler.handle(vec![XdsUpdate::Update(res)]).unwrap();
     }
     DemandProxyState::new(
         state,

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -198,10 +198,8 @@ impl ProxyStateUpdateMutator {
             );
             return;
         }
-        if state.services.remove(&name).is_none() {
-            if expected {
-                warn!("tried to remove service keyed by {name}, but it was not found");
-            }
+        if state.services.remove(&name).is_none() && expected {
+            warn!("tried to remove service keyed by {name}, but it was not found");
         }
     }
 

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -81,10 +81,17 @@ pub enum Error {
 }
 
 /// Updates the [ProxyState] from XDS.
+/// All state updates code goes in ProxyStateUpdateMutator, that takes state as a parameter.
+/// this guarantees that the state is always locked when it is updated.
+#[derive(Clone)]
+pub struct ProxyStateUpdateMutator {
+    cert_fetcher: Arc<dyn CertFetcher>,
+}
+
 #[derive(Clone)]
 pub struct ProxyStateUpdater {
     state: Arc<RwLock<ProxyState>>,
-    cert_fetcher: Arc<dyn CertFetcher>,
+    updater: ProxyStateUpdateMutator,
 }
 
 impl ProxyStateUpdater {
@@ -92,23 +99,34 @@ impl ProxyStateUpdater {
     pub fn new(state: Arc<RwLock<ProxyState>>, cert_fetcher: Arc<dyn CertFetcher>) -> Self {
         Self {
             state,
-            cert_fetcher,
+            updater: ProxyStateUpdateMutator { cert_fetcher },
+        }
+    }
+    /// Creates a new updater that does not prefetch workload certs.
+    pub fn new_no_fetch(state: Arc<RwLock<ProxyState>>) -> Self {
+        Self {
+            state,
+            updater: ProxyStateUpdateMutator::new_no_fetch(),
+        }
+    }
+}
+
+impl ProxyStateUpdateMutator {
+    /// Creates a new updater that does not prefetch workload certs.
+    pub fn new_no_fetch() -> Self {
+        ProxyStateUpdateMutator {
+            cert_fetcher: Arc::new(NoCertFetcher()),
         }
     }
 
-    /// Creates a new updater that does not prefetch workload certs.
-    pub fn new_no_fetch(state: Arc<RwLock<ProxyState>>) -> Self {
-        Self::new(state, Arc::new(NoCertFetcher()))
-    }
-
-    pub fn insert_workload(&self, w: XdsWorkload) -> anyhow::Result<()> {
+    pub fn insert_workload(&self, state: &mut ProxyState, w: XdsWorkload) -> anyhow::Result<()> {
         debug!("handling insert {}", w.uid);
 
         // Convert the workload.
         let workload = Workload::try_from(&w)?;
 
         // First, remove the entry entirely to make sure things are cleaned up properly.
-        self.remove(&w.uid);
+        self.maybe_remove(state, &w.uid);
 
         // Unhealthy workloads are always inserted, as we may get or receive traffic to them.
         // But we shouldn't include them in load balancing we do to Services.
@@ -122,7 +140,6 @@ impl ProxyStateUpdater {
         self.cert_fetcher.prefetch_cert(&workload);
 
         // Lock and upstate the stores.
-        let mut state = self.state.write().unwrap();
         state.workloads.insert(workload)?;
         while let Some(endpoint) = endpoints.pop() {
             state.services.insert_endpoint(endpoint);
@@ -131,9 +148,14 @@ impl ProxyStateUpdater {
         Ok(())
     }
 
-    pub fn remove(&self, xds_name: &String) {
-        let mut state = self.state.write().unwrap();
+    pub fn remove(&self, state: &mut ProxyState, xds_name: &String) {
+        self.remove_internal(state, xds_name, true);
+    }
 
+    fn maybe_remove(&self, state: &mut ProxyState, xds_name: &String) {
+        self.remove_internal(state, xds_name, false);
+    }
+    fn remove_internal(&self, state: &mut ProxyState, xds_name: &String, expected: bool) {
         // remove workload by UID; if xds_name is a service then this will no-op
         if let Some(prev) = state.workloads.remove(xds_name) {
             // Also remove service endpoints for the workload.
@@ -155,10 +177,12 @@ impl ProxyStateUpdater {
 
         let Ok(name) = NamespacedHostname::from_str(xds_name) else {
             // we don't have namespace/hostname xds primary key for service
-            warn!(
-                "tried to remove service keyed by {} but it did not have the expected namespace/hostname format",
-                xds_name
-            );
+            if expected {
+                warn!(
+                    "tried to remove service keyed by {} but it did not have the expected namespace/hostname format",
+                    xds_name
+                );
+            }
             return;
         };
 
@@ -175,23 +199,26 @@ impl ProxyStateUpdater {
             return;
         }
         if state.services.remove(&name).is_none() {
-            warn!("tried to remove service keyed by {name}, but it was not found");
+            if expected {
+                warn!("tried to remove service keyed by {name}, but it was not found");
+            }
         }
     }
 
-    pub fn insert_address(&self, a: XdsAddress) -> anyhow::Result<()> {
+    pub fn insert_address(&self, state: &mut ProxyState, a: XdsAddress) -> anyhow::Result<()> {
         match a.r#type {
-            Some(XdsType::Workload(w)) => self.insert_workload(w),
-            Some(XdsType::Service(s)) => self.insert_service(s),
+            Some(XdsType::Workload(w)) => self.insert_workload(state, w),
+            Some(XdsType::Service(s)) => self.insert_service(state, s),
             _ => Err(anyhow::anyhow!("unknown address type")),
         }
     }
 
-    pub fn insert_service(&self, service: XdsService) -> anyhow::Result<()> {
+    pub fn insert_service(
+        &self,
+        state: &mut ProxyState,
+        service: XdsService,
+    ) -> anyhow::Result<()> {
         let mut service = Service::try_from(&service)?;
-
-        // Lock the store.
-        let mut state = self.state.write().unwrap();
 
         // If the service already exists, add existing endpoints into the new service.
         if let Some(prev) = state
@@ -207,31 +234,34 @@ impl ProxyStateUpdater {
         Ok(())
     }
 
-    pub fn insert_authorization(&self, r: XdsAuthorization) -> anyhow::Result<()> {
+    pub fn insert_authorization(
+        &self,
+        state: &mut ProxyState,
+        r: XdsAuthorization,
+    ) -> anyhow::Result<()> {
         info!("handling RBAC update {}", r.name);
 
         let rbac = rbac::Authorization::try_from(&r)?;
         trace!("insert policy {}", serde_json::to_string(&rbac)?);
-        let mut state = self.state.write().unwrap();
         state.policies.insert(rbac);
         Ok(())
     }
 
-    pub fn remove_authorization(&self, name: String) {
+    pub fn remove_authorization(&self, state: &mut ProxyState, name: String) {
         info!("handling RBAC delete {}", name);
-        let mut state = self.state.write().unwrap();
         state.policies.remove(name);
     }
 }
 
 impl Handler<XdsWorkload> for ProxyStateUpdater {
     fn handle(&self, updates: Vec<XdsUpdate<XdsWorkload>>) -> Result<(), Vec<RejectedConfig>> {
+        let mut state = self.state.write().unwrap();
         let handle = |res: XdsUpdate<XdsWorkload>| {
             match res {
-                XdsUpdate::Update(w) => self.insert_workload(w.resource)?,
+                XdsUpdate::Update(w) => self.updater.insert_workload(&mut state, w.resource)?,
                 XdsUpdate::Remove(name) => {
                     debug!("handling delete {}", name);
-                    self.remove(&name)
+                    self.updater.remove(&mut state, &name)
                 }
             }
             Ok(())
@@ -242,12 +272,13 @@ impl Handler<XdsWorkload> for ProxyStateUpdater {
 
 impl Handler<XdsAddress> for ProxyStateUpdater {
     fn handle(&self, updates: Vec<XdsUpdate<XdsAddress>>) -> Result<(), Vec<RejectedConfig>> {
+        let mut state = self.state.write().unwrap();
         let handle = |res: XdsUpdate<XdsAddress>| {
             match res {
-                XdsUpdate::Update(w) => self.insert_address(w.resource)?,
+                XdsUpdate::Update(w) => self.updater.insert_address(&mut state, w.resource)?,
                 XdsUpdate::Remove(name) => {
                     debug!("handling delete {}", name);
-                    self.remove(&name)
+                    self.updater.remove(&mut state, &name)
                 }
             }
             Ok(())
@@ -302,10 +333,13 @@ impl Handler<XdsAuthorization> for ProxyStateUpdater {
     }
 
     fn handle(&self, updates: Vec<XdsUpdate<XdsAuthorization>>) -> Result<(), Vec<RejectedConfig>> {
+        let mut state = self.state.write().unwrap();
         let handle = |res: XdsUpdate<XdsAuthorization>| {
             match res {
-                XdsUpdate::Update(w) => self.insert_authorization(w.resource)?,
-                XdsUpdate::Remove(name) => self.remove_authorization(name),
+                XdsUpdate::Update(w) => {
+                    self.updater.insert_authorization(&mut state, w.resource)?
+                }
+                XdsUpdate::Remove(name) => self.updater.remove_authorization(&mut state, name),
             }
             Ok(())
         };

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -58,6 +58,7 @@ impl Display for ResourceKey {
     }
 }
 
+#[derive(Debug)]
 pub struct RejectedConfig {
     name: String,
     reason: anyhow::Error,


### PR DESCRIPTION
Make proxy cache updates consistent by taking the lock on the entire update operation.
so that things like 

```
{
state.remove()
state.insert()
}
```

are not racy.
