### PR TITLE
Periodic metrics reporting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-#patch = { crates-io = { realm_io = { path = "/home/john/.rhack/realm_io-0.4.0" } } }
 [package]
 name = "ztunnel"
 version = "0.0.0"
@@ -76,7 +75,7 @@ prost = "0.12"
 prost-types = "0.12"
 rand = "0.8"
 rcgen = { version = "0.13", optional = true, features = ["pem"] }
-realm_io = { version = "0.4" , features = ["statistic"]}
+realm_io = "0.4"
 rustls = { version = "0.23", default-features = false }
 rustls-native-certs = "0.7.0"
 rustls-pemfile = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+#patch = { crates-io = { realm_io = { path = "/home/john/.rhack/realm_io-0.4.0" } } }
 [package]
 name = "ztunnel"
 version = "0.0.0"
@@ -75,7 +76,7 @@ prost = "0.12"
 prost-types = "0.12"
 rand = "0.8"
 rcgen = { version = "0.13", optional = true, features = ["pem"] }
-realm_io = "0.4"
+realm_io = { version = "0.4" , features = ["statistic"]}
 rustls = { version = "0.23", default-features = false }
 rustls-native-certs = "0.7.0"
 rustls-pemfile = "2.1"

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -290,7 +290,7 @@ pub enum Error {
 }
 
 // TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
-const HBONE_BUFFER_SIZE: usize = 16_384 - 64;
+pub const HBONE_BUFFER_SIZE: usize = 16_384 - 64;
 
 pub async fn copy_hbone(
     upgraded: &mut hyper::upgrade::Upgraded,
@@ -368,7 +368,7 @@ struct CopyBuf<'a, R: ?Sized, W: ?Sized> {
     amt: u64,
 }
 
-async fn copy_buf<'a, R, W>(reader: &'a mut R, writer: &'a mut W, x: &ConnectionResult, send: bool) -> io::Result<u64>
+pub async fn copy_buf<'a, R, W>(reader: &'a mut R, writer: &'a mut W, x: &ConnectionResult, send: bool) -> io::Result<u64>
 where
     R: tokio::io::AsyncBufRead + Unpin + ?Sized,
     W: tokio::io::AsyncWrite + Unpin + ?Sized,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -290,7 +290,7 @@ pub enum Error {
 }
 
 // TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
-pub const HBONE_BUFFER_SIZE: usize = 16_384 - 64;
+const HBONE_BUFFER_SIZE: usize = 16_384 - 64;
 
 pub async fn copy_hbone(
     upgraded: &mut hyper::upgrade::Upgraded,
@@ -368,7 +368,7 @@ struct CopyBuf<'a, R: ?Sized, W: ?Sized> {
     amt: u64,
 }
 
-pub async fn copy_buf<'a, R, W>(reader: &'a mut R, writer: &'a mut W, x: &ConnectionResult, send: bool) -> io::Result<u64>
+async fn copy_buf<'a, R, W>(reader: &'a mut R, writer: &'a mut W, x: &ConnectionResult, send: bool) -> io::Result<u64>
 where
     R: tokio::io::AsyncBufRead + Unpin + ?Sized,
     W: tokio::io::AsyncWrite + Unpin + ?Sized,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -17,15 +17,10 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, io};
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 use drain::Watch;
-use futures_core::ready;
 
 use rand::Rng;
-use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite};
 
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::time::timeout;
@@ -289,131 +284,6 @@ pub enum Error {
     IPMismatch(IpAddr, IpAddr),
 }
 
-// TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
-const HBONE_BUFFER_SIZE: usize = 16_384 - 64;
-
-pub async fn copy_hbone(
-    upgraded: &mut hyper::upgrade::Upgraded,
-    stream: &mut TcpStream,
-) -> Result<(u64, u64), Error> {
-    use tokio::io::AsyncWriteExt;
-    let (mut ri, mut wi) = tokio::io::split(hyper_util::rt::TokioIo::new(upgraded));
-    let (mut ro, mut wo) = stream.split();
-
-    let (mut sent, mut received): (u64, u64) = (0, 0);
-
-    let client_to_server = async {
-        let mut ri = tokio::io::BufReader::with_capacity(HBONE_BUFFER_SIZE, &mut ri);
-        let res = tokio::io::copy_buf(&mut ri, &mut wo).await;
-        trace!(?res, "hbone -> tcp");
-        received = res?;
-        wo.shutdown().await
-    };
-
-    let server_to_client = async {
-        let mut ro = tokio::io::BufReader::with_capacity(HBONE_BUFFER_SIZE, &mut ro);
-        let res = tokio::io::copy_buf(&mut ro, &mut wi).await;
-        trace!(?res, "tcp -> hbone");
-        sent = res?;
-        wi.shutdown().await
-    };
-
-    tokio::try_join!(client_to_server, server_to_client)?;
-
-    trace!(sent, recv = received, "copy hbone complete");
-    Ok((sent, received))
-}
-
-pub async fn copy_hbone2<A, B>(
-    upgraded: &mut A,
-    stream: &mut B,
-    x: &ConnectionResult,
-) -> Result<(u64, u64), Error> where
-A: AsyncRead + AsyncWrite+ Unpin ,
-B: AsyncRead + AsyncWrite+ Unpin , {
-    use tokio::io::AsyncWriteExt;
-    let (mut ri, mut wi) = tokio::io::split(upgraded);
-    let (mut ro, mut wo) = tokio::io::split(stream);
-
-    let (mut sent, mut received): (u64, u64) = (0, 0);
-
-    let client_to_server = async {
-        let mut ri = tokio::io::BufReader::with_capacity(HBONE_BUFFER_SIZE, &mut ri);
-        let res = copy_buf(&mut ri, &mut wo, &x, false).await;
-        trace!(?res, "hbone -> tcp");
-        received = res?;
-        wo.shutdown().await
-    };
-
-    let server_to_client = async {
-        let mut ro = tokio::io::BufReader::with_capacity(HBONE_BUFFER_SIZE, &mut ro);
-        let res = copy_buf(&mut ro, &mut wi, x, true).await;
-        trace!(?res, "tcp -> hbone");
-        sent = res?;
-        wi.shutdown().await
-    };
-
-    tokio::try_join!(client_to_server, server_to_client)?;
-
-    trace!(sent, recv = received, "copy hbone complete");
-    Ok((sent, received))
-}
-
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-struct CopyBuf<'a, R: ?Sized, W: ?Sized> {
-    send: bool,
-    reader: &'a mut R,
-    writer: &'a mut W,
-    x: &'a ConnectionResult,
-    amt: u64,
-}
-
-async fn copy_buf<'a, R, W>(reader: &'a mut R, writer: &'a mut W, x: &ConnectionResult, send: bool) -> io::Result<u64>
-where
-    R: tokio::io::AsyncBufRead + Unpin + ?Sized,
-    W: tokio::io::AsyncWrite + Unpin + ?Sized,
-{
-    CopyBuf {
-        send,
-        reader,
-        writer,
-        x,
-        amt: 0,
-    }
-    .await
-}
-
-impl<R, W> Future for CopyBuf<'_, R, W>
-    where
-        R: AsyncBufRead + Unpin + ?Sized,
-        W: AsyncWrite + Unpin + ?Sized,
-{
-    type Output = io::Result<u64>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        loop {
-            let me = &mut *self;
-            let buffer = ready!(Pin::new(&mut *me.reader).poll_fill_buf(cx))?;
-            if buffer.is_empty() {
-                ready!(Pin::new(&mut self.writer).poll_flush(cx))?;
-                return Poll::Ready(Ok(self.amt));
-            }
-
-            let i = ready!(Pin::new(&mut *me.writer).poll_write(cx, buffer))?;
-            if i == 0 {
-                return Poll::Ready(Err(std::io::ErrorKind::WriteZero.into()));
-            }
-            if me.send {
-                me.x.increment_send(i as u64);
-            } else {
-                me.x.increment_recv(i as u64);
-            }
-            self.amt += i as u64;
-            Pin::new(&mut *self.reader).consume(i);
-        }
-    }
-}
-
 const PROXY_PROTOCOL_AUTHORITY_TLV: u8 = 0xD0;
 
 pub async fn write_proxy_protocol<T>(
@@ -586,19 +456,6 @@ pub async fn freebind_connect(
     timeout(CONNECTION_TIMEOUT, connect(local, addr, socket_factory))
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::TimedOut, e))?
-}
-
-pub async fn relay(
-    downstream: &mut TcpStream,
-    upstream: &mut TcpStream,
-) -> Result<(u64, u64), Error> {
-    match socket::relay(downstream, upstream).await {
-        Ok(transferred) => {
-            trace!(sent = transferred.0, recv = transferred.1, "relay complete");
-            Ok(transferred)
-        }
-        Err(e) => Err(Error::Io(e)),
-    }
 }
 
 // guess_inbound_service selects an upstream service for inbound metrics.

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -219,7 +219,7 @@ impl InboundPassthrough {
                     .map_err(Error::ConnectionFailed)?;
 
             trace!(%source_addr, destination=%dest_addr, component="inbound plaintext", "connected");
-            socket::copy_bidirectional( &mut inbound_stream, &mut outbound, &result_tracker).await
+            socket::copy_bidirectional(&mut inbound_stream, &mut outbound, &result_tracker).await
         };
 
         let res = tokio::select! {

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -22,7 +22,7 @@ use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::registry::Registry;
 
-use tracing::event;
+use tracing::{error, event};
 
 use crate::identity::Identity;
 use crate::metrics::{DefaultedUnknown, DeferRecorder, Deferred, IncrementRecorder, Recorder};
@@ -461,47 +461,47 @@ impl ConnectionResult {
 
     pub fn increment_send(&self, res: u64) {
         let tl = &self.tl;
-
+        error!("increment send {:?} {res}", tl.reporter);
         // If the connection succeeded, record bytes sent/recv
         if &tl.reporter == &Reporter::source {
             // Istio flips the metric for source: https://github.com/istio/istio/issues/32399
-            self.metrics.received_bytes.get_or_create(&tl).inc_by(res);
+            self.metrics.received_bytes.get_or_create(tl).inc_by(res);
         } else {
-            self.metrics.sent_bytes.get_or_create(&tl).inc_by(res);
+            self.metrics.sent_bytes.get_or_create(tl).inc_by(res);
         }
     }
     pub fn increment_recv(&self, res: u64) {
         let tl = &self.tl;
-
+        error!("increment recv {:?} {res}", tl.reporter);
         // If the connection succeeded, record bytes sent/recv
         if &tl.reporter == &Reporter::source {
             // Istio flips the metric for source: https://github.com/istio/istio/issues/32399
-            self.metrics.sent_bytes.get_or_create(&tl).inc_by(res);
+            self.metrics.sent_bytes.get_or_create(tl).inc_by(res);
         } else {
-            self.metrics.received_bytes.get_or_create(&tl).inc_by(res);
+            self.metrics.received_bytes.get_or_create(tl).inc_by(res);
         }
     }
-    pub fn record<E: std::error::Error>(self, res: Result<(u64, u64), E>) {
-        let tl = self.tl;
+    pub fn record<E: std::error::Error>(&self, res: Result<(u64, u64), E>) {
+        let tl = &self.tl;
 
         // Unconditionally record the connection was closed
-        self.metrics.connection_close.get_or_create(&tl).inc();
+        self.metrics.connection_close.get_or_create(tl).inc();
 
         // If the connection succeeded, record bytes sent/recv
-        if let Ok((sent, recv)) = res {
-            let (sent, recv) = if tl.reporter == Reporter::source {
-                // Istio flips the metric for source: https://github.com/istio/istio/issues/32399
-                (recv, sent)
-            } else {
-                (sent, recv)
-            };
-            if sent != 0 {
-                self.metrics.sent_bytes.get_or_create(&tl).inc_by(sent);
-            }
-            if recv != 0 {
-                self.metrics.received_bytes.get_or_create(&tl).inc_by(recv);
-            }
-        }
+        // if let Ok((sent, recv)) = res {
+        //     let (sent, recv) = if &tl.reporter == &Reporter::source {
+        //         // Istio flips the metric for source: https://github.com/istio/istio/issues/32399
+        //         (recv, sent)
+        //     } else {
+        //         (sent, recv)
+        //     };
+        //     if sent != 0 {
+        //         self.metrics.sent_bytes.get_or_create(&tl).inc_by(sent);
+        //     }
+        //     if recv != 0 {
+        //         self.metrics.received_bytes.get_or_create(&tl).inc_by(recv);
+        //     }
+        // }
 
         // Unconditionally write out an access log
         let mtls = tl.connection_security_policy == SecurityPolicy::mutual_tls;

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -459,6 +459,28 @@ impl ConnectionResult {
         }
     }
 
+    pub fn increment_send(&self, res: u64) {
+        let tl = &self.tl;
+
+        // If the connection succeeded, record bytes sent/recv
+        if &tl.reporter == &Reporter::source {
+            // Istio flips the metric for source: https://github.com/istio/istio/issues/32399
+            self.metrics.received_bytes.get_or_create(&tl).inc_by(res);
+        } else {
+            self.metrics.sent_bytes.get_or_create(&tl).inc_by(res);
+        }
+    }
+    pub fn increment_recv(&self, res: u64) {
+        let tl = &self.tl;
+
+        // If the connection succeeded, record bytes sent/recv
+        if &tl.reporter == &Reporter::source {
+            // Istio flips the metric for source: https://github.com/istio/istio/issues/32399
+            self.metrics.sent_bytes.get_or_create(&tl).inc_by(res);
+        } else {
+            self.metrics.received_bytes.get_or_create(&tl).inc_by(res);
+        }
+    }
     pub fn record<E: std::error::Error>(self, res: Result<(u64, u64), E>) {
         let tl = self.tl;
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -394,8 +394,8 @@ impl OutboundConnection {
         let upgraded = hyper::upgrade::on(response).await?;
 
         socket::copy_bidirectional(
-            &mut ::hyper_util::rt::TokioIo::new(upgraded),
             stream,
+            &mut ::hyper_util::rt::TokioIo::new(upgraded),
             connection_stats,
         )
         .instrument(trace_span!("hbone client"))
@@ -423,7 +423,7 @@ impl OutboundConnection {
         let mut outbound =
             super::freebind_connect(local, req.gateway, self.pi.socket_factory.as_ref()).await?;
         // Proxying data between downstream and upstream
-        socket::copy_bidirectional(&mut outbound, stream, connection_stats).await
+        socket::copy_bidirectional(stream, &mut outbound, connection_stats).await
     }
 
     fn conn_metrics_from_request(req: &Request) -> ConnectionOpen {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use futures_core::ready;
+use std::future::Future;
 use std::io::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use tokio::io;
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite};
 use tokio::net::TcpListener;
 use tokio::net::TcpSocket;
+use tracing::trace;
 
+use crate::proxy::ConnectionResult;
 #[cfg(target_os = "linux")]
 use {
-    realm_io,
     socket2::{Domain, SockRef},
     std::io::ErrorKind,
     tracing::warn,
@@ -166,26 +172,102 @@ mod linux {
     }
 }
 
-#[cfg(target_os = "linux")]
-pub async fn relay(
-    downstream: &mut tokio::net::TcpStream,
-    upstream: &mut tokio::net::TcpStream,
-) -> Result<(u64, u64), Error> {
-    const EINVAL: i32 = 22;
+// TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
+const BUFFER_SIZE: usize = 16_384 - 64;
 
-    match realm_io::bidi_zero_copy(downstream, upstream).await {
-        Ok(d) => Ok(d),
-        Err(ref e) if e.raw_os_error().map_or(false, |ec| ec == EINVAL) => {
-            tokio::io::copy_bidirectional(downstream, upstream).await
-        }
-        Err(e) => Err(e),
-    }
+pub async fn copy_bidirectional<A, B>(
+    downstream: &mut A,
+    upstream: &mut B,
+    stats: &ConnectionResult,
+) -> Result<(u64, u64), crate::proxy::Error>
+where
+    A: AsyncRead + AsyncWrite + Unpin,
+    B: AsyncRead + AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncWriteExt;
+    let (mut rd, mut wd) = tokio::io::split(downstream);
+    let (mut ru, mut wu) = tokio::io::split(upstream);
+
+    let (mut sent, mut received): (u64, u64) = (0, 0);
+
+    let downstream_to_upstream = async {
+        let mut rd = io::BufReader::with_capacity(BUFFER_SIZE, &mut rd);
+        let res = copy_buf(&mut rd, &mut wu, stats, false).await;
+        trace!(?res, "downstream -> upstream");
+        sent = res?;
+        wu.shutdown().await
+    };
+
+    let upstream_to_downstream = async {
+        let mut ru = io::BufReader::with_capacity(BUFFER_SIZE, &mut ru);
+        let res = copy_buf(&mut ru, &mut wd, stats, true).await;
+        trace!(?res, "tcp -> hbone");
+        received = res?;
+        wd.shutdown().await
+    };
+
+    tokio::try_join!(downstream_to_upstream, upstream_to_downstream)?;
+
+    trace!(sent, received, "copy complete");
+    Ok((sent, received))
 }
 
-#[cfg(not(target_os = "linux"))]
-pub async fn relay(
-    downstream: &mut tokio::net::TcpStream,
-    upstream: &mut tokio::net::TcpStream,
-) -> Result<(u64, u64), Error> {
-    tokio::io::copy_bidirectional(downstream, upstream).await
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+struct CopyBuf<'a, R: ?Sized, W: ?Sized> {
+    send: bool,
+    reader: &'a mut R,
+    writer: &'a mut W,
+    x: &'a ConnectionResult,
+    amt: u64,
+}
+
+async fn copy_buf<'a, R, W>(
+    reader: &'a mut R,
+    writer: &'a mut W,
+    x: &ConnectionResult,
+    send: bool,
+) -> std::io::Result<u64>
+where
+    R: tokio::io::AsyncBufRead + Unpin + ?Sized,
+    W: tokio::io::AsyncWrite + Unpin + ?Sized,
+{
+    CopyBuf {
+        send,
+        reader,
+        writer,
+        x,
+        amt: 0,
+    }
+    .await
+}
+
+impl<R, W> Future for CopyBuf<'_, R, W>
+where
+    R: AsyncBufRead + Unpin + ?Sized,
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    type Output = std::io::Result<u64>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            let me = &mut *self;
+            let buffer = ready!(Pin::new(&mut *me.reader).poll_fill_buf(cx))?;
+            if buffer.is_empty() {
+                ready!(Pin::new(&mut self.writer).poll_flush(cx))?;
+                return Poll::Ready(Ok(self.amt));
+            }
+
+            let i = ready!(Pin::new(&mut *me.writer).poll_write(cx, buffer))?;
+            if i == 0 {
+                return Poll::Ready(Err(std::io::ErrorKind::WriteZero.into()));
+            }
+            if me.send {
+                me.x.increment_send(i as u64);
+            } else {
+                me.x.increment_recv(i as u64);
+            }
+            self.amt += i as u64;
+            Pin::new(&mut *self.reader).consume(i);
+        }
+    }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -12,21 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use realm_io::AsyncRawIO;
 use std::io::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::ops::AddAssign;
-use std::os::fd::{AsRawFd, RawFd};
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 use tokio::io;
-use tokio::io::{AsyncRead, AsyncWrite, Interest, ReadBuf};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
 use tokio::net::TcpSocket;
-use tracing::trace;
 
-use crate::proxy::ConnectionResult;
 #[cfg(target_os = "linux")]
 use {
     realm_io,
@@ -174,93 +166,14 @@ mod linux {
     }
 }
 
-pub async fn relay<A, B>(
-    upgraded: &mut A,
-    stream: &mut B,
-    x: &ConnectionResult,
-) -> Result<(u64, u64), crate::proxy::Error>
-where
-    A: AsyncRead + AsyncWrite + Unpin,
-    B: AsyncRead + AsyncWrite + Unpin,
-{
-    use tokio::io::AsyncWriteExt;
-    let (mut ri, mut wi) = tokio::io::split(upgraded);
-    let (mut ro, mut wo) = tokio::io::split(stream);
-
-    let (mut sent, mut received): (u64, u64) = (0, 0);
-
-    let client_to_server = async {
-        let mut ri = tokio::io::BufReader::with_capacity(crate::proxy::HBONE_BUFFER_SIZE, &mut ri);
-        let res = crate::proxy::copy_buf(&mut ri, &mut wo, &x, false).await;
-        trace!(?res, "hbone -> tcp");
-        received = res?;
-        wo.shutdown().await
-    };
-
-    let server_to_client = async {
-        let mut ro = tokio::io::BufReader::with_capacity(crate::proxy::HBONE_BUFFER_SIZE, &mut ro);
-        let res = crate::proxy::copy_buf(&mut ro, &mut wi, x, true).await;
-        trace!(?res, "tcp -> hbone");
-        sent = res?;
-        wi.shutdown().await
-    };
-
-    tokio::try_join!(client_to_server, server_to_client)?;
-
-    trace!(sent, recv = received, "copy hbone complete");
-    Ok((sent, received))
-}
-
-struct StreamWrapper<'a> {
-    inner: realm_io::statistic::StatStream<&'a TcpStream, Wrapper<'a>>,
-}
-struct Wrapper<'a> {
-    data: &'a ConnectionResult,
-}
-
-impl<'a> AsRef<realm_io::statistic::StatStream<&'a TcpStream, Wrapper<'a>>> for StreamWrapper<'a, > {
-    fn as_ref(&self) -> &realm_io::statistic::StatStream<&'a TcpStream, Wrapper<'a>> {
-        &self.inner
-    }
-}
-
-impl<'a> AsyncRawIO for StreamWrapper<'a>
-where
-{
-    fn x_poll_read_ready(&self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        self.inner.poll_read_ready(cx)
-    }
-
-    fn x_poll_write_ready(&self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        self.inner.poll_write_ready(cx)
-    }
-
-    fn x_try_io<R>(
-        &self,
-        interest: Interest,
-        f: impl FnOnce() -> std::io::Result<R>,
-    ) -> std::io::Result<R> {
-        self.inner.try_io(interest, f)
-    }
-}
-impl<'a> AddAssign<usize> for Wrapper<'a> {
-    fn add_assign(&mut self, rhs: usize) {
-        self.data.increment_recv(rhs as u64)
-    }
-}
-
 #[cfg(target_os = "linux")]
