### PR TITLE
inbound: drop logic to spoof IP from Forwarded

### DIFF
--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -400,15 +400,7 @@ impl Inbound {
                         .body(Empty::new())
                         .expect("builder with known status code should not fail"));
                 }
-                let source_ip = if from_waypoint {
-                    // If the request is from our waypoint, trust the Forwarded header.
-                    // For other request types, we can only trust the source from the connection.
-                    // Since our own waypoint is in the same trust domain though, we can use Forwarded,
-                    // which drops the requirement of spoofing IPs from waypoints
-                    super::get_original_src_from_fwded(&req).unwrap_or(rbac_ctx.conn.src.ip())
-                } else {
-                    rbac_ctx.conn.src.ip()
-                };
+                let source_ip = rbac_ctx.conn.src.ip();
 
                 let baggage =
                     parse_baggage_header(req.headers().get_all(BAGGAGE_HEADER)).unwrap_or_default();


### PR DESCRIPTION
This logic never was actually used as Envoy did not send Forwarded.
Additionally, the `from_waypoint` stuff is murky now with the new plans,
and is being removed (https://github.com/istio/ztunnel/pull/873).

We don't ever want to impement this in Envoy, either, since it breaks
connection pooling
