### PR TITLE
proxy protocol for sandwich

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,6 +2126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d901d7dd743c478e14af9518bdbc33e53e50be56429233f812537f29dbf0d1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "pprof"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,6 +3824,7 @@ dependencies = [
  "nix 0.27.1",
  "oid-registry",
  "once_cell",
+ "ppp",
  "pprof",
  "priority-queue",
  "prometheus-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ libc = "0.2"
 log = "0.4"
 nix = { version = "0.27", features = ["socket", "sched", "uio", "fs", "ioctl", "user"] }
 once_cell = "1.19"
+ppp = "2.2"
 pprof = { version = "0.13", features = ["protobuf", "protobuf-codec", "criterion"] }
 priority-queue = "1.4"
 prometheus-client = { version = "0.22" }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1663,6 +1663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d901d7dd743c478e14af9518bdbc33e53e50be56429233f812537f29dbf0d1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "pprof"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,6 +3211,7 @@ dependencies = [
  "netns-rs",
  "nix 0.27.1",
  "once_cell",
+ "ppp",
  "pprof",
  "priority-queue",
  "prometheus-client",

--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -157,6 +157,12 @@ message Workload {
   // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.
   bool native_tunnel = 14;
 
+  
+  // If an application, such as a sandwiched waypoint proxy, supports
+  // directly receiving information from zTunnel they can set application_protocol.
+  // This supersedes native_tunnel.
+  ApplicationTunnel application_tunnel = 23;
+
   // The services for which this workload is an endpoint.
   // The key is the NamespacedHostname string of the format namespace/hostname.
   map<string, PortList> services = 22;
@@ -210,6 +216,29 @@ enum TunnelProtocol {
   // This does not dictate HTTP/1.1 vs HTTP/2; ALPN should be used for that purpose.
   HBONE = 1;
   // Future options may include things like QUIC/HTTP3, etc.
+}
+
+
+// ApplicationProtocol specifies a workload  (application or gateway) can
+// consume tunnel information.
+message ApplicationTunnel {
+  enum Protocol {
+    // Bytes are copied from the inner stream without modification.
+    NONE = 0;
+
+    // Prepend PROXY protocol headers before copying bytes
+    // Standard PROXY source and destination information
+    // is included, along with potential extra TLV headers:
+    // 0xD0 - The SPIFFE identity of the source workload
+    // 0xD1 - The FQDN or Hostname of the targeted Service
+    PROXY = 1;
+  }
+
+  // A target natively handles this type of traffic.  
+  Protocol protocol = 1;
+
+  // optional: if set, traffic should be sent to this port after the last zTunnel hop
+  uint32 port = 2;
 }
 
 // GatewayAddress represents the address of a gateway

--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -156,13 +156,7 @@ message Workload {
   // * Requests *from* this workload do not need to be tunneled if they already are tunneled by the tunnel_protocol.
   // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.
   bool native_tunnel = 14;
-
-  
-  // If an application, such as a sandwiched waypoint proxy, supports
-  // directly receiving information from zTunnel they can set application_protocol.
-  // This supersedes native_tunnel.
-  ApplicationTunnel application_tunnel = 23;
-
+ 
   // The services for which this workload is an endpoint.
   // The key is the NamespacedHostname string of the format namespace/hostname.
   map<string, PortList> services = 22;
@@ -237,7 +231,8 @@ message ApplicationTunnel {
   // A target natively handles this type of traffic.  
   Protocol protocol = 1;
 
-  // optional: if set, traffic should be sent to this port after the last zTunnel hop
+  // Optional: If set, the inbound zTunnel will send to this port on the upstream.
+  // Otherwise, traffic is sent to the port in the HBONE address.
   uint32 port = 2;
 }
 
@@ -255,6 +250,9 @@ message GatewayAddress {
   // used for sending unauthenticated traffic originating outside the mesh to a waypoint-enabled destination
   // A value of 0 = unset
   uint32 hbone_single_tls_port = 4;
+
+  // (Optional) augment the inner stream upon decapsulation
+  ApplicationTunnel application_tunnel = 5;
 }
 
 // NetworkAddress represents an address bound to a specific network.

--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -156,7 +156,13 @@ message Workload {
   // * Requests *from* this workload do not need to be tunneled if they already are tunneled by the tunnel_protocol.
   // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.
   bool native_tunnel = 14;
- 
+
+  
+  // If an application, such as a sandwiched waypoint proxy, supports
+  // directly receiving information from zTunnel they can set application_protocol.
+  // This supersedes native_tunnel.
+  ApplicationTunnel application_tunnel = 23;
+
   // The services for which this workload is an endpoint.
   // The key is the NamespacedHostname string of the format namespace/hostname.
   map<string, PortList> services = 22;
@@ -231,8 +237,7 @@ message ApplicationTunnel {
   // A target natively handles this type of traffic.  
   Protocol protocol = 1;
 
-  // Optional: If set, the inbound zTunnel will send to this port on the upstream.
-  // Otherwise, traffic is sent to the port in the HBONE address.
+  // optional: if set, traffic should be sent to this port after the last zTunnel hop
   uint32 port = 2;
 }
 
@@ -250,9 +255,6 @@ message GatewayAddress {
   // used for sending unauthenticated traffic originating outside the mesh to a waypoint-enabled destination
   // A value of 0 = unset
   uint32 hbone_single_tls_port = 4;
-
-  // (Optional) augment the inner stream upon decapsulation
-  ApplicationTunnel application_tunnel = 5;
 }
 
 // NetworkAddress represents an address bound to a specific network.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -644,6 +644,7 @@ mod tests {
                 })),
                 hbone_mtls_port: 15008,
                 hbone_single_tls_port: 15003,
+                application_tunnel: None,
             }),
             network_gateway: Some(XdsGatewayAddress {
                 destination: Some(XdsDestination::Address(XdsNetworkAddress {
@@ -652,6 +653,7 @@ mod tests {
                 })),
                 hbone_mtls_port: 15008,
                 hbone_single_tls_port: 15003,
+                application_tunnel: None,
             }),
             tunnel_protocol: Default::default(),
             uid: "uid".to_string(),

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -668,6 +668,7 @@ mod tests {
             cluster_id: "Kubernetes".to_string(),
             authorization_policies: Vec::new(),
             native_tunnel: false,
+            application_tunnel: None,
             workload_type: XdsWorkloadType::Deployment.into(),
             services: HashMap::from([(
                 "ns/svc1.ns.svc.cluster.local".to_string(),

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -644,7 +644,6 @@ mod tests {
                 })),
                 hbone_mtls_port: 15008,
                 hbone_single_tls_port: 15003,
-                application_tunnel: None,
             }),
             network_gateway: Some(XdsGatewayAddress {
                 destination: Some(XdsDestination::Address(XdsNetworkAddress {
@@ -653,7 +652,6 @@ mod tests {
                 })),
                 hbone_mtls_port: 15008,
                 hbone_single_tls_port: 15003,
-                application_tunnel: None,
             }),
             tunnel_protocol: Default::default(),
             uid: "uid".to_string(),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -740,6 +740,7 @@ mod tests {
 
             authorization_policies: Vec::new(),
             native_tunnel: false,
+            application_tunnel: None,
         }
     }
 
@@ -767,6 +768,7 @@ mod tests {
 
             authorization_policies: Vec::new(),
             native_tunnel: false,
+            application_tunnel: None,
         }
     }
 
