### PR TITLE
admin: add workload info to admin dump

### DIFF
--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -229,7 +229,8 @@ impl WorkloadProxyManagerState {
                 return Ok(());
             }
         }
-        self.admin_handler.proxy_pending(workload_uid);
+        self.admin_handler
+            .proxy_pending(workload_uid, workload_info);
 
         debug!(
             workload=?workload_uid,
@@ -255,7 +256,7 @@ impl WorkloadProxyManagerState {
         let uid = workload_uid.clone();
 
         self.admin_handler
-            .proxy_up(&uid, proxies.connection_manager);
+            .proxy_up(&uid, workload_info, proxies.connection_manager);
 
         let metrics = self.metrics.clone();
         let admin_handler = self.admin_handler.clone();

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::proxy::error;
+use crate::rbac;
 use crate::state::DemandProxyState;
 use crate::state::ProxyRbacContext;
 use drain;
@@ -127,6 +128,19 @@ impl ConnectionManager {
         // potentially large copy under read lock, could require optimization
         self.drains.read().expect("mutex").keys().cloned().collect()
     }
+
+    // get a dump (for admin API) for connects.
+    // This just avoids the redundant dest_workload_info
+    pub fn connections_dump(&self) -> Vec<rbac::Connection> {
+        // potentially large copy under read lock, could require optimization
+        self.drains
+            .read()
+            .expect("mutex")
+            .keys()
+            .cloned()
+            .map(|c| c.conn)
+            .collect()
+    }
 }
 
 impl Serialize for ConnectionManager {
@@ -134,7 +148,7 @@ impl Serialize for ConnectionManager {
     where
         S: Serializer,
     {
-        let conns = self.connections();
+        let conns = self.connections_dump();
         conns.serialize(serializer)
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -73,7 +73,9 @@ impl fmt::Display for Upstream {
 
 // Workload information that a specific proxy instance represents. This is used to cross check
 // with the workload fetched using destination address when making RBAC decisions.
-#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[derive(
+    Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize,
+)]
 pub struct WorkloadInfo {
     pub name: String,
     pub namespace: String,


### PR DESCRIPTION
```json
{
  "e9b1427c-b15c-4ad5-bc1d-dfb0d6486890": {
    "state": "Up",
    "connections": [],
    "info": {
      "name": "echo-8659868fcc-pq5h6",
      "namespace": "default",
      "trust_domain": "cluster.local",
      "service_account": "default"
    }
  },
  "5fdb1d99-0446-4cf1-9e34-36a85e5b50a5": {
    "state": "Up",
    "connections": [],
    "info": {
      "name": "echo-8659868fcc-zr9k7",
      "namespace": "default",
      "trust_domain": "cluster.local",
      "service_account": "default"
    }
  },
  "0fa4017f-8d82-4b6f-97bb-e610a9a81069": {
    "state": "Up",
    "connections": [],
    "info": {
      "name": "shell-6d8bcd654d-tznvt",
      "namespace": "default",
      "trust_domain": "cluster.local",
      "service_account": "default"
    }
  }
}
```
is the new current result
