### PR TITLE
Add retry backoff to cert refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.10",
+ "instant",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3239,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "atty",
+ "backoff",
  "boring",
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ futures-util = "0.3.26"
 chrono = "0.4.23"
 nix = "0.26.2"
 hashbrown = "0.14.0"
+backoff = "0.4.0"
 
 # DNS
 hickory-client = "0.24.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -151,6 +151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.10",
+ "instant",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +2956,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "atty",
+ "backoff",
  "boring",
  "byteorder",
  "bytes",

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -218,6 +218,24 @@ pub mod mock {
             state.fetches.push(id.to_owned());
             Ok(certs)
         }
+
+        pub async fn set_error(&mut self, error: bool) {
+            if error {
+                let mut state = self.state.write().await;
+                state.fetches.push(Identity::Spiffe {
+                    trust_domain: "error".to_string(),
+                    namespace: "error".to_string(),
+                    service_account: "error".to_string(),
+                });
+            } else {
+                let mut state = self.state.write().await;
+                state.fetches.push(Identity::Spiffe {
+                    trust_domain: "success".to_string(),
+                    namespace: "success".to_string(),
+                    service_account: "success".to_string(),
+                });
+            }
+        }
     }
 
     #[async_trait]

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -242,9 +242,10 @@ impl Worker {
             current_interval: Duration::from_secs(1),
             max_interval: Duration::from_secs(60),
             // cert_backoff.max_elapsed_time is the maximum elapsed time after instantiating
-            // [`ExponentialBackoff`](struct.ExponentialBackoff.html) or calling
-            // [`reset`](trait.Backoff.html#method.reset) after which [`next_backoff`](../trait.Backoff.html#method.reset)
-            // returns `None`. More info can be found here: https://docs.rs/backoff/0.4.0/backoff.
+            // [`ExponentialBackoff`](https://docs.rs/backoff/0.4.0/backoff/type.ExponentialBackoff.html)
+            // or calling [`reset`](https://docs.rs/backoff/0.4.0/backoff/backoff/trait.Backoff.html#method.reset)
+            // after which [`next_backoff`](https://docs.rs/backoff/0.4.0/backoff/backoff/trait.Backoff.html#method.next_backoff)
+            // returns `None`.
             //
             // We set it to 5 minutes (300 seconds) to ensure that we don't retry indefinitely.
             max_elapsed_time: Some(Duration::from_secs(300)),
@@ -331,9 +332,9 @@ impl Worker {
                             //     retry_interval * (random value in range [1 - randomization_factor, 1 + randomization_factor])
                             let refresh_at = Instant::now() + cert_backoff.next_backoff().unwrap_or(CERT_REFRESH_FAILURE_RETRY_DELAY_MAX_INTERVAL);
                             // cert_backoff.start_time is the system time. It is calculated when an
-                            // [`ExponentialBackoff`](struct.ExponentialBackoff.html) instance is created
-                            // and is reset when [`retry`](../trait.Operation.html#method.retry) is called.
-                            // More info can be found here: https://docs.rs/backoff/0.4.0/backoff.
+                            // [`ExponentialBackoff`](https://docs.rs/backoff/0.4.0/backoff/type.ExponentialBackoff.html)
+                            // instance is created and is reset when [`reset`](https://docs.rs/backoff/0.4.0/backoff/backoff/trait.Backoff.html#method.reset)
+                            // is called.
                             let start_time = cert_backoff.start_time;
                             let elapsed_duration = start_time.elapsed();
                             let time_difference = elapsed_duration;

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -317,7 +317,7 @@ impl Worker {
                             // None we'll use the max_interval to retry the fetch. The max_interval
                             // is set to 150 seconds, otherwise next_backoff will increment the backoff
                             // value based on the current_interval, the multiplier and the randomization_factor
-                            // defined earlier. In the case that we hit the max_interval, the 150 second wait 
+                            // defined earlier. In the case that we hit the max_interval, the 150 second wait
                             // time will continue for a cert until the backoff is reset by a successful fetch.
                             //
                             // The exact formula for how next backoff is calculated, per the backoff crate

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -339,10 +339,9 @@ impl Worker {
                             let time_difference = elapsed_duration;
                             // This is a check to ensure that the backoff has been reset before the max_elapsed_time
                             // is reached. If the backoff has not been reset by the time max_elapsed_time has been
-                            // reached then we should stop retrying.
+                            // reached (which would indicate a transient error) then we should stop retrying, because
+                            // the error is likely permanent.
                             if Some(time_difference) == cert_backoff.max_elapsed_time {
-                                // Hit the max_elapsed_time. If this was truly a transient error, the backoff would
-                                // have been reset by now. This indicates a permanent error, so we should stop retrying.
                                 log::error!("Failed to fetch certificate for {} after {} seconds", id, time_difference.as_secs());
                                 unreachable!("unable to process fetched certificate for identity: {} after {} seconds", id, time_difference.as_secs());
                             } else {

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -315,9 +315,10 @@ impl Worker {
                             // Use the next backoff to determine when to retry the fetch and default
                             // to the constant value if the backoff has been reset. In the case of
                             // None we'll use the max_interval to retry the fetch. The max_interval
-                            // is set to 60 seconds, otherwise next_backoff will increment the backoff
+                            // is set to 150 seconds, otherwise next_backoff will increment the backoff
                             // value based on the current_interval, the multiplier and the randomization_factor
-                            // defined earlier.
+                            // defined earlier. In the case that we hit the max_interval, the 150 second wait 
+                            // time will continue for a cert until the backoff is reset by a successful fetch.
                             //
                             // The exact formula for how next backoff is calculated, per the backoff crate
                             // documentation (https://docs.rs/backoff/0.4.0/backoff/#enums), is as follows:

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -33,7 +33,7 @@ use super::Error::{self, Spiffe};
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
 
-const CERT_REFRESH_FAILURE_RETRY_DELAY_MAX_INTERVAL: Duration = Duration::from_secs(60);
+const CERT_REFRESH_FAILURE_RETRY_DELAY_MAX_INTERVAL: Duration = Duration::from_secs(150);
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum Identity {
@@ -242,7 +242,7 @@ impl Worker {
             current_interval: Duration::from_secs(1),
             // The maximum interval is set to 150 seconds, which is the maximum time the backoff will
             // wait to retry a cert again.
-            max_interval: Duration::from_secs(150),
+            max_interval: CERT_REFRESH_FAILURE_RETRY_DELAY_MAX_INTERVAL,
             multiplier: 2.0,
             randomization_factor: 0.2,
             ..Default::default()


### PR DESCRIPTION
Add backoff retry logic as the mechanism for determining the refresh_at value for fetching certificates.

Related to issue #725.