### PR TITLE
admin: add connection info dump

### DIFF
--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -50,6 +50,15 @@ impl EncodeLabelValue for Identity {
     }
 }
 
+impl serde::Serialize for Identity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
 impl FromStr for Identity {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -254,7 +254,8 @@ impl WorkloadProxyManagerState {
 
         let uid = workload_uid.clone();
 
-        self.admin_handler.proxy_up(&uid);
+        self.admin_handler
+            .proxy_up(&uid, proxies.connection_manager);
 
         let metrics = self.metrics.clone();
         let admin_handler = self.admin_handler.clone();

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -175,7 +175,7 @@ impl Inbound {
                 trace!(dur=?start.elapsed(), "connected to: {addr}");
                 tokio::task::spawn(
                     (async move {
-                        let close = match connection_manager.track(&rbac_ctx).await {
+                        let close = match connection_manager.track(&rbac_ctx) {
                             Some(c) => c,
                             None => {
                                 // if track returns None it means the connection was closed due to policy change
@@ -271,7 +271,7 @@ impl Inbound {
                                 }
                             }
                         }
-                        connection_manager.release(&rbac_ctx).await;
+                        connection_manager.release(&rbac_ctx);
                     })
                     .in_current_span(),
                 );
@@ -362,12 +362,12 @@ impl Inbound {
                 };
 
                 //register before assert_rbac to ensure the connection is tracked during it's entire valid span
-                connection_manager.register(&rbac_ctx).await;
+                connection_manager.register(&rbac_ctx);
                 if from_waypoint {
                     debug!("request from waypoint, skipping policy");
                 } else if !pi.state.assert_rbac(&rbac_ctx).await {
                     info!(%rbac_ctx.conn, "RBAC rejected");
-                    connection_manager.release(&rbac_ctx).await;
+                    connection_manager.release(&rbac_ctx);
                     return Ok(Response::builder()
                         .status(StatusCode::UNAUTHORIZED)
                         .body(Empty::new())
@@ -377,7 +377,7 @@ impl Inbound {
                 // We should express as policy whether or not traffic is allowed to bypass a waypoint
                 if has_waypoint && !from_waypoint {
                     info!(%rbac_ctx.conn, "bypassed waypoint");
-                    connection_manager.release(&rbac_ctx).await;
+                    connection_manager.release(&rbac_ctx);
                     return Ok(Response::builder()
                         .status(StatusCode::UNAUTHORIZED)
                         .body(Empty::new())

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -197,9 +197,9 @@ impl OutboundConnection {
                 // Note that fastpath is disabled in the inpod mode, so that's not a concern.
                 dest_workload_info: None,
             };
-            self.pi.connection_manager.register(&rbac_ctx).await;
+            self.pi.connection_manager.register(&rbac_ctx);
             if !self.pi.state.assert_rbac(&rbac_ctx).await {
-                self.pi.connection_manager.release(&rbac_ctx).await;
+                self.pi.connection_manager.release(&rbac_ctx);
                 info!(%rbac_ctx, "RBAC rejected");
                 return Err(Error::HttpStatus(StatusCode::UNAUTHORIZED));
             }

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -91,15 +91,17 @@ impl ProxyFactory {
 
         // Optionally create the HBONE proxy.
         if self.config.proxy {
+            let cm = ConnectionManager::default();
             let pi = crate::proxy::ProxyInputs::new(
                 self.config.clone(),
                 self.cert_manager.clone(),
-                ConnectionManager::default(),
+                cm.clone(),
                 self.state.clone(),
                 self.proxy_metrics.clone().unwrap(),
                 socket_factory.clone(),
                 proxy_workload_info,
             );
+            result.connection_manager = Some(cm);
             result.proxy = Some(Proxy::from_inputs(pi, drain.clone()).await?);
         }
 
@@ -127,4 +129,5 @@ impl ProxyFactory {
 pub struct ProxyResult {
     pub proxy: Option<Proxy>,
     pub dns_proxy: Option<dns::Server>,
+    pub connection_manager: Option<ConnectionManager>,
 }

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -39,12 +39,12 @@ pub struct Authorization {
     pub rules: Vec<Vec<Vec<RbacMatch>>>,
 }
 
-#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
 pub struct Connection {
-    pub src_identity: Option<Identity>,
     pub src: SocketAddr,
-    pub dst_network: String,
     pub dst: SocketAddr,
+    pub src_identity: Option<Identity>,
+    pub dst_network: String,
 }
 
 struct OptionDisplay<'a, T>(&'a Option<T>);

--- a/src/state.rs
+++ b/src/state.rs
@@ -73,7 +73,7 @@ impl fmt::Display for Upstream {
 
 // Workload information that a specific proxy instance represents. This is used to cross check
 // with the workload fetched using destination address when making RBAC decisions.
-#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
 pub struct WorkloadInfo {
     pub name: String,
     pub namespace: String,
@@ -114,9 +114,10 @@ impl WorkloadInfo {
     }
 }
 
-#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
 pub struct ProxyRbacContext {
     pub conn: rbac::Connection,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub dest_workload_info: Option<Arc<WorkloadInfo>>,
 }
 


### PR DESCRIPTION
Example:
```json
{
  "dd03d501-825e-4fa9-b0c4-b31348219a11": {
    "state": "Up",
    "connections": []
  },
  "beb72dff-67bb-44f0-9edc-59d7a1dda275": {
    "state": "Up",
    "connections": [
      {
        "conn": {
          "src": "10.244.2.9:55393",
          "dst": "10.244.2.7:9090",
          "src_identity": "spiffe://cluster.local/ns/default/sa/default",
          "dst_network": ""
        }
      }
    ]
  },
  "432c28a6-4b03-4677-9777-242c4a437ef0": {
    "state": "Up",
    "connections": [
      {
        "conn": {
          "src": "10.244.2.9:53029",
          "dst": "10.244.2.10:80",
          "src_identity": "spiffe://cluster.local/ns/default/sa/default",
          "dst_network": ""
        }
      }
    ]
  }
}
```

Fixes https://github.com/istio/ztunnel/issues/84

There is a lot of changes from making the mutex use `std` mutex; tokio mutex is not needed since we never hold it across an `await` point