### PR TITLE
Bump to nix-0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,15 +1536,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -1656,9 +1647,19 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
- "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -3260,7 +3261,7 @@ dependencies = [
  "log",
  "matches",
  "netns-rs",
- "nix 0.26.2",
+ "nix 0.27.1",
  "once_cell",
  "pprof",
  "priority-queue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ http-body-1 = { package = "http-body", version = "1.0.0-rc.2" }
 tower-hyper-http-body-compat = { version = "0.2", features = ["server", "http2"] }
 futures-util = "0.3.26"
 chrono = "0.4.23"
-nix = "0.26.2"
+nix = { version = "0.27.1", features = ["socket", "sched", "uio", "fs", "ioctl", "user"] }
 hashbrown = "0.14.0"
 
 # DNS

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,9 +1281,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1393,15 +1393,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -1482,9 +1473,19 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
- "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -2971,7 +2972,7 @@ dependencies = [
  "libc",
  "log",
  "netns-rs",
- "nix 0.26.2",
+ "nix 0.27.1",
  "once_cell",
  "pprof",
  "priority-queue",

--- a/src/inpod/config.rs
+++ b/src/inpod/config.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::config;
-use std::{os::fd::FromRawFd, sync::Arc};
+use std::sync::Arc;
 
 use super::netns::InpodNetns;
 
@@ -151,8 +151,7 @@ impl crate::proxy::SocketFactory for InPodSocketPortReuseFactory {
                 )
                 .map_err(|e| std::io::Error::from_raw_os_error(e as i32)),
             }?;
-            // safety: we just created this socket
-            Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(sock) })
+            Ok(sock)
         })?;
 
         let socket_ref = socket2::SockRef::from(&sock);

--- a/src/inpod/netns.rs
+++ b/src/inpod/netns.rs
@@ -42,8 +42,7 @@ impl InpodNetns {
         // set the netns to our current netns. This is intended to be a no-op,
         // and meant to be used as a test, so we can fail early if we can't set the netns
         let curns = Self::current()?;
-        let curnsfd = curns.as_raw_fd();
-        setns(curnsfd, CloneFlags::CLONE_NEWNET)
+        setns(curns, CloneFlags::CLONE_NEWNET)
             .map_err(|e| std::io::Error::from_raw_os_error(e as i32))
     }
 
@@ -72,11 +71,10 @@ impl InpodNetns {
     where
         F: FnOnce() -> T,
     {
-        setns(self.inner.netns.as_raw_fd(), CloneFlags::CLONE_NEWNET)
+        setns(&self.inner.netns, CloneFlags::CLONE_NEWNET)
             .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
         let ret = f();
-        setns(self.inner.cur_netns.as_raw_fd(), CloneFlags::CLONE_NEWNET)
-            .expect("this must never fail");
+        setns(&self.inner.cur_netns, CloneFlags::CLONE_NEWNET).expect("this must never fail");
         Ok(ret)
     }
 }

--- a/src/inpod/protocol.rs
+++ b/src/inpod/protocol.rs
@@ -18,6 +18,7 @@ use drain::Watch;
 use nix::sys::socket::{recvmsg, sendmsg, ControlMessageOwned, MsgFlags};
 use prost::Message;
 use std::io::{IoSlice, IoSliceMut};
+use std::os::fd::OwnedFd;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use tokio::net::UnixStream;
 use tracing::{debug, info, warn};
@@ -213,16 +214,13 @@ fn maybe_get_fd(
     if let Some(our_netns) = &our_netns {
         // validate that the fd we got is a netns. This should never happen, and is here
         // to catch potential bugs in the node agent during development.
-        debug!(
-            "Validating netns FD: {:?}",
-            validate_ns(our_netns.as_raw_fd())
-        );
+        debug!("Validating netns FD: {:?}", validate_ns(our_netns));
     }
 
     Ok(our_netns)
 }
 
-fn validate_ns(fd: std::os::fd::RawFd) -> anyhow::Result<()> {
+fn validate_ns(fd: &OwnedFd) -> anyhow::Result<()> {
     // on newer kernels we can get the ns type! note that this doesn't work on older kernels.
     // so an error doesn't mean its not a netns.
     // #define NSIO	0xb7
@@ -230,24 +228,24 @@ fn validate_ns(fd: std::os::fd::RawFd) -> anyhow::Result<()> {
     // #define NS_GET_NSTYPE		_IO(NSIO, 0x3)
     const NS_GET_NSTYPE: u8 = 0x3;
     nix::ioctl_none!(get_ns_type, NSIO, NS_GET_NSTYPE);
-    let nstype = unsafe { get_ns_type(fd) };
+    let nstype = unsafe { get_ns_type(fd.as_raw_fd()) };
     if let Ok(nstype) = nstype {
         // ignore errors in case we are in an old kernel
         if nstype != nix::libc::CLONE_NEWNET {
             anyhow::bail!("Unexpected ns type: {:?}", nstype);
         } else {
-            debug!("FD {} type is netns", fd);
+            debug!("FD {:?} type is netns", fd);
         }
     } else {
         // can get ns type, do a different check - that the fd came from the nsfs.
-        let data = nix::sys::statfs::fstatfs(&fd)?;
+        let data = nix::sys::statfs::fstatfs(fd)?;
         let f_type = data.filesystem_type();
         if f_type != nix::sys::statfs::PROC_SUPER_MAGIC && f_type != nix::sys::statfs::NSFS_MAGIC {
             anyhow::bail!("Unexpected FD type for netns: {:?}", f_type);
         }
     }
 
-    debug!("FD {} looks like a netns", fd);
+    debug!("FD {:?} looks like a netns", fd);
     Ok(())
 }
 


### PR DESCRIPTION
- New version discourages slinging around non-lifetime'd `RawFd` args in favor of lifetime'd `(Owned/Borrowed)FDs` (good)
- This has a side effect of letting us drop a couple `unsafe` blocks (also good)