-pub async fn relay_zero_copy(
+pub async fn relay(
     downstream: &mut tokio::net::TcpStream,
     upstream: &mut tokio::net::TcpStream,
-    x: &ConnectionResult,
 ) -> Result<(u64, u64), Error> {
     const EINVAL: i32 = 22;
 
-    let wrapper = StreamWrapper {
-        inner: realm_io::statistic::StatStream::new(downstream, Wrapper { data: x }),
-    };
-    match realm_io::bidi_zero_copy(&mut wrapper, upstream).await {
+    match realm_io::bidi_zero_copy(downstream, upstream).await {
         Ok(d) => Ok(d),
         Err(ref e) if e.raw_os_error().map_or(false, |ec| ec == EINVAL) => {
             tokio::io::copy_bidirectional(downstream, upstream).await


### PR DESCRIPTION
Implements https://github.com/istio/ztunnel/issues/926

This PR adds incremental recv/sent bytes metrics recording. This is done by a fork of the tokio copy_buf implementation to increment stats on read/write.

This has two issues currently, which I will open followup issues:
* The `splice` mode is hard to do this way. We will need to fork the library we use or get support upstream. For now, this is disabled
* Currently every r/w operation increments the metrics. This might be a bit excessive. A metric update takes 300ns. A followup could be to only record every N operations (though, ideally, we would also have a way to do it every N seconds or N operations, whichever is smaller...)

For now, I think the benefit here is worth the tradeoffs.

When testing netperf with 2mb payloads and 1byte payloads:

* Before: 10.4Gb/s and 28Mb/s
* After: 10.7Gb/s and 29Mb/s
So roughly in the ballpark. (Presumably,  I did not make things faster, just noise).

Also, pprof shows <1% on metrics reporting
