### PR TITLE
forget certs where appropriate during xds remove

### DIFF
--- a/src/cert_fetcher.rs
+++ b/src/cert_fetcher.rs
@@ -24,6 +24,7 @@ use tracing::{debug, error, info};
 /// Responsible for pre-fetching certs for workloads.
 pub trait CertFetcher: Send + Sync {
     fn prefetch_cert(&self, w: &Workload);
+    fn forget(&self, w: &Workload);
 }
 
 /// A no-op implementation of [CertFetcher].
@@ -31,6 +32,7 @@ pub struct NoCertFetcher();
 
 impl CertFetcher for NoCertFetcher {
     fn prefetch_cert(&self, _: &Workload) {}
+    fn forget(&self, _: &Workload) {}
 }
 
 /// Constructs an appropriate [CertFetcher] for the proxy config.
@@ -45,27 +47,41 @@ pub fn new(cfg: &config::Config, cert_manager: Arc<SecretManager>) -> Arc<dyn Ce
 struct CertFetcherImpl {
     proxy_mode: ProxyMode,
     local_node: Option<String>,
-    tx: mpsc::Sender<Identity>,
+    tx: mpsc::Sender<Action>,
+}
+
+enum Action {
+    Fetch(Identity),
+    Forget(Identity),
 }
 
 impl CertFetcherImpl {
     fn new(cfg: &config::Config, cert_manager: Arc<SecretManager>) -> Self {
-        let (tx, mut rx) = mpsc::channel::<Identity>(256);
+        let (tx, mut rx) = mpsc::channel::<Action>(256);
 
         // Spawn a task for handling the pre-fetch requests asynchronously.
         tokio::spawn(async move {
-            while let Some(workload_identity) = rx.recv().await {
-                match cert_manager
-                    .fetch_certificate_pri(&workload_identity, Warmup)
-                    .await
-                {
-                    Ok(_) => debug!("prefetched cert for {:?}", workload_identity.to_string()),
-                    Err(e) => error!(
-                        "unable to prefetch cert for {:?}, skipping, {:?}",
-                        workload_identity.to_string(),
-                        e
-                    ),
-                }
+            while let Some(action) = rx.recv().await {
+                match action {
+                    Action::Fetch(workload_identity) => {
+                        match cert_manager
+                            .fetch_certificate_pri(&workload_identity, Warmup)
+                            .await
+                        {
+                            Ok(_) => {
+                                debug!("prefetched cert for {:?}", workload_identity.to_string())
+                            }
+                            Err(e) => error!(
+                                "unable to prefetch cert for {:?}, skipping, {:?}",
+                                workload_identity.to_string(),
+                                e
+                            ),
+                        }
+                    }
+                    Action::Forget(workload_identity) => {
+                        cert_manager.forget_certificate(&workload_identity).await;
+                    }
+                };
             }
         });
 
@@ -92,9 +108,16 @@ impl CertFetcherImpl {
 impl CertFetcher for CertFetcherImpl {
     fn prefetch_cert(&self, w: &Workload) {
         if self.should_prefetch_certificate(w) {
-            if let Err(e) = self.tx.try_send(w.identity()) {
+            if let Err(e) = self.tx.try_send(Action::Fetch(w.identity())) {
                 info!("couldn't prefetch: {:?}", e)
             }
+        }
+    }
+    fn forget(&self, w: &Workload) {
+        info!("forgetting {}", w.identity());
+        if let Err(e) = self.tx.try_send(Action::Forget(w.identity())) {
+            // now we're going to be in trouble though, what else is going to attempt to forget this? should it be async or spawn a task?
+            error!("couldn't forget {} due to {}", w.identity(), e)
         }
     }
 }

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -546,6 +546,15 @@ impl WorkloadStore {
         }
     }
 
+    // checks whether or not the service account associated with a Workload
+    // has another is also associated with another Pod on the node
+    pub fn svc_account_match_on_node(&self, workload: &Workload, node: &str) -> bool {
+        let service_account = workload.service_account.as_str();
+        self.by_uid
+            .values()
+            .any(|w| w.node == node && w.service_account == service_account)
+    }
+
     /// Finds the workload by address.
     pub fn find_address(&self, addr: &NetworkAddress) -> Option<Workload> {
         self.by_addr.get(addr).map(|wl| wl.deref().clone())


### PR DESCRIPTION
fixes #351

Adds and implementation for forgetting certificates during xds removal when no other WL is present on the node which requires the certificate.