### PR TITLE
Implement outbound drain

### DIFF
--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -146,12 +146,18 @@ impl Pool {
                     request_sender
                 }
                 // Connect won, checkout can just be dropped.
-                Either::Right((Err(err), checkout)) => match err {
-                    // Connect won but we already had an in-flight connection, so use that.
-                    Error::PoolAlreadyConnecting => checkout.await?,
-                    // Some other connection error
-                    err => return Err(err),
-                },
+                Either::Right((Err(err), checkout)) => {
+                    debug!(
+                        ?key,
+                        "connect won, but wait for existing pooled connection to establish"
+                    );
+                    match err {
+                        // Connect won but we already had an in-flight connection, so use that.
+                        Error::PoolAlreadyConnecting => checkout.await?,
+                        // Some other connection error
+                        err => return Err(err),
+                    }
+                }
             };
 
         Ok(Connection(request_sender))


### PR DESCRIPTION
Similar to https://github.com/istio/ztunnel/pull/894 - there are some other `spawns` that we need to guarantee terminate, to avoid stuck tasks.

Most of these are in Outbound, which unlike the others never really had per-connection drain.

This adds drains such that all outbound `spawns` are guaranteed to terminate when the workload is drained, this avoids several scenarios where task leaks are possible.


What we _really_ need beyond this PR is something like a `drain_type` and more complex drain channels:

- Drain(reason: workload gone) -> workload gone, don't wait for connections to "unstick" - just drop.
- Drain(reason: proxy terminating) -> workloads are not gone, but whole proxy is going - start refusing conns and give workloads a grace period.

This PR is just a stopgap to handle some workload termination corner cases.