### PR TITLE
outbound: add request builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,6 +3226,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-builder"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444d8748011b93cb168770e8092458cb0f8854f931ff82fdf6ddfbd72a9c933e"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563b3b88238ec95680aef36bdece66896eaa7ce3c0f1b4f39d38fb2435261352"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3729,6 +3749,7 @@ dependencies = [
  "tower-hyper-http-body-compat",
  "tracing",
  "tracing-subscriber",
+ "typed-builder",
  "url",
  "x509-parser",
  "ztunnel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "j
 url = "2.2"
 x509-parser = { version = "0.16", default-features = false }
 backoff = "0.4.0"
+typed-builder = "0.18.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"


### PR DESCRIPTION
Fix #846 

Introduce typed-builder to reduce builder codes and make all struct easy to build.