### PR TITLE
Explicitly panic (so test actually fails) if we cannot run it

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -1,2 +1,15 @@
 # Use the build container by default
 BUILD_WITH_CONTAINER ?= 1
+
+# Cannot run root tests in container unless the container is privileged,
+# and we cannot/should not run it as privileged by default - so communicate that.
+ifeq ($(TEST_MODE), root)
+    ifeq ($(BUILD_WITH_CONTAINER), 1)
+        $(info ***** NOTE ******)
+        $(info TEST_MODE=root and BUILD_WITH_CONTAINER=1)
+        $(info If you wish to run tests that require root privilege inside the build container,)
+        $(info you must run the container as privileged yourself.)
+        $(info Alternatively, set BUILD_WITH_CONTAINER=0 and run the tests as root outside the build container.)
+        $(info ***** NOTE ******)
+	endif
+endif

--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -7,9 +7,11 @@ ifeq ($(TEST_MODE), root)
     ifeq ($(BUILD_WITH_CONTAINER), 1)
         $(info ***** NOTE ******)
         $(info TEST_MODE=root and BUILD_WITH_CONTAINER=1)
-        $(info If you wish to run tests that require root privilege inside the build container,)
-        $(info you must run the container as privileged yourself.)
-        $(info Alternatively, set BUILD_WITH_CONTAINER=0 and run the tests as root outside the build container.)
+        $(info Running tests as root inside a build container requires running the container in privileged mode)
+        $(info If you are uncomfortable with this or your environment does not allow priviledged containers,)
+        $(info set BUILD_WITH_CONTAINER=0 and run the tests as root outside the build container.)
         $(info ***** NOTE ******)
+		DOCKER_RUN_OPTIONS += --privileged
+		UID = 0
 	endif
 endif

--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -2,7 +2,7 @@
 BUILD_WITH_CONTAINER ?= 1
 
 # Cannot run root tests in container unless the container is privileged,
-# and we cannot/should not run it as privileged by default - so communicate that.
+# so if you set both those flags we will attempt to run the build container as privileged.
 ifeq ($(TEST_MODE), root)
     ifeq ($(BUILD_WITH_CONTAINER), 1)
         $(info ***** NOTE ******)

--- a/src/inpod/config.rs
+++ b/src/inpod/config.rs
@@ -176,7 +176,7 @@ mod test {
 
     macro_rules! fixture {
         () => {{
-            if !crate::test_helpers::can_run_privilged_test() {
+            if !crate::test_helpers::can_run_privileged_test() {
                 panic!("This test requires root - rerun with TEST_MODE=root; skipping");
             }
 

--- a/src/inpod/config.rs
+++ b/src/inpod/config.rs
@@ -177,8 +177,7 @@ mod test {
     macro_rules! fixture {
         () => {{
             if !crate::test_helpers::can_run_privilged_test() {
-                eprintln!("This test requires root; skipping");
-                return;
+                panic!("This test requires root - rerun with TEST_MODE=root; skipping");
             }
 
             crate::config::Config {

--- a/src/inpod/netns.rs
+++ b/src/inpod/netns.rs
@@ -118,8 +118,7 @@ mod tests {
     #[test]
     fn test_run_works() {
         if !crate::test_helpers::can_run_privilged_test() {
-            eprintln!("This test requires root; skipping");
-            return;
+            panic!("This test requires root - rerun with TEST_MODE=root; skipping");
         }
 
         // start with new netns to not impact the current netns

--- a/src/inpod/netns.rs
+++ b/src/inpod/netns.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_run_works() {
-        if !crate::test_helpers::can_run_privilged_test() {
+        if !crate::test_helpers::can_run_privileged_test() {
             panic!("This test requires root - rerun with TEST_MODE=root; skipping");
         }
 

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -340,7 +340,7 @@ mod tests {
 
     macro_rules! fixture {
         () => {{
-            if !crate::test_helpers::can_run_privilged_test() {
+            if !crate::test_helpers::can_run_privileged_test() {
                 panic!("This test requires root - rerun with TEST_MODE=root; skipping");
             }
             let f = test_helpers::Fixture::default();

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -341,8 +341,7 @@ mod tests {
     macro_rules! fixture {
         () => {{
             if !crate::test_helpers::can_run_privilged_test() {
-                eprintln!("This test requires root; skipping");
-                return;
+                panic!("This test requires root - rerun with TEST_MODE=root; skipping");
             }
             let f = test_helpers::Fixture::default();
             let state = WorkloadProxyManagerState::new(

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -355,7 +355,7 @@ pub(crate) mod tests {
 
     macro_rules! fixture {
         () => {{
-            if !crate::test_helpers::can_run_privilged_test() {
+            if !crate::test_helpers::can_run_privileged_test() {
                 panic!("This test requires root - rerun with TEST_MODE=root; skipping");
             }
             let f = test_helpers::Fixture::default();

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -356,7 +356,7 @@ pub(crate) mod tests {
     macro_rules! fixture {
         () => {{
             if !crate::test_helpers::can_run_privilged_test() {
-                panic!("This test requires root; skipping");
+                panic!("This test requires root - rerun with TEST_MODE=root; skipping");
             }
             let f = test_helpers::Fixture::default();
             let state = WorkloadProxyManagerState::new(

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -356,8 +356,7 @@ pub(crate) mod tests {
     macro_rules! fixture {
         () => {{
             if !crate::test_helpers::can_run_privilged_test() {
-                eprintln!("This test requires root; skipping");
-                return;
+                panic!("This test requires root; skipping");
             }
             let f = test_helpers::Fixture::default();
             let state = WorkloadProxyManagerState::new(

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -57,7 +57,7 @@ pub mod linux;
 #[cfg(target_os = "linux")]
 pub mod netns;
 
-pub fn can_run_privilged_test() -> bool {
+pub fn can_run_privileged_test() -> bool {
     let is_root = unsafe { libc::getuid() } == 0;
     if !is_root && std::env::var("CI").is_ok() {
         panic!("CI tests should run as root to have full coverage");

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -60,8 +60,7 @@ mod namespaced {
                 if std::env::var("CI").is_ok() {
                     panic!("CI tests should run as root to have full coverage");
                 }
-                eprintln!("This test requires root; skipping");
-                return Ok(());
+                panic!("This test requires root - rerun with TEST_MODE=root; skipping");
             }
             initialize_telemetry();
             let f = function!()


### PR DESCRIPTION
`eprintln` doesn't actually fail the test in local `cargo test` runs - resulting in the test "silently" being skipped, which is not great if it would actually fail in the required environment.