@@ -815,7 +817,6 @@ mod tests {
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),
-            application_tunnel: None,
         }
     }
 
@@ -827,7 +828,6 @@ mod tests {
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),
-            application_tunnel: None,
         }
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -740,7 +740,6 @@ mod tests {
 
             authorization_policies: Vec::new(),
             native_tunnel: false,
-            application_tunnel: None,
         }
     }
 
@@ -768,7 +767,6 @@ mod tests {
 
             authorization_policies: Vec::new(),
             native_tunnel: false,
-            application_tunnel: None,
         }
     }
 
@@ -817,6 +815,7 @@ mod tests {
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),
+            application_tunnel: None,
         }
     }
 
@@ -828,6 +827,7 @@ mod tests {
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),
+            application_tunnel: None,
         }
     }
 

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -189,7 +189,6 @@ mod tests {
                 src_identity: None,
                 src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(192, 168, 0, 1).into(), 80),
                 dst_network: "".to_string(),
-                dst_network: "".to_string(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),
                     8080,

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -187,7 +187,8 @@ mod tests {
         let rbac_ctx1 = crate::state::ProxyRbacContext {
             conn: Connection {
                 src_identity: None,
-                src_ip: std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+                src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(192, 168, 0, 1).into(), 80),
+                dst_network: "".to_string(),
                 dst_network: "".to_string(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),
@@ -243,7 +244,7 @@ mod tests {
         let rbac_ctx2 = crate::state::ProxyRbacContext {
             conn: Connection {
                 src_identity: None,
-                src_ip: std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 0, 3)),
+                src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(192, 168, 0, 3).into(), 80),
                 dst_network: "".to_string(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),
@@ -300,7 +301,7 @@ mod tests {
         let conn1 = crate::state::ProxyRbacContext {
             conn: Connection {
                 src_identity: None,
-                src_ip: std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+                src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(192, 168, 0, 1).into(), 80),
                 dst_network: "".to_string(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),
@@ -313,7 +314,7 @@ mod tests {
         let conn2 = crate::state::ProxyRbacContext {
             conn: Connection {
                 src_identity: None,
-                src_ip: std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 0, 3)),
+                src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(192, 168, 0, 3).into(), 80),
                 dst_network: "".to_string(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),
@@ -422,7 +423,7 @@ mod tests {
         let conn1 = crate::state::ProxyRbacContext {
             conn: Connection {
                 src_identity: None,
-                src_ip: std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+                src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(192, 168, 0, 1).into(), 80),
                 dst_network: "".to_string(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -189,6 +189,7 @@ mod tests {
                 src_identity: None,
                 src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(192, 168, 0, 1).into(), 80),
                 dst_network: "".to_string(),
+                dst_network: "".to_string(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),
                     8080,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -45,7 +45,7 @@ use crate::state::workload::address::Address;
 use crate::state::workload::application_tunnel::Protocol as AppProtocol;
 use crate::{proxy, tls};
 
-use crate::state::workload::{self, ApplicationTunnel, NetworkAddress, Workload};
+use crate::state::workload::{self, NetworkAddress, Workload};
 use crate::state::DemandProxyState;
 use crate::tls::TlsError;
 
@@ -316,8 +316,8 @@ impl Inbound {
                     }
                 };
 
-                // Determine the next hop (the actual ip/port we'll send to; hbone target may differ)
-                let (upstream_addr, upstream, upstream_service, app_protocol) =
+                // Determine the next hop.
+                let (upstream_addr, upstream, upstream_service) =
                     match Self::find_inbound_upstream(pi.state.clone(), &conn, hbone_addr).await {
                         Ok(res) => res,
                         Err(e) => {
@@ -328,6 +328,19 @@ impl Inbound {
                                 .unwrap());
                         }
                     };
+
+                // Application tunnel may override the port.
+                let (upstream_addr, inbound_protocol) = match upstream.application_tunnel.clone() {
+                    Some(workload::ApplicationTunnel {
+                        port: Some(port),
+                        protocol,
+                    }) => (SocketAddr::new(upstream_addr.ip(), port), protocol),
+                    Some(workload::ApplicationTunnel {
+                        port: None,
+                        protocol,
+                    }) => (upstream_addr, protocol),
+                    None => (upstream_addr, workload::application_tunnel::Protocol::NONE),
+                };
 
                 // Connection has 15008, swap with the real port
                 let conn = Connection {
@@ -422,7 +435,7 @@ impl Inbound {
                     destination_service: ds,
                 };
 
-                let request_type = match app_protocol {
+                let request_type = match inbound_protocol {
                     AppProtocol::PROXY => Proxy(
                         req,
                         (rbac_ctx.conn.src, rbac_ctx.conn.dst),
@@ -469,15 +482,7 @@ impl Inbound {
         state: DemandProxyState,
         conn: &Connection,
         hbone_addr: SocketAddr,
-    ) -> Result<
-        (
-            SocketAddr,
-            Workload,
-            Vec<Service>,
-            workload::application_tunnel::Protocol,
-        ),
-        Error,
-    > {
+    ) -> Result<(SocketAddr, Workload, Vec<Service>), Error> {
         let dst = &NetworkAddress {
             network: conn.dst_network.to_string(),
             address: hbone_addr.ip(),
@@ -488,39 +493,12 @@ impl Inbound {
             let Some((us_wl, us_svc)) = state.fetch_workload_services(dst).await else {
                 return Err(Error::UnknownDestination(hbone_addr.ip()));
             };
-            return Ok((
-                hbone_addr,
-                us_wl,
-                us_svc,
-                workload::application_tunnel::Protocol::NONE,
-            ));
+            return Ok((hbone_addr, us_wl, us_svc));
         }
 
-        if let Some((us_wl, us_svc, app_tunnel)) =
-            Self::find_sandwich_upstream(state, conn, hbone_addr).await
-        {
-            // Application tunnel may override the port.
-            let (upstream_port, inbound_protocol) = match app_tunnel.clone() {
-                // port override
-                Some(workload::ApplicationTunnel {
-                    port: Some(port),
-                    protocol,
-                }) => (port, protocol),
-                // just protocol
-                Some(workload::ApplicationTunnel {
-                    port: None,
-                    protocol,
-                }) => (hbone_addr.port(), protocol),
-                // no app tunnel
-                None => (
-                    hbone_addr.port(),
-                    workload::application_tunnel::Protocol::NONE,
-                ),
-            };
-
-            let next_hop = SocketAddr::new(conn.dst.ip(), upstream_port);
-
-            return Ok((next_hop, us_wl, us_svc, inbound_protocol));
+        if let Some((us_wl, us_svc)) = Self::find_sandwich_upstream(state, conn, hbone_addr).await {
+            let next_hop = SocketAddr::new(conn.dst.ip(), hbone_addr.port());
+            return Ok((next_hop, us_wl, us_svc));
         }
 
         Err(Error::IPMismatch(conn.dst.ip(), hbone_addr.ip()))
@@ -530,7 +508,7 @@ impl Inbound {
         state: DemandProxyState,
         conn: &Connection,
         hbone_addr: SocketAddr,
-    ) -> Option<(Workload, Vec<Service>, Option<ApplicationTunnel>)> {
+    ) -> Option<(Workload, Vec<Service>)> {
         let connection_dst = &NetworkAddress {
             network: conn.dst_network.to_string(),
             address: conn.dst.ip(),
@@ -542,7 +520,7 @@ impl Inbound {
 
         // Outer option tells us whether or not we can retry
         // Some(None) means we have enough information to decide this isn't sandwich
-        let lookup = || {
+        let lookup = || -> Option<Option<(Workload, Vec<Service>)>> {
             let state = state.read();
 
             // TODO Allow HBONE address to be a hostname. We have to respect rules about
@@ -566,20 +544,21 @@ impl Inbound {
             };
 
             // Resolve the reference from our HBONE target
-            let Some(target_waypoint_addr) = state.find_destination(&target_waypoint.destination)
-            else {
+            let target_waypoint = state.find_destination(&target_waypoint.destination);
+
+            let Some(target_waypoint) = target_waypoint else {
                 // don't need to fetch/retry this; we found conn_wl and this must match conn_wl.
                 return Some(None);
             };
 
             // Validate that the HBONE target references the Waypoint we're connecting to
-            Some(match target_waypoint_addr {
+            Some(match target_waypoint {
                 Address::Service(svc) => {
                     if !svc.contains_endpoint(&conn_wl, Some(connection_dst)) {
                         // target points to a different waypoint
                         return Some(None);
                     }
-                    Some((conn_wl, vec![*svc], target_waypoint.application_tunnel))
+                    Some((conn_wl, vec![*svc]))
                 }
                 Address::Workload(wl) => {
                     if !wl.workload_ips.contains(&conn.dst.ip()) {
@@ -587,7 +566,7 @@ impl Inbound {
                         return Some(None);
                     }
                     let svc = state.services.get_by_workload(&wl);
-                    Some((*wl, svc, target_waypoint.application_tunnel))
+                    Some((*wl, svc))
                 }
             })
         };
@@ -677,9 +656,8 @@ mod tests {
             self,
             service::{endpoint_uid, Endpoint, Service},
             workload::{
-                application_tunnel::Protocol as AppProtocol, gatewayaddress::Destination,
-                ApplicationTunnel, GatewayAddress, NamespacedHostname, NetworkAddress, Protocol,
-                Workload,
+                gatewayaddress::Destination, GatewayAddress, NamespacedHostname, NetworkAddress,
+                Protocol, Workload,
             },
             DemandProxyState,
         },
@@ -697,30 +675,18 @@ mod tests {
     const WAYPOINT_POD_IP: &str = "10.0.0.3";
     const WAYPOINT_SVC_IP: &str = "10.10.0.2";
 
-    const PROXY_PORT: u16 = 15088;
-    const TARGET_PORT: u16 = 8080;
-
-    const APP_TUNNEL_PROXY: Option<ApplicationTunnel> = Some(ApplicationTunnel {
-        port: Some(PROXY_PORT),
-        protocol: AppProtocol::PROXY,
-    });
+    const HBONE_TARGET_PORT: u16 = 8080;
 
     // Regular zTunnel workload traffic inbound
-    #[test_case(Waypoint::None, SERVER_POD_IP, SERVER_POD_IP, Some((SERVER_POD_IP, TARGET_PORT)); "to workload no waypoint")]
-    // to workload traffic
-    #[test_case(Waypoint::Workload(WAYPOINT_POD_IP, None), WAYPOINT_POD_IP, SERVER_POD_IP , Some((WAYPOINT_POD_IP, TARGET_PORT)); "to workload with waypoint referenced by pod")]
-    #[test_case(Waypoint::Workload(WAYPOINT_SVC_IP, None), WAYPOINT_POD_IP, SERVER_POD_IP , Some((WAYPOINT_POD_IP, TARGET_PORT)); "to workload with waypoint referenced by vip")]
-    #[test_case(Waypoint::Workload(WAYPOINT_SVC_IP, APP_TUNNEL_PROXY), WAYPOINT_POD_IP, SERVER_POD_IP , Some((WAYPOINT_POD_IP, PROXY_PORT)); "to workload with app tunnel")]
-    // to service traffic
-    #[test_case(Waypoint::Service(WAYPOINT_POD_IP, None), WAYPOINT_POD_IP, SERVER_SVC_IP , Some((WAYPOINT_POD_IP, TARGET_PORT)); "to service with waypoint referenced by pod")]
-    #[test_case(Waypoint::Service(WAYPOINT_SVC_IP, None), WAYPOINT_POD_IP, SERVER_SVC_IP , Some((WAYPOINT_POD_IP, TARGET_PORT)); "to service with waypint referenced by vip")]
-    #[test_case(Waypoint::Service(WAYPOINT_SVC_IP, APP_TUNNEL_PROXY), WAYPOINT_POD_IP, SERVER_SVC_IP , Some((WAYPOINT_POD_IP, PROXY_PORT)); "to service with app tunnel")]
-    // Override port via app_protocol
+    #[test_case(Waypoint::None, SERVER_POD_IP, SERVER_POD_IP , Some((SERVER_POD_IP, HBONE_TARGET_PORT)); "to workload no waypoint")]
+    // Waypoint is referenced directly by Pod IP
+    #[test_case(Waypoint::Workload(WAYPOINT_POD_IP), WAYPOINT_POD_IP, SERVER_POD_IP , Some((WAYPOINT_POD_IP, HBONE_TARGET_PORT)); "to workload with waypoint pod")]
+    #[test_case(Waypoint::Workload(WAYPOINT_SVC_IP), WAYPOINT_POD_IP, SERVER_POD_IP , Some((WAYPOINT_POD_IP, HBONE_TARGET_PORT)); "to workload with waypoint svc")]
+    // Waypoint is referenced through it's service VIP
+    #[test_case(Waypoint::Service(WAYPOINT_POD_IP), WAYPOINT_POD_IP, SERVER_SVC_IP , Some((WAYPOINT_POD_IP, HBONE_TARGET_PORT)); "to service with waypoint pod")]
+    #[test_case(Waypoint::Service(WAYPOINT_SVC_IP), WAYPOINT_POD_IP, SERVER_SVC_IP , Some((WAYPOINT_POD_IP, HBONE_TARGET_PORT)); "to service with waypoint svc")]
     // Error cases
     #[test_case(Waypoint::None, SERVER_POD_IP, CLIENT_POD_IP, None; "to server ip mismatch" )]
-    #[test_case(Waypoint::None, WAYPOINT_POD_IP, CLIENT_POD_IP, None; "to waypoint without attachment" )]
-    #[test_case(Waypoint::Service(WAYPOINT_POD_IP, None), WAYPOINT_POD_IP, SERVER_POD_IP , None; "to workload via waypoint with wrong attachment")]
-    #[test_case(Waypoint::Workload(WAYPOINT_POD_IP, None), WAYPOINT_POD_IP, SERVER_SVC_IP , None; "to service via waypoint with wrong attachment")]
     #[tokio::test]
     async fn test_find_inbound_upstream<'a>(
         target_waypoint: Waypoint<'a>,
@@ -728,17 +694,17 @@ mod tests {
         hbone_dst: &str,
         want: Option<(&str, u16)>,
     ) {
-        let state = setup_test_state(target_waypoint).expect("state setup");
+        let state = test_state(target_waypoint).expect("state setup");
         let conn = Connection {
             src_identity: None,
-            src: format!("{CLIENT_POD_IP}:1234").parse().unwrap(),
+            src: format!("{CLIENT_POD_IP:1234}").parse().unwrap(),
             dst_network: "".to_string(),
             dst: format!("{connection_dst}:15008").parse().unwrap(),
         };
         let res = Inbound::find_inbound_upstream(
             state,
             &conn,
-            format!("{hbone_dst}:{TARGET_PORT}").parse().unwrap(),
+            format!("{hbone_dst}:{HBONE_TARGET_PORT}").parse().unwrap(),
         )
         .await;
 
@@ -753,17 +719,12 @@ mod tests {
         }
     }
 
-    fn setup_test_state(server_waypoint: Waypoint) -> anyhow::Result<state::DemandProxyState> {
+    fn test_state(server_waypoint: Waypoint) -> anyhow::Result<state::DemandProxyState> {
         let mut state = state::ProxyState::default();
 
         let services = vec![
             ("waypoint", WAYPOINT_SVC_IP, WAYPOINT_POD_IP, Waypoint::None),
-            (
-                "server",
-                SERVER_SVC_IP,
-                SERVER_POD_IP,
-                server_waypoint.clone(),
-            ),
+            ("server", SERVER_SVC_IP, SERVER_POD_IP, server_waypoint),
         ]
         .into_iter()
         .map(|(name, vip, ep_ip, waypoint)| {
@@ -833,41 +794,39 @@ mod tests {
     }
 
     // tells the test if we're using workload-attached or svc-attached waypoints
-    #[derive(Clone)]
+    #[derive(Copy, Clone)]
     enum Waypoint<'a> {
         None,
-        Service(&'a str, Option<ApplicationTunnel>),
-        Workload(&'a str, Option<ApplicationTunnel>),
+        Service(&'a str),
+        Workload(&'a str),
     }
 
     impl<'a> Waypoint<'a> {
         fn service_attached(&self) -> Option<GatewayAddress> {
-            let Waypoint::Service(ip, application_tunnel) = self.clone() else {
+            let Waypoint::Service(s) = self else {
                 return None;
             };
             Some(GatewayAddress {
                 destination: Destination::Address(NetworkAddress {
                     network: "".to_string(),
-                    address: ip.parse().expect("a valid waypoint IP"),
+                    address: s.parse().expect("a valid waypoint IP"),
                 }),
                 hbone_mtls_port: 15008,
                 hbone_single_tls_port: None,
-                application_tunnel,
             })
         }
 
         fn workload_attached(&self) -> Option<GatewayAddress> {
-            let Waypoint::Workload(ip, application_tunnel) = self.clone() else {
+            let Waypoint::Workload(s) = self else {
                 return None;
             };
             Some(GatewayAddress {
                 destination: Destination::Address(NetworkAddress {
                     network: "".to_string(),
-                    address: ip.parse().expect("a valid waypoint IP"),
+                    address: s.parse().expect("a valid waypoint IP"),
                 }),
                 hbone_mtls_port: 15008,
                 hbone_single_tls_port: None,
-                application_tunnel,
             })
         }
     }

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -138,7 +138,7 @@ impl InboundPassthrough {
             // Spoofing the source IP only works when the destination or the source are on our node.
             // In this case, the source and the destination might both be remote, so we need to disable it.
             oc.pi.cfg.enable_original_source = Some(false);
-            return oc.proxy_to(inbound, source.ip(), orig, false).await;
+            return oc.proxy_to(inbound, source, orig, false).await;
         }
 
         // We enforce RBAC only for non-hairpin cases. This is because we may not be able to properly
@@ -147,7 +147,7 @@ impl InboundPassthrough {
         // On the inbound HBONE side, we will validate it came from the waypoint (and therefor had enforcemen).
         let conn = rbac::Connection {
             src_identity: None,
-            src_ip: source.ip(),
+            src: source,
             // inbound request must be on our network since this is passthrough
             // rather than HBONE, which can be tunneled across networks through gateways.
             // by definition, without the gateway our source must be on our network.

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -866,7 +866,6 @@ mod tests {
                     )),
                     hbone_mtls_port: 15008,
                     hbone_single_tls_port: 15003,
-                    application_tunnel: None,
                 }),
                 ..Default::default()
             }),
@@ -897,7 +896,6 @@ mod tests {
                     )),
                     hbone_mtls_port: 15008,
                     hbone_single_tls_port: 15003,
-                    application_tunnel: None,
                 }),
                 ..Default::default()
             }),
@@ -935,7 +933,6 @@ mod tests {
                     )),
                     hbone_mtls_port: 15008,
                     hbone_single_tls_port: 15003,
-                    application_tunnel: None,
                 }),
                 ..Default::default()
             }),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -866,6 +866,7 @@ mod tests {
                     )),
                     hbone_mtls_port: 15008,
                     hbone_single_tls_port: 15003,
+                    application_tunnel: None,
                 }),
                 ..Default::default()
             }),
@@ -896,6 +897,7 @@ mod tests {
                     )),
                     hbone_mtls_port: 15008,
                     hbone_single_tls_port: 15003,
+                    application_tunnel: None,
                 }),
                 ..Default::default()
             }),
@@ -933,6 +935,7 @@ mod tests {
                     )),
                     hbone_mtls_port: 15008,
                     hbone_single_tls_port: 15003,
+                    application_tunnel: None,
                 }),
                 ..Default::default()
             }),

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -190,7 +190,7 @@ async fn handle(mut oc: OutboundConnection, mut stream: TcpStream) -> Result<(),
 
     info!("accepted connection from {remote_addr} to {host}");
     tokio::spawn(async move {
-        let res = oc.proxy_to(stream, remote_addr.ip(), host, true).await;
+        let res = oc.proxy_to(stream, remote_addr, host, true).await;
         match res {
             Ok(_) => {}
             Err(ref e) => warn!("outbound proxy failed: {}", e),

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -508,7 +508,7 @@ mod tests {
                 namespace: "a".to_string(),
                 service_account: "account".to_string(),
             }),
-            src: "127.0.0.1:1234".parse.unwrap(),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -508,7 +508,7 @@ mod tests {
                 namespace: "a".to_string(),
                 service_account: "account".to_string(),
             }),
-            src: "127.0.0.1:1234".parse().unwrap(),
+            src: "127.0.0.1:1234".parse.unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -16,7 +16,7 @@ use ipnet::IpNet;
 
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use tracing::{instrument, trace};
 use xds::istio::security::string_match::MatchType;
 use xds::istio::security::Address as XdsAddress;
@@ -42,7 +42,7 @@ pub struct Authorization {
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Connection {
     pub src_identity: Option<Identity>,
-    pub src_ip: IpAddr,
+    pub src: SocketAddr,
     pub dst_network: String,
     pub dst: SocketAddr,
 }
@@ -63,7 +63,7 @@ impl Display for Connection {
         write!(
             f,
             "{}({})->{}",
-            self.src_ip,
+            self.src,
             OptionDisplay(&self.src_identity),
             self.dst
         )
@@ -120,7 +120,7 @@ impl Authorization {
                         "source_ips",
                         &mg.source_ips,
                         &mg.not_source_ips,
-                        |i| i.contains(&conn.src_ip),
+                        |i| i.contains(&conn.src.ip()),
                     );
                     m &= Self::matches_internal(
                         "destination_ports",
@@ -434,7 +434,7 @@ mod tests {
     fn plaintext_conn() -> Connection {
         Connection {
             src_identity: None,
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:8080".parse().unwrap(),
         }
@@ -447,7 +447,7 @@ mod tests {
                 namespace: "namespace".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:8080".parse().unwrap(),
         }
@@ -460,7 +460,7 @@ mod tests {
                 namespace: "ns-alt".to_string(),
                 service_account: "sa=alt".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 3]),
+            src: "127.0.0.3:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.4:9090".parse().unwrap(),
         }
@@ -508,7 +508,7 @@ mod tests {
                 namespace: "a".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse.unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -518,7 +518,7 @@ mod tests {
                 namespace: "b".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -529,7 +529,7 @@ mod tests {
                 namespace: "b".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "remote".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -540,7 +540,7 @@ mod tests {
                 namespace: "bad".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -551,7 +551,7 @@ mod tests {
                 namespace: "b".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:12345".parse().unwrap(),
         }));
@@ -579,7 +579,7 @@ mod tests {
                 namespace: "a".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -589,7 +589,7 @@ mod tests {
                 namespace: "b".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));
@@ -600,7 +600,7 @@ mod tests {
                 namespace: "bad".to_string(),
                 service_account: "account".to_string(),
             }),
-            src_ip: IpAddr::from([127, 0, 0, 1]),
+            src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
             dst: "127.0.0.2:80".parse().unwrap(),
         }));

--- a/src/state.rs
+++ b/src/state.rs
@@ -834,7 +834,10 @@ mod tests {
         let mut ctx = crate::state::ProxyRbacContext {
             conn: rbac::Connection {
                 src_identity: None,
-                src_ip: std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+                src: std::net::SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::new(192, 168, 0, 1),
+                    1234,
+                )),
                 dst_network: "".to_string(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -78,8 +78,6 @@ pub struct GatewayAddress {
     pub destination: gatewayaddress::Destination,
     pub hbone_mtls_port: u16,
     pub hbone_single_tls_port: Option<u16>,
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub application_tunnel: Option<ApplicationTunnel>,
 }
 
 pub mod gatewayaddress {
@@ -175,6 +173,9 @@ pub struct Workload {
 
     #[serde(default, skip_serializing_if = "is_default")]
     pub native_tunnel: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub application_tunnel: Option<ApplicationTunnel>,
+
 
     #[serde(default, skip_serializing_if = "is_default")]
     pub authorization_policies: Vec<String>,
@@ -285,10 +286,6 @@ impl TryFrom<&XdsGatewayAddress> for GatewayAddress {
     type Error = WorkloadError;
 
     fn try_from(value: &xds::istio::workload::GatewayAddress) -> Result<Self, Self::Error> {
-        let application_tunnel = match &value.application_tunnel {
-            Some(ap) => Some(ApplicationTunnel::try_from(ap)?),
-            None => None,
-        };
         let gw_addr: GatewayAddress = match &value.destination {
             Some(a) => match a {
                 xds::istio::workload::gateway_address::Destination::Address(addr) => {
@@ -303,7 +300,6 @@ impl TryFrom<&XdsGatewayAddress> for GatewayAddress {
                         } else {
                             Some(value.hbone_single_tls_port as u16)
                         },
-                        application_tunnel,
                     }
                 }
                 xds::istio::workload::gateway_address::Destination::Hostname(hn) => {
@@ -318,7 +314,6 @@ impl TryFrom<&XdsGatewayAddress> for GatewayAddress {
                         } else {
                             Some(value.hbone_single_tls_port as u16)
                         },
-                        application_tunnel,
                     }
                 }
             },
@@ -340,6 +335,11 @@ impl TryFrom<&XdsWorkload> for Workload {
 
         let network_gw = match &resource.network_gateway {
             Some(w) => Some(GatewayAddress::try_from(w)?),
+            None => None,
+        };
+
+        let application_tunnel = match &resource.application_tunnel {
+            Some(ap) => Some(ApplicationTunnel::try_from(ap)?),
             None => None,
         };
 
@@ -392,6 +392,7 @@ impl TryFrom<&XdsWorkload> for Workload {
             )?),
 
             native_tunnel: resource.native_tunnel,
+            application_tunnel,
 
             authorization_policies: resource.authorization_policies,
 

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -176,7 +176,6 @@ pub struct Workload {
     #[serde(default, skip_serializing_if = "is_default")]
     pub application_tunnel: Option<ApplicationTunnel>,
 
-
     #[serde(default, skip_serializing_if = "is_default")]
     pub authorization_policies: Vec<String>,
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -214,6 +214,7 @@ pub fn test_default_workload() -> Workload {
 
         authorization_policies: Vec::new(),
         native_tunnel: false,
+        application_tunnel: None,
     }
 }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -366,7 +366,6 @@ pub fn local_xds_config(
                     }),
                     hbone_mtls_port: 15008,
                     hbone_single_tls_port: Some(15003),
-                    application_tunnel: None,
                 }),
                 ..test_default_workload()
             },

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -366,6 +366,7 @@ pub fn local_xds_config(
                     }),
                     hbone_mtls_port: 15008,
                     hbone_single_tls_port: Some(15003),
+                    application_tunnel: None,
                 }),
                 ..test_default_workload()
             },

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -238,6 +238,7 @@ impl<'a> TestServiceBuilder<'a> {
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),
+            application_tunnel: None,
         });
         self
     }
