### PR TITLE
dns: fix flaky test port reuse

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -120,7 +120,8 @@ pub async fn build_with_cert(
 
     // Optionally create the HBONE proxy.
     let mut proxy_addresses = None;
-    let mut dns_proxy_address: Option<SocketAddr> = None;
+    let mut tcp_dns_proxy_address: Option<SocketAddr> = None;
+    let mut udp_dns_proxy_address: Option<SocketAddr> = None;
 
     let proxy_gen = ProxyFactory::new(
         config.clone(),
@@ -180,7 +181,8 @@ pub async fn build_with_cert(
         match proxies.dns_proxy {
             Some(dns_proxy) => {
                 // Optional
-                dns_proxy_address = Some(dns_proxy.address());
+                tcp_dns_proxy_address = Some(dns_proxy.tcp_address());
+                udp_dns_proxy_address = Some(dns_proxy.udp_address());
 
                 // Run the DNS proxy in the data plane worker pool.
                 let mut xds_rx_for_dns_proxy = xds_rx.clone();
@@ -219,7 +221,8 @@ pub async fn build_with_cert(
         admin_address,
         metrics_address,
         proxy_addresses,
-        dns_proxy_address,
+        tcp_dns_proxy_address,
+        udp_dns_proxy_address,
     })
 }
 
@@ -331,7 +334,8 @@ pub struct Bound {
     pub readiness_address: SocketAddr,
 
     pub proxy_addresses: Option<proxy::Addresses>,
-    pub dns_proxy_address: Option<SocketAddr>,
+    pub tcp_dns_proxy_address: Option<SocketAddr>,
+    pub udp_dns_proxy_address: Option<SocketAddr>,
 
     pub shutdown: signal::Shutdown,
     drain_tx: drain::Signal,

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -44,7 +44,8 @@ pub struct TestApp {
     pub metrics_address: SocketAddr,
     pub readiness_address: SocketAddr,
     pub proxy_addresses: proxy::Addresses,
-    pub dns_proxy_address: Option<SocketAddr>,
+    pub tcp_dns_proxy_address: Option<SocketAddr>,
+    pub udp_dns_proxy_address: Option<SocketAddr>,
     pub cert_manager: Arc<SecretManager>,
 
     pub namespace: Option<super::netns::Namespace>,
@@ -57,7 +58,8 @@ impl From<(&Bound, Arc<SecretManager>)> for TestApp {
             metrics_address: app.metrics_address,
             proxy_addresses: app.proxy_addresses.unwrap(),
             readiness_address: app.readiness_address,
-            dns_proxy_address: app.dns_proxy_address,
+            tcp_dns_proxy_address: app.tcp_dns_proxy_address,
+            udp_dns_proxy_address: app.udp_dns_proxy_address,
             cert_manager,
             namespace: None,
         }
@@ -193,7 +195,11 @@ impl TestApp {
         udp: bool,
         ipv6: bool,
     ) -> hickory_proto::xfer::DnsResponse {
-        let addr = self.dns_proxy_address.unwrap();
+        let addr = if udp {
+            self.udp_dns_proxy_address.unwrap()
+        } else {
+            self.tcp_dns_proxy_address.unwrap()
+        };
         dns_request(addr, hostname, udp, ipv6).await
     }
 }

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -128,8 +128,12 @@ impl WorkloadManager {
                     inbound: helpers::with_ip(proxy_addresses.inbound, ip),
                     socks5: helpers::with_ip(proxy_addresses.socks5, ip),
                 },
-                dns_proxy_address: Some(helpers::with_ip(
-                    app.dns_proxy_address.unwrap_or("0.0.0.0:0".parse()?),
+                tcp_dns_proxy_address: Some(helpers::with_ip(
+                    app.tcp_dns_proxy_address.unwrap_or("0.0.0.0:0".parse()?),
+                    ip,
+                )),
+                udp_dns_proxy_address: Some(helpers::with_ip(
+                    app.udp_dns_proxy_address.unwrap_or("0.0.0.0:0".parse()?),
                     ip,
                 )),
                 cert_manager,


### PR DESCRIPTION
`4467 runs so far, 0 failures (100.00% pass rate). 42.809716ms avg, 127.666155ms max, 24.811437ms min`
Fixes https://github.com/istio/ztunnel/issues/819

cc @MorrisLaw 