### PR TITLE
Fix lint error

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -356,10 +356,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
 
         num_worker_threads: parse_default(
             ZTUNNEL_WORKER_THREADS,
-            pc.concurrency
-                .unwrap_or(DEFAULT_WORKER_THREADS)
-                .try_into()
-                .expect("concurrency cannot be negative"),
+            pc.concurrency.unwrap_or(DEFAULT_WORKER_THREADS).into(),
         )?,
 
         enable_original_source: parse(ENABLE_ORIG_SRC)?,


### PR DESCRIPTION
I'm hitting this new cargo 1.75.0 lint error when running the lint in a dev container locally:
https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_fallible_conversions

Not sure why CI wasn't complaining about this.