### PR TITLE
metrics: minor improvements, documentation, and stability levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,45 @@ cargo build
 This manual twiddling of environment vars is not ideal but given that the alternative is prefixing `cargo build` with these envs on every `cargo build/run`, for now we have chosen to hardcode these in `config.toml` - that may be revisited in the future depending on local pain and/or evolving `boring` upstream build flows.
 
 Note that the Dockerfiles used to build these vendored `boringssl` builds may be found in the respective vendor directories, and can serve as a reference for the build environment needed to generate FIPS-compliant ztunnel builds.
+
+## Metrics
+
+Ztunnel exposes a variety of metrics, at varying levels of stability.
+
+**Core** metrics are considered stable APIs
+**Unstable** metrics may be changed. This includes removal, semantic changes, and label changes.
+
+### Core metrics
+
+#### Traffic metrics
+
+- Tcp Bytes Sent (`istio_tcp_sent_bytes_total`): This is a `COUNTER` which measures the size of total bytes sent during response in case of a TCP connection.
+- Tcp Bytes Received (`istio_tcp_received_bytes_total`): This is a `COUNTER` which measures the size of total bytes received during request in case of a TCP connection.
+- Tcp Connections Opened (`istio_tcp_connections_opened_total`): This is a `COUNTER` incremented for every opened connection.
+- Tcp Connections Closed (`istio_tcp_connections_closed_total`): This is a `COUNTER` incremented for every closed connection.
+
+#### Meta metrics
+
+-Istio build information (`istio_build`)
+
+### Unstable metrics
+
+#### DNS metrics
+
+- DNS Requests (`istio_dns_requests_total`)
+- DNS Upstream Requests (`istio_dns_upstream_requests_total`)
+- DNS Upstream Failures (`istio_dns_upstream_failures_total`)
+- DNS Upstream Request Duration (`istio_dns_upstream_request_duration_seconds`)
+- On Demand DNS Requests (`istio_on_demand_dns_total`)
+- On Demand DNS Cache Misses (`istio_on_demand_dns_cache_misses_total`)
+
+#### In-Pod metrics
+
+- Active proxy count (`istio_active_proxy_count_total`)
+- Pending proxy count (`istio_pending_proxy_count_total`)
+- Proxies started (`istio_proxies_started_total`)
+- Proxies stopped (`istio_proxies_stopped_total`)
+
+#### XDS metrics
+
+- XDS Connection terminations (`istio_xds_connection_terminations_total`)

--- a/src/dns/metrics.rs
+++ b/src/dns/metrics.rs
@@ -17,7 +17,7 @@ use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram::Histogram;
-use prometheus_client::registry::Registry;
+use prometheus_client::registry::{Registry, Unit};
 use std::time::Duration;
 
 use crate::metrics::{DefaultedUnknown, DeferRecorder, Recorder};
@@ -36,30 +36,31 @@ impl Metrics {
         let requests = Family::default();
         registry.register(
             "dns_requests",
-            "Total number of DNS requests",
+            "Total number of DNS requests (unstable)",
             requests.clone(),
         );
 
         let forwarded_requests = Family::default();
         registry.register(
             "dns_upstream_requests",
-            "Total number of DNS requests forwarded to upstream",
+            "Total number of DNS requests forwarded to upstream (unstable)",
             forwarded_requests.clone(),
         );
 
         let forwarded_failures = Family::default();
         registry.register(
             "dns_upstream_failures",
-            "Total number of DNS requests forwarded to upstream",
+            "Total number of DNS requests forwarded to upstream (unstable)",
             forwarded_failures.clone(),
         );
 
         let forwarded_duration = Family::<DnsLabels, Histogram>::new_with_constructor(|| {
             Histogram::new(vec![0.005f64, 0.001, 0.01, 0.1, 1.0, 5.0].into_iter())
         });
-        registry.register(
-            "dns_upstream_request_duration_seconds",
-            "Total time in seconds Istio takes to get DNS response from upstream",
+        registry.register_with_unit(
+            "dns_upstream_request_duration",
+            "Total time in seconds Istio takes to get DNS response from upstream (unstable)",
+            Unit::Seconds,
             forwarded_duration.clone(),
         );
 

--- a/src/inpod/metrics.rs
+++ b/src/inpod/metrics.rs
@@ -36,22 +36,22 @@ impl Metrics {
         let m = Self::default();
         registry.register(
             "active_proxy_count",
-            "The total number current workloads with active proxies",
+            "The total number current workloads with active proxies (unstable)",
             m.active_proxy_count.clone(),
         );
         registry.register(
             "pending_proxy_count",
-            "The total number current workloads with pending proxies",
+            "The total number current workloads with pending proxies (unstable)",
             m.pending_proxy_count.clone(),
         );
         registry.register(
             "proxies_started",
-            "The total number of proxies that were started",
+            "The total number of proxies that were started (unstable)",
             m.proxies_started.clone(),
         );
         registry.register(
             "proxies_stopped",
-            "The total number of proxies that were stopped",
+            "The total number of proxies that were stopped (unstable)",
             m.proxies_stopped.clone(),
         );
         m

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -317,13 +317,13 @@ impl Metrics {
         let on_demand_dns = Family::default();
         registry.register(
             "on_demand_dns",
-            "The total number of requests that used on-demand DNS",
+            "The total number of requests that used on-demand DNS (unstable)",
             on_demand_dns.clone(),
         );
         let on_demand_dns_cache_misses = Family::default();
         registry.register(
             "on_demand_dns_cache_misses",
-            "The total number of cache misses for requests on-demand DNS",
+            "The total number of cache misses for requests on-demand DNS (unstable)",
             on_demand_dns_cache_misses.clone(),
         );
 

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -308,6 +308,9 @@ impl ParsedMetrics {
         })
         .unwrap_or(0)
     }
+    pub fn metric_info(&self) -> HashMap<String, String> {
+        self.scrape.docs.clone()
+    }
     pub fn dump(&self) -> String {
         self.scrape
             .samples

--- a/src/xds/metrics.rs
+++ b/src/xds/metrics.rs
@@ -40,8 +40,8 @@ impl Metrics {
     pub fn new(registry: &mut Registry) -> Self {
         let connection_terminations = Family::default();
         registry.register(
-            "connection_terminations",
-            "The total number of completed connections to xds server",
+            "xds_connection_terminations",
+            "The total number of completed connections to xds server (unstable)",
             connection_terminations.clone(),
         );
 


### PR DESCRIPTION
* Define stability levels for metrics. Core == istio standard metrics,
  everything else is currently unstable
* Add test for stability
* Add units where applicable
* Add xds_ prefix to XDS metrics to distinguish them
