### PR TITLE
Update the dns crate and add graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,14 +621,14 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1000,6 +1000,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
+name = "hickory-client"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3e08124cf0ddda93b1186d4af73599de401f3b52f14cd9aaa719049379462e"
+dependencies = [
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-util",
+ "hickory-proto",
+ "once_cell",
+ "radix_trie",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-server"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbbb45bc4dcb456445732c705e3cfdc7393b8bcae5c36ecec36b9d76bd67cb5"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "enum-as-inner",
+ "futures-util",
+ "hickory-proto",
+ "hickory-resolver",
+ "serde",
+ "thiserror",
+ "time 0.3.23",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,17 +1294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1730,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -2652,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2662,15 +2738,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2851,96 +2918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-client"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c408c32e6a9dbb38037cece35740f2cf23c875d8ca134d33631cec83f74d3fe"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "lazy_static",
- "radix_trie",
- "rand 0.8.5",
- "thiserror",
- "time 0.3.23",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand 0.8.5",
- "serde",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "lru-cache",
- "parking_lot",
- "resolv-conf",
- "serde",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-server"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99022f9befa6daec2a860be68ac28b1f0d9d7ccf441d8c5a695e35a58d88840d"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "enum-as-inner",
- "futures-executor",
- "futures-util",
- "serde",
- "thiserror",
- "time 0.3.23",
- "tokio",
- "toml",
- "tracing",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,7 +2957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -3265,6 +3242,10 @@ dependencies = [
  "go-parse-duration",
  "gperftools",
  "hashbrown 0.14.0",
+ "hickory-client",
+ "hickory-proto",
+ "hickory-resolver",
+ "hickory-server",
  "http-body 0.4.5",
  "http-body 1.0.0-rc.2",
  "http-body-util",
@@ -3308,10 +3289,6 @@ dependencies = [
  "tower-hyper-http-body-compat",
  "tracing",
  "tracing-subscriber",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
- "trust-dns-server",
  "url",
  "ztunnel",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,10 +82,10 @@ nix = "0.26.2"
 hashbrown = "0.14.0"
 
 # DNS
-trust-dns-client = "0.22.0"
-trust-dns-proto = "0.22.0"
-trust-dns-resolver = "0.22.0"
-trust-dns-server = { version = "0.22.1", features = [ "trust-dns-resolver" ] }
+hickory-client = "0.24.0"
+hickory-proto = "0.24.0"
+hickory-resolver = "0.24.0"
+hickory-server = { version = "0.24.0", features = [ "hickory-resolver" ] }
 duration-str = "0.7.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -527,14 +527,14 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -881,6 +881,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "hickory-client"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3e08124cf0ddda93b1186d4af73599de401f3b52f14cd9aaa719049379462e"
+dependencies = [
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-util",
+ "hickory-proto",
+ "once_cell",
+ "radix_trie",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-server"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbbb45bc4dcb456445732c705e3cfdc7393b8bcae5c36ecec36b9d76bd67cb5"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "enum-as-inner",
+ "futures-util",
+ "hickory-proto",
+ "hickory-resolver",
+ "serde",
+ "thiserror",
+ "time 0.3.22",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,17 +1155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1290,12 +1366,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -1562,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -2383,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2393,15 +2463,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2554,96 +2615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-client"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c408c32e6a9dbb38037cece35740f2cf23c875d8ca134d33631cec83f74d3fe"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "lazy_static",
- "radix_trie",
- "rand 0.8.5",
- "thiserror",
- "time 0.3.22",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand 0.8.5",
- "serde",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "lru-cache",
- "parking_lot",
- "resolv-conf",
- "serde",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-server"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99022f9befa6daec2a860be68ac28b1f0d9d7ccf441d8c5a695e35a58d88840d"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "enum-as-inner",
- "futures-executor",
- "futures-util",
- "serde",
- "thiserror",
- "time 0.3.22",
- "tokio",
- "toml",
- "tracing",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -2984,6 +2955,10 @@ dependencies = [
  "futures-util",
  "go-parse-duration",
  "hashbrown 0.14.3",
+ "hickory-client",
+ "hickory-proto",
+ "hickory-resolver",
+ "hickory-server",
  "http-body 0.4.5",
  "http-body 1.0.0-rc.2",
  "http-body-util",
@@ -3024,10 +2999,6 @@ dependencies = [
  "tower-hyper-http-body-compat",
  "tracing",
  "tracing-subscriber",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
- "trust-dns-server",
  "url",
 ]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,9 +22,9 @@ use std::{env, fs};
 
 use anyhow::anyhow;
 use bytes::Bytes;
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hyper::http::uri::InvalidUri;
 use hyper::Uri;
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 
 use crate::identity;
 
@@ -300,7 +300,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         Err(_) => identity::AuthSource::None,
     };
 
-    use trust_dns_resolver::system_conf::read_system_conf;
+    use hickory_resolver::system_conf::read_system_conf;
     let (dns_resolver_cfg, dns_resolver_opts) = read_system_conf().unwrap();
 
     let dns_proxy_addr = match pc.proxy_metadata.get(DNS_PROXY_ADDR_METADATA) {

--- a/src/dns/handler.rs
+++ b/src/dns/handler.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use crate::dns::resolver::{Answer, Resolver};
+use hickory_proto::op::{Edns, Header, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::Record;
+use hickory_resolver::error::ResolveErrorKind;
+use hickory_server::authority::{LookupError, MessageResponse, MessageResponseBuilder};
+use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
 use std::sync::Arc;
 use tracing::{error, warn};
-use trust_dns_proto::op::{Edns, Header, MessageType, OpCode, ResponseCode};
-use trust_dns_proto::rr::Record;
-use trust_dns_resolver::error::ResolveErrorKind;
-use trust_dns_server::authority::{LookupError, MessageResponse, MessageResponseBuilder};
-use trust_dns_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
 
 /// A Trust-DNS [RequestHandler] that proxies all DNS requests.
 ///
@@ -204,18 +204,18 @@ mod tests {
     use crate::dns::resolver::{Answer, Resolver};
     use crate::test_helpers::dns::{a, a_request, n, socket_addr};
     use crate::test_helpers::helpers::subscribe;
+    use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+    use hickory_proto::rr::{Name, Record, RecordType};
+    use hickory_proto::serialize::binary::BinEncoder;
+    use hickory_server::authority::LookupError;
+    use hickory_server::authority::MessageResponse;
+    use hickory_server::server::{
+        Protocol, Request, RequestHandler, ResponseHandler, ResponseInfo,
+    };
     use std::net::Ipv4Addr;
     use std::sync::Arc;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::Sender;
-    use trust_dns_proto::op::{Message, MessageType, OpCode, ResponseCode};
-    use trust_dns_proto::rr::{Name, Record, RecordType};
-    use trust_dns_proto::serialize::binary::BinEncoder;
-    use trust_dns_server::authority::LookupError;
-    use trust_dns_server::authority::MessageResponse;
-    use trust_dns_server::server::{
-        Protocol, Request, RequestHandler, ResponseHandler, ResponseInfo,
-    };
 
     #[tokio::test]
     async fn record_found() {
@@ -251,7 +251,7 @@ mod tests {
         let answers = resp.answers();
         assert!(!answers.is_empty());
         assert_eq!(n("fake.com."), *answers[0].name());
-        assert_eq!(RecordType::A, answers[0].rr_type());
+        assert_eq!(RecordType::A, answers[0].record_type());
 
         let expected = a(n("fake.com."), Ipv4Addr::new(127, 0, 0, 1));
         assert_eq!(expected, *answers.iter().next().unwrap());

--- a/src/dns/metrics.rs
+++ b/src/dns/metrics.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use hickory_server::server::Request;
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram::Histogram;
 use prometheus_client::registry::Registry;
 use std::time::Duration;
-use trust_dns_server::server::Request;
 
 use crate::metrics::{DefaultedUnknown, DeferRecorder, Recorder};
 use crate::state::workload::address::Address;

--- a/src/dns/name_util.rs
+++ b/src/dns/name_util.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use trust_dns_proto::rr::Name;
+use hickory_proto::rr::Name;
 
 /// Returns true if the given name ends with the labels provided by the domain iterator.
 // TODO(nmittler): Consider upstreaming to TrustDNS.
@@ -49,7 +49,7 @@ pub fn trim_domain(name: &Name, domain: &Name) -> Option<Name> {
 mod tests {
     use super::*;
     use crate::test_helpers::dns::n;
-    use trust_dns_proto::rr::Name;
+    use hickory_proto::rr::Name;
 
     #[test]
     fn test_has_domain() {

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use hickory_proto::rr::Record;
+use hickory_resolver::lookup::Lookup;
+use hickory_server::authority::LookupError;
+use hickory_server::server::Request;
 use std::slice::Iter;
-use trust_dns_proto::rr::Record;
-use trust_dns_resolver::lookup::Lookup;
-use trust_dns_server::authority::LookupError;
-use trust_dns_server::server::Request;
 
 /// Similar to a TrustDNS `Authority`, although the resulting [Answer] indicates whether
 /// the response is authoritative. This makes the interface generally more composable and

--- a/src/inpod/test_helpers.rs
+++ b/src/inpod/test_helpers.rs
@@ -23,7 +23,7 @@ use prometheus_client::registry::Registry;
 use std::sync::{Arc, RwLock};
 use tokio::net::UnixStream;
 
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 
 use prost::Message;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -494,7 +494,7 @@ impl crate::tls::ServerCertProvider for InboundCertProvider {
 
 #[cfg(test)]
 mod test {
-    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 
     use super::*;
     use crate::state::service::endpoint_uid;

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -594,11 +594,11 @@ mod tests {
     use crate::xds::{LocalClient, ProxyStateUpdateMutator};
     use crate::{cert_fetcher, test_helpers};
     use bytes::Bytes;
+    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
     use std::collections::HashSet;
     use std::default::Default;
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::sync::RwLock;
-    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
     use xds::istio::workload::NetworkAddress as XdsNetworkAddress;
 
     #[test]

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -192,7 +192,7 @@ impl TestApp {
         hostname: &str,
         udp: bool,
         ipv6: bool,
-    ) -> trust_dns_proto::xfer::DnsResponse {
+    ) -> hickory_proto::xfer::DnsResponse {
         let addr = self.dns_proxy_address.unwrap();
         dns_request(addr, hostname, udp, ipv6).await
     }
@@ -203,11 +203,11 @@ pub async fn dns_request(
     hostname: &str,
     udp: bool,
     ipv6: bool,
-) -> trust_dns_proto::xfer::DnsResponse {
+) -> hickory_proto::xfer::DnsResponse {
     use crate::test_helpers::dns::n;
     use crate::test_helpers::dns::send_request;
     use crate::test_helpers::dns::{new_tcp_client, new_udp_client};
-    use trust_dns_proto::rr::RecordType;
+    use hickory_proto::rr::RecordType;
 
     let mut client = if udp {
         new_udp_client(addr).await

--- a/src/test_helpers/xds.rs
+++ b/src/test_helpers/xds.rs
@@ -21,6 +21,7 @@ use crate::xds::istio::workload::Address as XdsAddress;
 use async_trait::async_trait;
 use futures::Stream;
 use futures::StreamExt;
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hyper::server::conn::http2;
 use hyper_util::rt::TokioIo;
 use prometheus_client::registry::Registry;
@@ -28,7 +29,6 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Response, Status, Streaming};
 use tracing::{debug, error, info};
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 
 use super::test_config_with_port_xds_addr_and_root_cert;
 use crate::config::RootCert;


### PR DESCRIPTION
[trust-dns](https://crates.io/crates/trust-dns) crate has been changed to [hickory-dns](https://crates.io/crates/hickory-dns).
This PR is updating to the new crate and also using the new graceful shutdown support to shutdown the server on drain and avoid the warnings in logs.