### PR TITLE
close connections which violate policy after updates

### DIFF
--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -33,7 +33,7 @@ use super::Error::{self, Spiffe};
 
 const CERT_REFRESH_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(60);
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Ord)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum Identity {
     Spiffe {
         trust_domain: String,
@@ -42,12 +42,18 @@ pub enum Identity {
     },
 }
 
-impl PartialOrd for Identity {
+impl Ord for Identity {
     // Not sure this is a super legit compare but I think it should work for POC
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    fn cmp(&self, other: &Self) -> Ordering {
         let s = format!("{self}");
         let o = format!("{other}");
-        s.partial_cmp(&o)
+        s.cmp(&o)
+    }
+}
+
+impl PartialOrd for Identity {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -42,6 +42,15 @@ pub enum Identity {
     },
 }
 
+impl PartialOrd for Identity {
+    // Not sure this is a super legit compare but I think it should work for POC
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let s = format!("{self}");
+        let o = format!("{other}");
+        s.partial_cmp(&o)
+    }
+}
+
 impl EncodeLabelValue for Identity {
     fn encode(&self, writer: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
         writer.write_str(&self.to_string())

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -33,7 +33,7 @@ use super::Error::{self, Spiffe};
 
 const CERT_REFRESH_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(60);
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Ord)]
 pub enum Identity {
     Spiffe {
         trust_domain: String,

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -33,28 +33,13 @@ use super::Error::{self, Spiffe};
 
 const CERT_REFRESH_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(60);
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum Identity {
     Spiffe {
         trust_domain: String,
         namespace: String,
         service_account: String,
     },
-}
-
-impl Ord for Identity {
-    // Not sure this is a super legit compare but I think it should work for POC
-    fn cmp(&self, other: &Self) -> Ordering {
-        let s = format!("{self}");
-        let o = format!("{other}");
-        s.cmp(&o)
-    }
-}
-
-impl PartialOrd for Identity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 impl EncodeLabelValue for Identity {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -41,6 +41,7 @@ use crate::state::workload::{network_addr, Workload};
 use crate::state::DemandProxyState;
 use crate::{config, identity, socket, tls};
 
+mod connection_manager;
 mod inbound;
 mod inbound_passthrough;
 #[allow(non_camel_case_types)]

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -84,14 +84,6 @@ impl ConnectionManager {
         // potentially large copy under read lock, could require optomization
         self.drains.read().await.keys().cloned().collect()
     }
-
-    #[allow(dead_code)]
-    pub async fn drain_all(self) {
-        let mut drains = self.drains.write_owned().await;
-        for (_conn, cd) in drains.drain() {
-            cd.drain().await;
-        }
-    }
 }
 
 pub async fn policy_watcher(
@@ -120,13 +112,20 @@ pub async fn policy_watcher(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use drain::Watch;
     use std::net::{Ipv4Addr, SocketAddrV4};
+    use std::sync::{Arc, RwLock};
     use std::time::Duration;
+    use tokio::sync::watch;
+    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+
+    use crate::rbac::Connection;
+    use crate::state::{DemandProxyState, ProxyState};
+    use crate::xds::istio::security::{Action, Authorization, Scope};
+    use crate::xds::ProxyStateUpdateMutator;
 
     use super::ConnectionManager;
-    use crate::rbac::Connection;
 
     #[tokio::test]
     async fn test_connection_manager() {
@@ -173,8 +172,8 @@ mod test {
         assert_eq!(connections, vec![conn1.clone(), conn2.clone()]);
 
         // spawn tasks to assert that we close in a timely manner for conn1
-        tokio::spawn(async_close_assert(close1));
-        tokio::spawn(async_close_assert(another_close1));
+        tokio::spawn(assert_close(close1));
+        tokio::spawn(assert_close(another_close1));
         // close conn1
         connection_manager.close(&conn1).await;
         // ensure drains contains exactly 1 item
@@ -183,7 +182,7 @@ mod test {
         assert_eq!(connection_manager.connections().await, vec!(conn2.clone()));
 
         // spawn a task to assert that we close in a timely manner for conn2
-        tokio::spawn(async_close_assert(close2));
+        tokio::spawn(assert_close(close2));
         // close conn2
         connection_manager.close(&conn2).await;
         // assert that drains is empty again
@@ -191,8 +190,72 @@ mod test {
         assert_eq!(connection_manager.connections().await.len(), 0);
     }
 
+    #[tokio::test]
+    async fn test_policy_watcher_closes() {
+        // preamble: setup an environment
+        let state = Arc::new(RwLock::new(ProxyState::default()));
+        let dstate = DemandProxyState::new(
+            state.clone(),
+            None,
+            ResolverConfig::default(),
+            ResolverOpts::default(),
+        );
+        let connection_manager = ConnectionManager::new();
+        let parent_proxy = "test";
+        let (stop_tx, stop_rx) = watch::channel(());
+        let state_mutator = ProxyStateUpdateMutator::new_no_fetch();
+
+        // clones to move into spawned task
+        let ds = dstate.clone();
+        let cm = connection_manager.clone();
+        // spawn a task which watches policy and asserts that the policy watcher stop correctly
+        tokio::spawn(async move {
+            let res = tokio::time::timeout(
+                Duration::from_secs(1),
+                super::policy_watcher(ds, stop_rx, cm, parent_proxy),
+            )
+            .await;
+            assert!(res.is_ok())
+        });
+
+        // create a test connection
+        let conn1 = Connection {
+            src_identity: None,
+            src_ip: std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+            dst_network: "".to_string(),
+            dst: std::net::SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 0, 2), 8080)),
+        };
+        // watch the connection
+        let close1 = connection_manager.clone().track(&conn1).await;
+
+        // generate policy which denies everything
+        let auth = Authorization {
+            name: "allow-nothing".to_string(),
+            action: Action::Deny as i32,
+            scope: Scope::Global as i32,
+            namespace: "default".to_string(),
+            rules: vec![],
+        };
+
+        // spawn an assertion that our connection close is received
+        tokio::spawn(assert_close(close1));
+
+        // update our state
+        let mut s = state
+            .write()
+            .expect("test fails if we're unable to get a write lock on state");
+        let res = state_mutator.insert_authorization(&mut s, auth);
+        // assert that the update was OK
+        assert!(res.is_ok());
+        // release lock
+        drop(s);
+
+        // send the signal which stops policy watcher
+        stop_tx.send_replace(());
+    }
+
     // small helper to assert that the Watches are working in a timely manner
-    async fn async_close_assert(c: Watch) {
+    async fn assert_close(c: Watch) {
         let result = tokio::time::timeout(Duration::from_secs(1), c.signaled()).await;
         assert!(result.is_ok())
     }

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -1,0 +1,87 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::proxy::error;
+use crate::rbac::Connection;
+use drain;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub struct ConnectionDrain {
+    tx: drain::Signal,
+    rx: drain::Watch,
+}
+
+impl ConnectionDrain {
+    fn new() -> Self {
+        let (tx, rx) = drain::channel();
+        ConnectionDrain { tx, rx }
+    }
+}
+
+#[derive(Clone)]
+pub struct ConnectionManager {
+    drains: Arc<RwLock<HashMap<Connection, ConnectionDrain>>>,
+}
+
+impl ConnectionManager {
+    pub fn new() -> Self {
+        ConnectionManager {
+            drains: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn track(self, c: &Connection) -> drain::Watch {
+        match self.drains.read().await.get(c) {
+            Some(cd) => cd.rx.clone(),
+            None => {
+                let cd = ConnectionDrain::new();
+                let rx = cd.rx.clone();
+                //TODO: this was racy, another insert may happen between dropping the read lock and attaining this write lock
+                // try_insert is the best solution once it's no longer a nightly-only experimental API
+                let mut drains = self.drains.write().await;
+                if let Some(w) = drains.get(c) {
+                    return w.rx.clone();
+                }
+                drains.insert(c.clone(), cd);
+                rx
+            }
+        }
+    }
+
+    pub async fn drain(&self, c: &Connection) {
+        match self.drains.clone().write().await.remove(c) {
+            Some(cd) => {
+                cd.tx.drain().await;
+            }
+            None => {
+                // this is bad, possibly drain called twice
+                error!("requested drain on a Connection which wasn't initialized");
+            }
+        }
+    }
+
+    pub async fn connections(&self) -> Vec<Connection> {
+        // potentially large copy under read lock, could require optomization
+        self.drains.read().await.keys().cloned().collect()
+    }
+
+    pub async fn drain_all(self) {
+        let mut drains = self.drains.write_owned().await;
+        for (_c, cd) in drains.drain() {
+            cd.tx.drain().await;
+        }
+    }
+}

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -140,10 +140,9 @@ mod test {
         // ensure drains contains exactly 2 items
         assert_eq!(connection_manager.drains.read().await.len(), 2);
         assert_eq!(connection_manager.connections().await.len(), 2);
-        assert_eq!(
-            connection_manager.connections().await,
-            vec!(conn1.clone(), conn2.clone())
-        );
+        let mut connections = connection_manager.connections().await;
+        connections.sort(); // ordering cannot be guaranteed without sorting
+        assert_eq!(connections, vec![conn1.clone(), conn2.clone()]);
 
         // spawn tasks to assert that we close in a timely manner for conn1
         tokio::spawn(async_close_assert(close1));

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -114,11 +114,11 @@ pub async fn policy_watcher(
 #[cfg(test)]
 mod tests {
     use drain::Watch;
+    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
     use std::net::{Ipv4Addr, SocketAddrV4};
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
     use tokio::sync::watch;
-    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 
     use crate::rbac::Connection;
     use crate::state::{DemandProxyState, ProxyState};

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -68,7 +68,7 @@ impl ConnectionManager {
         rx
     }
 
-    pub async fn drain(&self, c: &Connection) {
+    pub async fn close(&self, c: &Connection) {
         if let Some(cd) = self.drains.clone().write().await.remove(c) {
             cd.drain().await;
         } else {
@@ -82,6 +82,7 @@ impl ConnectionManager {
         self.drains.read().await.keys().cloned().collect()
     }
 
+    #[allow(dead_code)]
     pub async fn drain_all(self) {
         let mut drains = self.drains.write_owned().await;
         for (_conn, cd) in drains.drain() {

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -166,6 +166,6 @@ mod test {
     // small helper to assert that the Watches are working in a timely manner
     async fn async_close_assert(c: Watch) {
         let result = tokio::time::timeout(Duration::from_secs(1), c.signaled()).await;
-        assert!(matches!(result, Ok(_)));
+        assert!(result.is_ok());
     }
 }

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -82,7 +82,7 @@ impl ConnectionManager {
 
     // signal all connections listening to this channel to take action (typically terminate traffic)
     async fn close(&self, c: &Connection) {
-        if let Some(cd) = self.drains.clone().write().await.remove(c) {
+        if let Some(cd) = self.drains.write().await.remove(c) {
             cd.drain().await;
         } else {
             // this is bad, possibly drain called twice

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -253,7 +253,6 @@ impl Inbound {
                                         &metrics,
                                         transferred_bytes,
                                         ).instrument(trace_span!("hbone server")) => {r}
-                                    
                                         _c = close.signaled() => {
                                             error!(dur=?start.elapsed(), "internal server copy: connection close received");
                                             Ok(())
@@ -302,7 +301,7 @@ impl Inbound {
         req: Request<Incoming>,
         metrics: Arc<Metrics>,
         socket_factory: Arc<dyn SocketFactory + Send + Sync>,
-        connection_manager: ConnectionManager
+        connection_manager: ConnectionManager,
     ) -> Result<Response<Empty<Bytes>>, hyper::Error> {
         let close = connection_manager.track(&conn).await;
         match req.method() {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -195,7 +195,7 @@ impl Inbound {
                 trace!(dur=?start.elapsed(), "connected to: {addr}");
                 tokio::task::spawn(
                     (async move {
-                        let close = match connection_manager.clone().track(&conn).await {
+                        let close = match connection_manager.track(&conn).await {
                             Some(c) => c,
                             None => {
                                 // if track returns None it means the connection was closed due to policy change
@@ -345,12 +345,12 @@ impl Inbound {
                     debug!("request from gateway");
                 }
                 //register before assert_rbac to ensure the connection is tracked during it's entire valid span
-                connection_manager.clone().register(&conn).await;
+                connection_manager.register(&conn).await;
                 if from_waypoint {
                     debug!("request from waypoint, skipping policy");
                 } else if !state.assert_rbac(&conn).await {
                     info!(%conn, "RBAC rejected");
-                    connection_manager.clone().release(&conn).await;
+                    connection_manager.release(&conn).await;
                     return Ok(Response::builder()
                         .status(StatusCode::UNAUTHORIZED)
                         .body(Empty::new())
@@ -358,7 +358,7 @@ impl Inbound {
                 }
                 if has_waypoint && !from_waypoint {
                     info!(%conn, "bypassed waypoint");
-                    connection_manager.clone().release(&conn).await;
+                    connection_manager.release(&conn).await;
                     return Ok(Response::builder()
                         .status(StatusCode::UNAUTHORIZED)
                         .body(Empty::new())

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -82,7 +82,6 @@ impl InboundPassthrough {
             let socket = self.listener.accept().await;
             let pi = self.pi.clone();
 
-
             let connection_manager = self.connection_manager.clone();
             match socket {
                 Ok((stream, remote)) => {

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -161,7 +161,7 @@ impl InboundPassthrough {
             info!(%conn, "RBAC rejected");
             return Ok(());
         }
-        let drain = connection_manager.track(&conn).await;
+        let close = connection_manager.track(&conn).await;
         let source_ip = super::get_original_src_from_stream(&inbound);
         let orig_src = pi
             .cfg
@@ -208,7 +208,7 @@ impl InboundPassthrough {
         let transferred_bytes = metrics::BytesTransferred::from(&connection_metrics);
         tokio::select! {
             err =  proxy::relay(&mut outbound, &mut inbound, &pi.metrics, transferred_bytes) => {err?;}
-            _signaled = drain.signaled() => {}
+            _signaled = close.signaled() => {}
         }
         info!(%source, destination=%orig, component="inbound plaintext", "connection complete");
         Ok(())

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -197,7 +197,6 @@ impl OutboundConnection {
                 info!(%conn, "RBAC rejected");
                 return Err(Error::HttpStatus(StatusCode::UNAUTHORIZED));
             }
-            let close = self.connection_manager.clone().track(&conn).await;
             // same as above but inverted, this is the "inbound" metric
             let inbound_connection_metrics = metrics::ConnectionOpen {
                 reporter: Reporter::destination,
@@ -219,7 +218,8 @@ impl OutboundConnection {
                 connection_metrics,
                 Some(inbound_connection_metrics),
                 self.pi.socket_factory.as_ref(),
-                close,
+                self.connection_manager.clone(),
+                conn,
             )
             .await
             .map_err(Error::Io);

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -193,7 +193,9 @@ impl OutboundConnection {
                 dst_network: req.source.network.clone(), // since this is node local, it's the same network
                 dst: req.destination,
             };
+            self.connection_manager.clone().register(&conn).await;
             if !self.pi.state.assert_rbac(&conn).await {
+                self.connection_manager.clone().release(&conn).await;
                 info!(%conn, "RBAC rejected");
                 return Err(Error::HttpStatus(StatusCode::UNAUTHORIZED));
             }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -193,9 +193,9 @@ impl OutboundConnection {
                 dst_network: req.source.network.clone(), // since this is node local, it's the same network
                 dst: req.destination,
             };
-            self.connection_manager.clone().register(&conn).await;
+            self.connection_manager.register(&conn).await;
             if !self.pi.state.assert_rbac(&conn).await {
-                self.connection_manager.clone().release(&conn).await;
+                self.connection_manager.release(&conn).await;
                 info!(%conn, "RBAC rejected");
                 return Err(Error::HttpStatus(StatusCode::UNAUTHORIZED));
             }

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -39,7 +39,7 @@ pub struct Authorization {
     pub rules: Vec<Vec<Vec<RbacMatch>>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct Connection {
     pub src_identity: Option<Identity>,
     pub src_ip: IpAddr,

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -39,7 +39,7 @@ pub struct Authorization {
     pub rules: Vec<Vec<Vec<RbacMatch>>>,
 }
 
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Connection {
     pub src_identity: Option<Identity>,
     pub src_ip: IpAddr,


### PR DESCRIPTION
related #311 

Adds:
- tracking open connections for `inbound` and `inbound_passthrough`
- notifications to trackers when auth policy changes occur
- separate task handles change notifications, asserts policy against the existing connections and closes open connections which are now denied by policy