### PR TITLE
Initial connection MDS implementation

### DIFF
--- a/go-metadata/examples/main.go
+++ b/go-metadata/examples/main.go
@@ -1,0 +1,70 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+
+	istiometadata "istio.io/ztunnel/go-metadata"
+)
+
+func main() {
+	switch os.Args[1] {
+	case "client":
+		ip := os.Args[2]
+		conn, err := net.Dial("tcp", ip+":9090")
+		fatal(err)
+
+		req, err := http.NewRequest("GET", "/", nil)
+		fatal(err)
+		fatal(req.Write(conn))
+
+		resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+		fatal(err)
+
+		rb, err := io.ReadAll(resp.Body)
+		fatal(err)
+		log.Println("Server response: ", string(rb))
+
+		si, err := istiometadata.FetchFromClientConnection(conn)
+		fatal(err)
+		log.Println("Connected to server with identity: ", si)
+	case "server":
+		l, _ := net.Listen("tcp", "0.0.0.0:9090")
+		log.Println("listening")
+		handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			id := istiometadata.ExtractFromRequest(r)
+			if id == nil {
+				rw.Write([]byte("client has unknown identity"))
+			} else {
+				rw.Write([]byte("client identity: " + id.Identity))
+			}
+		})
+		fatal(http.Serve(l, istiometadata.Handler(handler)))
+	default:
+		panic("unknown mode")
+	}
+}
+
+func fatal(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go-metadata/go.mod
+++ b/go-metadata/go.mod
@@ -1,0 +1,3 @@
+module istio.io/ztunnel/go-metadata
+
+go 1.19

--- a/go-metadata/istio.go
+++ b/go-metadata/istio.go
@@ -135,7 +135,7 @@ func FetchFromClientConnection(c net.Conn) (*ConnectionMetadata, error) {
 	return lookup(c.LocalAddr().String(), c.RemoteAddr().String())
 }
 
-// FetchFromServerConnection attempts to fetch ConnectionMetadata from a client connection.
+// FetchFromServerConnection attempts to fetch ConnectionMetadata from a server connection.
 func FetchFromServerConnection(c net.Conn) (*ConnectionMetadata, error) {
 	return lookup(c.RemoteAddr().String(), c.LocalAddr().String())
 }

--- a/go-metadata/istio.go
+++ b/go-metadata/istio.go
@@ -1,0 +1,141 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istiometadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+// ConnectionMetadata returns the metadata about a connection
+type ConnectionMetadata struct {
+	// Identity provides the identity of the peer.
+	// Example: spiffe://cluster.local/ns/a/sa/b.
+	Identity string `json:"identity"`
+}
+
+// metadataClient provides a default client for all metadata requests
+var metadataClient = http.Client{
+	Timeout: time.Second,
+}
+
+// metadataContextKey is the key the metadata handler will store connection metadata in
+var metadataContextKey = &contextKey{}
+
+type contextKey struct {
+	name string
+}
+
+func (k *contextKey) String() string { return "istio metadata context value" }
+
+const mdsHostEnv = "GCE_METADATA_HOST"
+
+// For now, we use a well-known IP which is intercepted.
+// TODO: consider creating a real service with node-affinity to drop redirection dependency.
+const defaultHost = "169.254.169.111"
+
+func metadataServerURL() *url.URL {
+	host := os.Getenv(mdsHostEnv)
+	if host == "" {
+		host = defaultHost
+	}
+	u, err := url.Parse("http://" + host)
+	if err != nil {
+		panic(err.Error())
+	}
+	return u
+}
+
+func lookup(src, dst string) (*ConnectionMetadata, error) {
+	u := metadataServerURL()
+	params := url.Values{}
+	params.Add("src", src)
+	params.Add("dst", dst)
+	u.RawQuery = params.Encode()
+	u.Path = "/connection"
+
+	resp, err := metadataClient.Get(u.String())
+	if err != nil {
+		return nil, fmt.Errorf("metadata lookup failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bdy, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metadata server returned %v: %v", resp.StatusCode, string(bdy))
+	}
+
+	mr := &ConnectionMetadata{}
+	if err := json.NewDecoder(resp.Body).Decode(mr); err != nil {
+		return nil, err
+	}
+	return mr, nil
+}
+
+// Handler is an HTTP middleware that looks up the metadata for each request, storing it in context.
+// It can later be looked up with ExtractFromRequest.
+func Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Context().Value(metadataContextKey) != nil {
+			h.ServeHTTP(w, r)
+			return
+		}
+		local := r.Context().Value(http.LocalAddrContextKey)
+		cm, err := lookup(r.RemoteAddr, local.(*net.TCPAddr).String())
+		if err != nil {
+			// Nothing we can do
+			h.ServeHTTP(w, r)
+			return
+		}
+		// Serve underlying handler
+		ctx := context.WithValue(r.Context(), metadataContextKey, cm)
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ExtractFromRequest attempts to extract ConnectionMetadata from a request.
+// This requires Handler to be used.
+// If a connection is re-used between requests, only a single call will be made.
+func ExtractFromRequest(r *http.Request) *ConnectionMetadata {
+	v := r.Context().Value(metadataContextKey)
+	if v == nil {
+		return nil
+	}
+	return v.(*ConnectionMetadata)
+}
+
+// FetchFromRequest attempts to fetch ConnectionMetadata from a request.
+// This will make a call for each request, which may be inefficient.
+func FetchFromRequest(r *http.Request) (*ConnectionMetadata, error) {
+	local := r.Context().Value(http.LocalAddrContextKey)
+	return lookup(r.RemoteAddr, local.(*net.TCPAddr).String())
+}
+
+// FetchFromClientConnection attempts to fetch ConnectionMetadata from a client connection.
+func FetchFromClientConnection(c net.Conn) (*ConnectionMetadata, error) {
+	return lookup(c.LocalAddr().String(), c.RemoteAddr().String())
+}
+
+// FetchFromServerConnection attempts to fetch ConnectionMetadata from a client connection.
+func FetchFromServerConnection(c net.Conn) (*ConnectionMetadata, error) {
+	return lookup(c.RemoteAddr().String(), c.LocalAddr().String())
+}

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -23,6 +23,7 @@ use crate::config::ProxyMode;
 use async_trait::async_trait;
 
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
+use serde::{Serialize, Serializer};
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::time::{sleep_until, Duration, Instant};
 
@@ -42,6 +43,15 @@ pub enum Identity {
         namespace: String,
         service_account: String,
     },
+}
+
+impl Serialize for Identity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
 }
 
 impl EncodeLabelValue for Identity {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -44,6 +44,7 @@ use crate::{config, identity, socket, tls};
 pub mod connection_manager;
 mod inbound;
 mod inbound_passthrough;
+mod metadata;
 #[allow(non_camel_case_types)]
 pub mod metrics;
 mod outbound;

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -195,7 +195,7 @@ impl PolicyWatcher {
 mod tests {
     use drain::Watch;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-    use std::net::{Ipv4Addr, SocketAddrV4};
+
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
 

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -33,6 +33,7 @@ use tracing::{debug, error, info, instrument, trace, trace_span, warn, Instrumen
 use super::connection_manager::ConnectionManager;
 use super::{Error, SocketFactory};
 use crate::baggage::parse_baggage_header;
+
 use crate::identity::{Identity, SecretManager};
 use crate::metrics::Recorder;
 use crate::proxy::inbound::InboundConnect::{DirectPath, Hbone};
@@ -79,7 +80,6 @@ impl Inbound {
     }
 
     pub(super) async fn run(self) {
-        // let (tx, rx) = oneshot::channel();
         let acceptor = InboundCertProvider {
             state: self.pi.state.clone(),
             cert_manager: self.pi.cert_manager.clone(),
@@ -126,7 +126,7 @@ impl Inbound {
                     );
                 // Wait for drain to signal or connection serving to complete
                 match futures_util::future::select(Box::pin(drain.signaled()), serve).await {
-                    // We got a shutdown request. Start gracful shutdown and wait for the pending requests to complete.
+                    // We got a shutdown request. Start graceful shutdown and wait for the pending requests to complete.
                     futures_util::future::Either::Left((_shutdown, mut server)) => {
                         let drain = std::pin::Pin::new(&mut server);
                         drain.graceful_shutdown();

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -147,7 +147,7 @@ impl InboundPassthrough {
         // On the inbound HBONE side, we will validate it came from the waypoint (and therefor had enforcemen).
         let conn = rbac::Connection {
             src_identity: None,
-            src_ip: source.ip(),
+            src: source,
             // inbound request must be on our network since this is passthrough
             // rather than HBONE, which can be tunneled across networks through gateways.
             // by definition, without the gateway our source must be on our network.

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -138,7 +138,7 @@ impl InboundPassthrough {
             // Spoofing the source IP only works when the destination or the source are on our node.
             // In this case, the source and the destination might both be remote, so we need to disable it.
             oc.pi.cfg.enable_original_source = Some(false);
-            return oc.proxy_to(inbound, source.ip(), orig, false).await;
+            return oc.proxy_to(inbound, source, orig, false).await;
         }
 
         // We enforce RBAC only for non-hairpin cases. This is because we may not be able to properly

--- a/src/proxy/metadata.rs
+++ b/src/proxy/metadata.rs
@@ -1,0 +1,105 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use std::time::Duration;
+
+use anyhow::anyhow;
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::service::service_fn;
+use hyper::{Response, StatusCode};
+
+use tokio::net::TcpStream;
+use tracing::{error, trace};
+
+use crate::proxy::connection_manager::{ConnectionManager, ConnectionTuple};
+
+use super::Error;
+
+/// METADATA_SERVER_IP provides the well-known metadata server IP.
+/// This is captured by the redirection.
+pub const METADATA_SERVER_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(169, 254, 169, 111));
+
+pub async fn handle_metadata_lookup(
+    ct: &ConnectionManager,
+    stream: TcpStream,
+    remote_addr: SocketAddr,
+) -> Result<(), Error> {
+    trace!(remote=%remote_addr, "metadata lookup");
+    if let Err(e) = crate::hyper_util::http1_server()
+        .half_close(true)
+        .header_read_timeout(Duration::from_secs(2))
+        .max_buf_size(8 * 1024)
+        .serve_connection(
+            hyper_util::rt::TokioIo::new(stream),
+            service_fn(|req: hyper::Request<hyper::body::Incoming>| {
+                let ct = ct.clone();
+                async move {
+                    let res: Result<_, Infallible> =
+                        serve_request(&ct, remote_addr, req).await.or_else(|e| {
+                            Ok(crate::hyper_util::plaintext_response(
+                                StatusCode::UNPROCESSABLE_ENTITY,
+                                e.to_string(),
+                            ))
+                        });
+                    res
+                }
+            }),
+        )
+        .await
+    {
+        error!("Error while serving HTTP connection: {}", e);
+    }
+    Ok(())
+}
+
+async fn serve_request(
+    ct: &ConnectionManager,
+    remote: SocketAddr,
+    req: hyper::Request<hyper::body::Incoming>,
+) -> anyhow::Result<Response<Full<Bytes>>> {
+    // Currently only one path, so just check it
+    if req.uri().path() != "/connection" {
+        anyhow::bail!("invalid path")
+    }
+
+    let query = req.uri().query().ok_or(anyhow!("missing query"))?;
+
+    let params = url::form_urlencoded::parse(query.as_bytes())
+        .into_owned()
+        .collect::<HashMap<String, String>>();
+    let src: SocketAddr = params.get("src").ok_or(anyhow!("missing src"))?.parse()?;
+    let dst: SocketAddr = params.get("dst").ok_or(anyhow!("missing dst"))?.parse()?;
+
+    // To restrict access to sensitive metadata, ensure the client is part of the requested connection.
+    // This can be error prone if the client has multiple NICs.
+    if remote.ip() != dst.ip() && remote.ip() != src.ip() {
+        anyhow::bail!("metadata server request must come from the src or dst address (remote {}, dst {}, src {})", remote.ip(), dst.ip(), src.ip())
+    }
+
+    let ctu = ConnectionTuple { src, dst };
+    let Some(resp) = ct.fetch(&ctu).await else {
+        return Ok(crate::hyper_util::plaintext_response(
+            StatusCode::NOT_FOUND,
+            "".to_string(),
+        ));
+    };
+
+    let r = serde_json::to_vec(&resp).unwrap();
+    Ok(Response::new(Full::new(Bytes::from(r))))
+}

--- a/src/proxy/metadata.rs
+++ b/src/proxy/metadata.rs
@@ -121,7 +121,6 @@ async fn serve_request_helper<T>(
 mod tests {
     use http_body_util::{BodyExt, Empty};
     use hyper::Method;
-    use std::net::{Ipv4Addr, SocketAddrV4};
 
     use crate::rbac::Connection;
 

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -118,7 +118,7 @@ pub struct DerivedWorkload {
     pub cluster_id: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ConnectionOpen {
     pub reporter: Reporter,
     pub source: Option<Workload>,

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -30,6 +30,7 @@ use tracing::{debug, error, info, info_span, trace, trace_span, warn, Instrument
 use crate::config::ProxyMode;
 use crate::identity::Identity;
 use crate::proxy::inbound::{Inbound, InboundConnect};
+use crate::proxy::metadata::{handle_metadata_lookup, METADATA_SERVER_IP};
 use crate::proxy::metrics::Reporter;
 use crate::proxy::{metrics, pool};
 use crate::proxy::{util, Error, ProxyInputs, TraceParent, BAGGAGE_HEADER, TRACEPARENT_HEADER};
@@ -127,22 +128,31 @@ impl OutboundConnection {
     async fn proxy(&mut self, stream: TcpStream) -> Result<(), Error> {
         let peer = socket::to_canonical(stream.peer_addr().expect("must receive peer addr"));
         let orig_dst_addr = socket::orig_dst_addr_or_default(&stream);
-        self.proxy_to(stream, peer.ip(), orig_dst_addr, false).await
+        self.proxy_to(stream, peer, orig_dst_addr, false).await
     }
 
     pub async fn proxy_to(
         &mut self,
         mut stream: TcpStream,
-        remote_addr: IpAddr,
+        remote_addr: SocketAddr,
         orig_dst_addr: SocketAddr,
         block_passthrough: bool,
     ) -> Result<(), Error> {
+        let remote_ip = remote_addr.ip();
+        if orig_dst_addr.ip() == METADATA_SERVER_IP {
+            return handle_metadata_lookup(
+                &self.pi.connection_manager.clone(),
+                stream,
+                remote_addr,
+            )
+            .await;
+        }
         if self.pi.cfg.proxy_mode == ProxyMode::Shared
             && Some(orig_dst_addr.ip()) == self.pi.cfg.local_ip
         {
             return Err(Error::SelfCall);
         }
-        let req = self.build_request(remote_addr, orig_dst_addr).await?;
+        let req = self.build_request(remote_ip, orig_dst_addr).await?;
         debug!(
             "request from {} to {} via {} type {:#?} dir {:#?}",
             req.source.name, orig_dst_addr, req.gateway, req.request_type, req.direction
@@ -185,7 +195,7 @@ impl OutboundConnection {
             };
             let conn = rbac::Connection {
                 src_identity: Some(req.source.identity()),
-                src_ip: remote_addr,
+                src_ip: remote_ip,
                 dst_network: req.source.network.clone(), // since this is node local, it's the same network
                 dst: req.destination,
             };
@@ -219,7 +229,7 @@ impl OutboundConnection {
                 InboundConnect::DirectPath(stream),
                 origin_src,
                 req.destination,
-                self.pi.metrics.to_owned(), // self is a borrow so this clone is to return an owned
+                self.pi.metrics.clone(),
                 connection_metrics,
                 Some(inbound_connection_metrics),
                 self.pi.socket_factory.as_ref(),
@@ -278,7 +288,7 @@ impl OutboundConnection {
                         .cfg
                         .enable_original_source
                         .unwrap_or_default()
-                        .then_some(remote_addr);
+                        .then_some(remote_ip);
                     let id = &req.source.identity();
                     let cert = self.pi.cert_manager.fetch_certificate(id).await?;
                     let connector = cert.outbound_connector(dst_identity)?;

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -190,7 +190,7 @@ async fn handle(mut oc: OutboundConnection, mut stream: TcpStream) -> Result<(),
 
     info!("accepted connection from {remote_addr} to {host}");
     tokio::spawn(async move {
-        let res = oc.proxy_to(stream, remote_addr.ip(), host, true).await;
+        let res = oc.proxy_to(stream, remote_addr, host, true).await;
         match res {
             Ok(_) => {}
             Err(ref e) => warn!("outbound proxy failed: {}", e),

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -16,7 +16,7 @@ use ipnet::IpNet;
 
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use tracing::{instrument, trace};
 use xds::istio::security::string_match::MatchType;
 use xds::istio::security::Address as XdsAddress;
@@ -42,7 +42,7 @@ pub struct Authorization {
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Connection {
     pub src_identity: Option<Identity>,
-    pub src_ip: IpAddr,
+    pub src: SocketAddr,
     pub dst_network: String,
     pub dst: SocketAddr,
 }
@@ -63,7 +63,7 @@ impl Display for Connection {
         write!(
             f,
             "{}({})->{}",
-            self.src_ip,
+            self.src,
             OptionDisplay(&self.src_identity),
             self.dst
         )
@@ -120,7 +120,7 @@ impl Authorization {
                         "source_ips",
                         &mg.source_ips,
                         &mg.not_source_ips,
-                        |i| i.contains(&conn.src_ip),
+                        |i| i.contains(&conn.src.ip()),
                     );
                     m &= Self::matches_internal(
                         "destination_ports",
@@ -434,7 +434,7 @@ mod tests {
     fn plaintext_conn() -> Connection {
         Connection {
             src_identity: None,
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:8080".parse().unwrap(),
         }
@@ -447,7 +447,7 @@ mod tests {
                 namespace: "namespace".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:8080".parse().unwrap(),
         }
@@ -460,7 +460,7 @@ mod tests {
                 namespace: "ns-alt".to_string(),
                 service_account: "sa=alt".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 3]),
+            src: "127.0.0.3:1235".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.4:9090".parse().unwrap(),
         }
@@ -508,7 +508,7 @@ mod tests {
                 namespace: "a".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -518,7 +518,7 @@ mod tests {
                 namespace: "b".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -529,7 +529,7 @@ mod tests {
                 namespace: "b".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "remote".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -540,7 +540,7 @@ mod tests {
                 namespace: "bad".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -551,7 +551,7 @@ mod tests {
                 namespace: "b".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:12345".parse().unwrap(),
         }));
@@ -579,7 +579,7 @@ mod tests {
                 namespace: "a".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -589,7 +589,7 @@ mod tests {
                 namespace: "b".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -600,7 +600,7 @@ mod tests {
                 namespace: "bad".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));

--- a/src/state.rs
+++ b/src/state.rs
@@ -834,12 +834,9 @@ mod tests {
         let mut ctx = crate::state::ProxyRbacContext {
             conn: rbac::Connection {
                 src_identity: None,
-                src_ip: std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+                src: "192.168.0.1:1234".parse().unwrap(),
+                dst: "192.168.0.2:8080".parse().unwrap(),
                 dst_network: "".to_string(),
-                dst: std::net::SocketAddr::V4(SocketAddrV4::new(
-                    Ipv4Addr::new(192, 168, 0, 2),
-                    8080,
-                )),
             },
             dest_workload_info: Some(Arc::new(wi.clone())),
         };

--- a/src/state.rs
+++ b/src/state.rs
@@ -730,7 +730,7 @@ impl ProxyStateManager {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, net::SocketAddrV4, time::Duration};
+    use std::{net::Ipv4Addr, time::Duration};
 
     use super::*;
     use crate::test_helpers;

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -908,7 +908,7 @@ mod tests {
                     let conn = crate::rbac::Connection{
                         dst: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),
                         src_identity: None,
-                        src_ip: std::net::Ipv4Addr::new(1, 2,3, 5).into(),
+                        src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 5).into(), 1234),
                         dst_network: "".to_string(),
                     };
                     let rbac_ctx = crate::state::ProxyRbacContext {


### PR DESCRIPTION
* Store each connection in a shared map
* Capture special IP address, redirect to MDS handler
* MDS handler takes 4 tuple as input.
* Response is JSON containing identity

Also has an example Golang library implementation to add HTTP middleware that extracts the identity.

Istio tests: https://github.com/istio/istio/pull/44536 (blocked by this PR, of course), which also show how to use it

Original PR in https://github.com/istio/ztunnel/pull/504 got force deleted so cannot re-open