@@ -305,6 +306,7 @@ impl<'a> TestWorkloadBuilder<'a> {
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),
+            application_tunnel: None,
         });
         self
     }

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -238,7 +238,6 @@ impl<'a> TestServiceBuilder<'a> {
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),
-            application_tunnel: None,
         });
         self
     }
@@ -306,7 +305,6 @@ impl<'a> TestWorkloadBuilder<'a> {
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),
-            application_tunnel: None,
         });
         self
     }

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -908,7 +908,7 @@ mod tests {
                     let conn = crate::rbac::Connection{
                         dst: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),
                         src_identity: None,
-                        src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),                        dst_network: "".to_string(),
+                        src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),
                         dst_network: "".to_string(),
                     };
                     let rbac_ctx = crate::state::ProxyRbacContext {

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -908,7 +908,7 @@ mod tests {
                     let conn = crate::rbac::Connection{
                         dst: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),
                         src_identity: None,
-                        src_ip: std::net::Ipv4Addr::new(1, 2,3, 5).into(),
+                        src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),                        dst_network: "".to_string(),
                         dst_network: "".to_string(),
                     };
                     let rbac_ctx = crate::state::ProxyRbacContext {

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -908,7 +908,7 @@ mod tests {
                     let conn = crate::rbac::Connection{
                         dst: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),
                         src_identity: None,
-                        src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),
+                        src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),                        dst_network: "".to_string(),
                         dst_network: "".to_string(),
                     };
                     let rbac_ctx = crate::state::ProxyRbacContext {


### PR DESCRIPTION
We add `ApplicationTunnel` as an optional piece of `GatewayAddress` to allow more advanced sandwiches:

* It's possible that a sandwiched waypoint wants additional info like PROXY protocol
* It's possible that the sandwiched waypoint binds to a different port than the HBONE address targets

