### PR TITLE
Revert Add retry backoff to cert refresh (#768)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,17 +239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom 0.2.12",
- "instant",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3774,7 +3763,6 @@ dependencies = [
  "async-stream",
  "async-trait",
  "atty",
- "backoff",
  "base64 0.21.7",
  "boring",
  "boring-rustls-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ anyhow = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"
 atty = "0.2"
-backoff = "0.4.0"
 base64 = "0.21"
 byteorder = "1.5"
 bytes = { version = "1.5", features = ["serde"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -190,17 +190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom 0.2.12",
- "instant",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,7 +3160,6 @@ dependencies = [
  "async-stream",
  "async-trait",
  "atty",
- "backoff",
  "base64 0.21.7",
  "byteorder",
  "bytes",

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -223,24 +223,6 @@ pub mod mock {
             state.fetches.push(id.to_owned());
             Ok(certs)
         }
-
-        pub async fn set_error(&mut self, error: bool) {
-            if error {
-                let mut state = self.state.write().await;
-                state.fetches.push(Identity::Spiffe {
-                    trust_domain: "error".to_string(),
-                    namespace: "error".to_string(),
-                    service_account: "error".to_string(),
-                });
-            } else {
-                let mut state = self.state.write().await;
-                state.fetches.push(Identity::Spiffe {
-                    trust_domain: "success".to_string(),
-                    namespace: "success".to_string(),
-                    service_account: "success".to_string(),
-                });
-            }
-        }
     }
 
     #[async_trait]


### PR DESCRIPTION
It appears that https://github.com/istio/ztunnel/pull/768 has broken the [TestIntermediateCertificateRefresh ](https://github.com/istio/istio/pull/49609) test. This PR reverts that PR https://github.com/istio/istio/pull/49609.