### PR TITLE
basic sandwich

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -11,6 +11,9 @@ endif
 test:
 	RUST_BACKTRACE=1 cargo test --benches --tests --bins $(FEATURES)
 
+test.root:
+	CARGO_TARGET=`rustc -vV | sed -n 's|host: ||p' | tr [:lower:] [:upper:]| tr - _`_RUNNER='sudo -E' RUST_BACKTRACE=1 cargo test --benches --tests --bins $(FEATURES)
+
 build:
 	cargo build $(FEATURES)
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -11,9 +11,6 @@ endif
 test:
 	RUST_BACKTRACE=1 cargo test --benches --tests --bins $(FEATURES)
 
-test.root:
-	CARGO_TARGET=`rustc -vV | sed -n 's|host: ||p' | tr [:lower:] [:upper:]| tr - _`_RUNNER='sudo -E' RUST_BACKTRACE=1 cargo test --benches --tests --bins $(FEATURES)
-
 build:
 	cargo build $(FEATURES)
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -629,11 +629,7 @@ mod tests {
             workload::gatewayaddress::Destination,
         },
     };
-    use std::{
-        collections::HashMap,
-        net::{Ipv4Addr, SocketAddrV4},
-        sync::RwLock,
-    };
+    use std::{collections::HashMap, net::Ipv4Addr, sync::RwLock};
 
     #[tokio::test]
     async fn check_gateway() {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -40,9 +40,11 @@ use crate::proxy::metrics::{ConnectionOpen, Metrics, Reporter};
 use crate::proxy::{metrics, ProxyInputs, TraceParent, BAGGAGE_HEADER, TRACEPARENT_HEADER};
 use crate::rbac::Connection;
 use crate::socket::to_canonical;
+use crate::state::service::Service;
+use crate::state::workload::address::Address;
 use crate::{proxy, tls};
 
-use crate::state::workload::{address, GatewayAddress, NetworkAddress, Workload};
+use crate::state::workload::{NetworkAddress, Workload};
 use crate::state::DemandProxyState;
 use crate::tls::TlsError;
 
@@ -277,41 +279,47 @@ impl Inbound {
             &Method::CONNECT => {
                 let uri = req.uri();
                 info!("got {} request to {}", req.method(), uri);
-                let addr: Result<SocketAddr, _> = uri.to_string().as_str().parse();
-                if addr.is_err() {
-                    info!("Sending 400, {:?}", addr.err());
-                    return Ok(Response::builder()
-                        .status(StatusCode::BAD_REQUEST)
-                        .body(Empty::new())
-                        .unwrap());
-                }
-
-                let addr: SocketAddr = addr.unwrap();
-                if addr.ip() != conn.dst.ip() {
-                    info!("Sending 400, ip mismatch {addr} != {}", conn.dst);
-                    return Ok(Response::builder()
-                        .status(StatusCode::BAD_REQUEST)
-                        .body(Empty::new())
-                        .unwrap());
-                }
-                // Orig has 15008, swap with the real port
-                let conn = Connection { dst: addr, ..conn };
-                let dst_network_addr = NetworkAddress {
-                    network: conn.dst_network.to_string(), // dst must be on our network
-                    address: addr.ip(),
+                let hbone_addr: SocketAddr = match uri.to_string().as_str().parse() {
+                    Ok(parsed) => parsed,
+                    Err(e) => {
+                        info!("Sending 400, {}", e);
+                        return Ok(Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .body(Empty::new())
+                            .unwrap());
+                    }
                 };
-                let Some((upstream, upstream_service)) =
-                    pi.state.fetch_workload_services(&dst_network_addr).await
-                else {
-                    info!(%conn, "unknown destination");
-                    return Ok(Response::builder()
-                        .status(StatusCode::NOT_FOUND)
-                        .body(Empty::new())
-                        .unwrap());
+
+                let (upstream_addr, upstream, upstream_service) =
+                    match Self::find_inbound_upstream(pi.state.clone(), &conn, hbone_addr).await {
+                        Ok(res) => res,
+                        Err(e) => {
+                            info!(%conn, "Sending 400, {}", e);
+                            return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Empty::new())
+                                .unwrap());
+                        }
+                    };
+
+                // Orig has 15008, swap with the real port
+                let conn = Connection {
+                    dst: upstream_addr,
+                    ..conn
                 };
                 let has_waypoint = upstream.waypoint.is_some();
-                let from_waypoint = Self::check_waypoint(pi.state.clone(), &upstream, &conn).await;
-                let from_gateway = Self::check_gateway(pi.state.clone(), &upstream, &conn).await;
+                let from_waypoint = proxy::check_from_waypoint(
+                    pi.state.clone(),
+                    &upstream,
+                    conn.src_identity.as_ref(),
+                )
+                .await;
+                let from_gateway = proxy::check_from_network_gateway(
+                    pi.state.clone(),
+                    &upstream,
+                    conn.src_identity.as_ref(),
+                )
+                .await;
 
                 if from_gateway {
                     debug!("request from gateway");
@@ -388,7 +396,7 @@ impl Inbound {
                 let status_code = match Self::handle_inbound(
                     Hbone(req),
                     enable_original_source.then_some(source_ip),
-                    addr,
+                    upstream_addr,
                     pi.metrics,
                     connection_metrics,
                     None,
@@ -419,49 +427,103 @@ impl Inbound {
         }
     }
 
-    async fn check_waypoint(
+    async fn find_inbound_upstream(
         state: DemandProxyState,
-        upstream: &Workload,
         conn: &Connection,
-    ) -> bool {
-        Self::check_gateway_address(state, conn, upstream.waypoint.as_ref()).await
-    }
+        hbone_addr: SocketAddr,
+    ) -> Result<(SocketAddr, Workload, Vec<Service>), Error> {
+        let dst = &NetworkAddress {
+            network: conn.dst_network.to_string(),
+            address: hbone_addr.ip(),
+        };
 
-    async fn check_gateway(
-        state: DemandProxyState,
-        upstream: &Workload,
-        conn: &Connection,
-    ) -> bool {
-        Self::check_gateway_address(state, conn, upstream.network_gateway.as_ref()).await
-    }
-
-    async fn check_gateway_address(
-        state: DemandProxyState,
-        conn: &Connection,
-        gateway_address: Option<&GatewayAddress>,
-    ) -> bool {
-        if let Some(gateway_address) = gateway_address {
-            let from_gateway = match state.fetch_destination(&gateway_address.destination).await {
-                Some(address::Address::Workload(wl)) => Some(wl.identity()) == conn.src_identity,
-                Some(address::Address::Service(svc)) => {
-                    for (_ep_uid, ep) in svc.endpoints.iter() {
-                        // fetch workloads by workload UID since we may not have an IP for an endpoint (e.g., endpoint is just a hostname)
-                        if state
-                            .fetch_workload_by_uid(&ep.workload_uid)
-                            .await
-                            .map(|w| w.identity())
-                            == conn.src_identity
-                        {
-                            return true;
-                        }
-                    }
-                    false
-                }
-                None => false,
+        // If the IPs match, this is not sandwich.
+        if conn.dst.ip() == hbone_addr.ip() {
+            let Some((us_wl, us_svc)) = state.fetch_workload_services(dst).await else {
+                return Err(Error::UnknownDestination(hbone_addr.ip()));
             };
-            return from_gateway;
+            return Ok((hbone_addr, us_wl, us_svc));
         }
-        false // this occurs if gateway_address was None
+
+        if let Some((us_wl, us_svc)) = Self::find_sandwich_upstream(state, conn, hbone_addr).await {
+            let next_hop = SocketAddr::new(conn.dst.ip(), hbone_addr.port());
+            return Ok((next_hop, us_wl, us_svc));
+        }
+
+        Err(Error::IPMismatch(conn.dst.ip(), hbone_addr.ip()))
+    }
+
+    async fn find_sandwich_upstream(
+        state: DemandProxyState,
+        conn: &Connection,
+        hbone_addr: SocketAddr,
+    ) -> Option<(Workload, Vec<Service>)> {
+        let connection_dst = &NetworkAddress {
+            network: conn.dst_network.to_string(),
+            address: conn.dst.ip(),
+        };
+        let hbone_dst = &NetworkAddress {
+            network: conn.dst_network.to_string(),
+            address: hbone_addr.ip(),
+        };
+
+        // Outer option tells us whether or not we can retry
+        // Some(None) means we have enough information to decide this isn't sandwich
+        let lookup = || -> Option<Option<(Workload, Vec<Service>)>> {
+            let state = state.read();
+
+            // TODO Allow HBONE address to be a hostname. We have to respect rules about
+            // hostname scoping. Can we use the client's namespace here to do that?
+            let hbone_target = state.find_address(hbone_dst);
+
+            // We can only sandwich a Workload waypoint
+            let conn_wl = state.workloads.find_address(connection_dst);
+
+            // on-demand fetch then retry
+            let (Some(hbone_target), Some(conn_wl)) = (hbone_target, conn_wl) else {
+                return None;
+            };
+
+            let Some(target_waypoint) = (match hbone_target {
+                Address::Service(svc) => svc.waypoint.clone(),
+                Address::Workload(wl) => wl.waypoint,
+            }) else {
+                // can't sandwich if the HBONE target doesn't want a Waypoint.
+                return Some(None);
+            };
+
+            // Resolve the reference from our HBONE target
+            let target_waypoint = state.find_destination(&target_waypoint.destination);
+
+            let Some(target_waypoint) = target_waypoint else {
+                // don't need to fetch/retry this; we found conn_wl and this must match conn_wl.
+                return Some(None);
+            };
+
+            // Validate that the HBONE target references the Waypoint we're connecting to
+            Some(match target_waypoint {
+                Address::Service(svc) => {
+                    if !svc.contains_endpoint(&conn_wl, Some(connection_dst)) {
+                        return Some(None);
+                    }
+                    Some((conn_wl, vec![*svc]))
+                }
+                Address::Workload(wl) => {
+                    let svc = state.services.get_by_workload(&wl);
+                    Some((*wl, svc))
+                }
+            })
+        };
+
+        if let Some(res) = lookup() {
+            return res;
+        }
+
+        tokio::join![
+            state.fetch_on_demand(connection_dst.to_string()),
+            state.fetch_on_demand(hbone_dst.to_string()),
+        ];
+        lookup().flatten()
     }
 }
 
@@ -517,191 +579,3 @@ impl crate::tls::ServerCertProvider for InboundCertProvider {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-
-    use super::*;
-    use crate::state::service::endpoint_uid;
-    use crate::state::workload::NamespacedHostname;
-    use crate::{
-        identity::Identity,
-        state::{
-            self,
-            service::{Endpoint, Service},
-            workload::gatewayaddress::Destination,
-        },
-    };
-    use std::{
-        collections::HashMap,
-        net::{Ipv4Addr, SocketAddrV4},
-        sync::RwLock,
-    };
-
-    #[tokio::test]
-    async fn check_gateway() {
-        let w = mock_default_gateway_workload();
-        let s = mock_default_gateway_service();
-        let mut state = state::ProxyState::default();
-        if let Err(err) = state.workloads.insert(w) {
-            panic!("received error inserting workload: {}", err);
-        }
-        state.services.insert(s);
-        let state = state::DemandProxyState::new(
-            Arc::new(RwLock::new(state)),
-            None,
-            ResolverConfig::default(),
-            ResolverOpts::default(),
-        );
-
-        let gateawy_id = Identity::Spiffe {
-            trust_domain: "cluster.local".to_string(),
-            namespace: "gatewayns".to_string(),
-            service_account: "default".to_string(),
-        };
-        let from_gw_conn = Connection {
-            src_identity: Some(gateawy_id),
-            src_ip: IpAddr::V4(mock_default_gateway_ipaddr()),
-            dst_network: "default".to_string(),
-            dst: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 10), 80)),
-        };
-        let not_from_gw_conn = Connection {
-            src_identity: Some(Identity::default()),
-            src_ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            dst_network: "default".to_string(),
-            dst: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 10), 80)),
-        };
-
-        let upstream_with_address = mock_wokload_with_gateway(Some(mock_default_gateway_address()));
-        assert!(Inbound::check_gateway(state.clone(), &upstream_with_address, &from_gw_conn).await);
-        assert!(
-            !Inbound::check_gateway(state.clone(), &upstream_with_address, &not_from_gw_conn).await
-        );
-
-        // using hostname (will check the service variant of address::Address)
-        let upstream_with_hostname =
-            mock_wokload_with_gateway(Some(mock_default_gateway_hostname()));
-        assert!(
-            Inbound::check_gateway(state.clone(), &upstream_with_hostname, &from_gw_conn).await
-        );
-        assert!(!Inbound::check_gateway(state, &upstream_with_hostname, &not_from_gw_conn).await);
-    }
-
-    // private helpers
-    fn mock_wokload_with_gateway(gw: Option<GatewayAddress>) -> Workload {
-        Workload {
-            workload_ips: vec![IpAddr::V4(Ipv4Addr::LOCALHOST)],
-            waypoint: None,
-            network_gateway: gw,
-            gateway_address: None,
-            protocol: Default::default(),
-            uid: "".to_string(),
-            name: "app".to_string(),
-            namespace: "appns".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
-            network: "".to_string(),
-            workload_name: "app".to_string(),
-            workload_type: "deployment".to_string(),
-            canonical_name: "app".to_string(),
-            canonical_revision: "".to_string(),
-            hostname: "".to_string(),
-            node: "".to_string(),
-            status: Default::default(),
-            cluster_id: "Kubernetes".to_string(),
-
-            authorization_policies: Vec::new(),
-            native_tunnel: false,
-        }
-    }
-
-    fn mock_default_gateway_workload() -> Workload {
-        Workload {
-            workload_ips: vec![IpAddr::V4(mock_default_gateway_ipaddr())],
-            waypoint: None,
-            network_gateway: None,
-            gateway_address: None,
-            protocol: Default::default(),
-            uid: "".to_string(),
-            name: "gateway".to_string(),
-            namespace: "gatewayns".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
-            network: "".to_string(),
-            workload_name: "gateway".to_string(),
-            workload_type: "deployment".to_string(),
-            canonical_name: "".to_string(),
-            canonical_revision: "".to_string(),
-            hostname: "".to_string(),
-            node: "".to_string(),
-            status: Default::default(),
-            cluster_id: "Kubernetes".to_string(),
-
-            authorization_policies: Vec::new(),
-            native_tunnel: false,
-        }
-    }
-
-    fn mock_default_gateway_service() -> Service {
-        let vip1 = NetworkAddress {
-            address: IpAddr::V4(Ipv4Addr::new(127, 0, 10, 1)),
-            network: "".to_string(),
-        };
-        let vips = vec![vip1];
-        let mut ports = HashMap::new();
-        ports.insert(8080, 80);
-        let mut endpoints = HashMap::new();
-        let addr = Some(NetworkAddress {
-            network: "".to_string(),
-            address: IpAddr::V4(mock_default_gateway_ipaddr()),
-        });
-        endpoints.insert(
-            endpoint_uid(&mock_default_gateway_workload().uid, addr.as_ref()),
-            Endpoint {
-                workload_uid: mock_default_gateway_workload().uid,
-                service: NamespacedHostname {
-                    namespace: "gatewayns".to_string(),
-                    hostname: "gateway".to_string(),
-                },
-                address: addr,
-                port: ports.clone(),
-            },
-        );
-        Service {
-            name: "gateway".to_string(),
-            namespace: "gatewayns".to_string(),
-            hostname: "gateway".to_string(),
-            vips,
-            ports,
-            endpoints,
-            subject_alt_names: vec![],
-            waypoint: None,
-        }
-    }
-
-    fn mock_default_gateway_address() -> GatewayAddress {
-        GatewayAddress {
-            destination: Destination::Address(NetworkAddress {
-                network: "".to_string(),
-                address: IpAddr::V4(mock_default_gateway_ipaddr()),
-            }),
-            hbone_mtls_port: 15008,
-            hbone_single_tls_port: Some(15003),
-        }
-    }
-
-    fn mock_default_gateway_hostname() -> GatewayAddress {
-        GatewayAddress {
-            destination: Destination::Hostname(state::workload::NamespacedHostname {
-                namespace: "gatewayns".to_string(),
-                hostname: "gateway".to_string(),
-            }),
-            hbone_mtls_port: 15008,
-            hbone_single_tls_port: Some(15003),
-        }
-    }
-
-    fn mock_default_gateway_ipaddr() -> Ipv4Addr {
-        Ipv4Addr::new(127, 0, 0, 100)
-    }
-}

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -312,6 +312,7 @@ impl Inbound {
                     pi.state.clone(),
                     &upstream,
                     conn.src_identity.as_ref(),
+                    &conn.src_ip,
                 )
                 .await;
                 let from_gateway = proxy::check_from_network_gateway(
@@ -504,11 +505,16 @@ impl Inbound {
             Some(match target_waypoint {
                 Address::Service(svc) => {
                     if !svc.contains_endpoint(&conn_wl, Some(connection_dst)) {
+                        // target points to a different waypoint
                         return Some(None);
                     }
                     Some((conn_wl, vec![*svc]))
                 }
                 Address::Workload(wl) => {
+                    if !wl.workload_ips.contains(&conn.dst.ip()) {
+                        // target points to a different waypoint
+                        return Some(None);
+                    }
                     let svc = state.services.get_by_workload(&wl);
                     Some((*wl, svc))
                 }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -470,44 +470,56 @@ impl OutboundConnection {
             )
             .await?;
 
-        // For case upstream server has enabled waypoint
-        match self
-            .pi
-            .state
-            .fetch_waypoint(&mutable_us.workload, workload_ip)
-            .await
-        {
-            Ok(None) => {} // workload doesn't have a waypoint; this is fine
-            Ok(Some(waypoint_us)) => {
-                let waypoint_workload = waypoint_us.workload;
-                let waypoint_ip = self
-                    .pi
-                    .state
-                    .load_balance(
-                        &waypoint_workload,
-                        &source_workload,
-                        self.pi.metrics.clone(),
-                    )
-                    .await?;
-                let wp_socket_addr = SocketAddr::new(waypoint_ip, waypoint_us.port);
-                return Ok(Request {
-                    // Always use HBONE here
-                    protocol: Protocol::HBONE,
-                    source: source_workload,
-                    // Use the original VIP, not translated
-                    destination: target,
-                    destination_workload: Some(mutable_us.workload),
-                    destination_service: mutable_us.destination_service.clone(),
-                    expected_identity: Some(waypoint_workload.identity()),
-                    gateway: wp_socket_addr,
-                    // Let the client remote know we are on the inbound path.
-                    direction: Direction::Inbound,
-                    request_type: RequestType::ToServerWaypoint,
-                    upstream_sans: mutable_us.sans,
-                });
+        // TODO src_id may not be enough; should also check addresses/uid
+        let src_id = Some(source_workload.identity());
+        let from_waypoint = proxy::check_from_waypoint(
+            self.pi.state.clone(),
+            &mutable_us.workload,
+            src_id.as_ref(),
+        )
+        .await;
+
+        // Don't traverse waypoint twice if the source is sandwich-outbound.
+        if !from_waypoint {
+            // For case upstream server has enabled waypoint
+            match self
+                .pi
+                .state
+                .fetch_waypoint(&mutable_us.workload, workload_ip)
+                .await
+            {
+                Ok(None) => {} // workload doesn't have a waypoint; this is fine
+                Ok(Some(waypoint_us)) => {
+                    let waypoint_workload = waypoint_us.workload;
+                    let waypoint_ip = self
+                        .pi
+                        .state
+                        .load_balance(
+                            &waypoint_workload,
+                            &source_workload,
+                            self.pi.metrics.clone(),
+                        )
+                        .await?;
+                    let wp_socket_addr = SocketAddr::new(waypoint_ip, waypoint_us.port);
+                    return Ok(Request {
+                        // Always use HBONE here
+                        protocol: Protocol::HBONE,
+                        source: source_workload,
+                        // Use the original VIP, not translated
+                        destination: target,
+                        destination_workload: Some(mutable_us.workload),
+                        destination_service: mutable_us.destination_service.clone(),
+                        expected_identity: Some(waypoint_workload.identity()),
+                        gateway: wp_socket_addr,
+                        // Let the client remote know we are on the inbound path.
+                        direction: Direction::Inbound,
+                        request_type: RequestType::ToServerWaypoint,
+                        upstream_sans: mutable_us.sans,
+                    });
+                }
+                // we expected the workload to have a waypoint, but could not find one
+                Err(e) => return Err(Error::UnknownWaypoint(e.to_string())),
             }
-            // we expected the workload to have a waypoint, but could not find one
-            Err(e) => return Err(Error::UnknownWaypoint(e.to_string())),
         }
 
         let us = match set_gateway_address(&mut mutable_us, workload_ip, self.pi.hbone_port) {
@@ -666,6 +678,7 @@ mod tests {
             namespace: "ns".to_string(),
             addresses: vec![Bytes::copy_from_slice(&[127, 0, 0, 10])],
             node: "local-node".to_string(),
+            service_account: "waypoint-sa".to_string(),
             ..Default::default()
         };
         let state = match xds {

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -470,12 +470,11 @@ impl OutboundConnection {
             )
             .await?;
 
-        // TODO src_id may not be enough; should also check addresses/uid
-        let src_id = Some(source_workload.identity());
         let from_waypoint = proxy::check_from_waypoint(
             self.pi.state.clone(),
             &mutable_us.workload,
-            src_id.as_ref(),
+            Some(&source_workload.identity()),
+            &downstream_network_addr.address,
         )
         .await;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -631,7 +631,7 @@ impl DemandProxyState {
         self.state.read().unwrap().find_hostname(hostname)
     }
 
-    async fn fetch_on_demand(&self, key: String) {
+    pub async fn fetch_on_demand(&self, key: String) {
         if let Some(demand) = &self.demand {
             debug!(%key, "sending demand request");
             demand

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -52,6 +52,10 @@ impl Service {
             hostname: self.hostname.clone(),
         }
     }
+
+    pub fn contains_endpoint(&self, wl: &Workload, addr: Option<&NetworkAddress>) -> bool {
+        self.endpoints.contains_key(&endpoint_uid(&wl.uid, addr))
+    }
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize)]

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -356,7 +356,7 @@ impl TryFrom<&XdsWorkload> for Workload {
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum WaypointError {
-    #[error("failed to find waypoint for workload: {0}")]
+    #[error("failed to find waypoint for: {0}")]
     FindWaypointError(String),
     #[error("unsupported feature: {0}")]
     UnsupportedFeature(String),


### PR DESCRIPTION
When the Waypoint is captured, zTunnel sees the connection address as the Waypoint's address and the HBONE address as the actual destination. 

This impl currently uses that to detect whether the current connection is part of a sandwich, and verifies that the HBONE target actually references the connection address as a Waypoint. Instead of sending traffic to the HBONE target, we send it to the connection address. 

Depends on https://github.com/istio/ztunnel/pull/832 so the relevant commits are: https://github.com/istio/ztunnel/pull/789/files/b5af5ac0fb7e71805ee6f5b9fe56e8010511dead..a17e43e3488a4567c4c84eaae0638bf09d045c4d