### PR TITLE
Add waypoint to Service proto definition in WDS

### DIFF
--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -71,6 +71,9 @@ message Service {
   // Optional; if set, the SAN to verify for TLS connections.
   // Typically, this is not set and per-workload identity is used to verify
   repeated string subject_alt_names = 6;
+  // Waypoint is the waypoint proxy for this service. When set, all incoming requests must go
+  // through the waypoint.
+  GatewayAddress waypoint = 7;
 }
 
 // Workload represents a workload - an endpoint (or collection behind a hostname).

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -773,6 +773,7 @@ mod tests {
                 target_port: 80,
             }],
             subject_alt_names: vec!["SAN1".to_string(), "SAN2".to_string()],
+            waypoint: None,
             // ..Default::default() // intentionally don't default. we want all fields populated
         };
 

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -804,6 +804,7 @@ mod tests {
                         target_port: 80,
                     }],
                     subject_alt_names: vec![],
+                    waypoint: None,
                 },
             )
             .unwrap();
@@ -834,6 +835,7 @@ mod tests {
                         target_port: 80,
                     }],
                     subject_alt_names: vec![],
+                    waypoint: None,
                 },
             )
             .unwrap();
@@ -887,6 +889,7 @@ mod tests {
                         target_port: 80,
                     }],
                     subject_alt_names: vec![],
+                    waypoint: None,
                 },
             )
             .unwrap();


### PR DESCRIPTION
This PR extends WDS by adding a waypoint field to the proto definition for Service. Allows representation for svc-addressed waypoint capture.

Completes #816 