### PR TITLE
Better-behaved HBONE pooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "const-random",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -483,6 +484,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.12",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +815,18 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flurry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7874ce5eeafa5e546227f7c62911e586387bf03d6c9a45ac78aa1c3bc2fedb61"
+dependencies = [
+ "ahash",
+ "num_cpus",
+ "parking_lot",
+ "seize",
 ]
 
 [[package]]
@@ -2622,6 +2655,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "seize"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5739de653b129b0a59da381599cf17caf24bc586f6a797c52d3d6147c5b85a"
+dependencies = [
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,6 +3014,15 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3677,6 +3729,7 @@ dependencies = [
  "diff",
  "drain",
  "duration-str",
+ "flurry",
  "futures",
  "futures-core",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +1995,35 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pingora-pool"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4569e3bef52b0abab239a5cf3287c71307615ca61be7fc7799d71fdaab33d81"
+dependencies = [
+ "crossbeam-queue",
+ "log",
+ "lru",
+ "parking_lot",
+ "pingora-timeout",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
+name = "pingora-timeout"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be182194d34e1b28608eaa49ee0fb86e5b7ab1d21a1d7a2b4d402446fda47e1"
+dependencies = [
+ "futures",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "thread_local",
+ "tokio",
+]
 
 [[package]]
 name = "plotters"
@@ -3658,6 +3705,8 @@ dependencies = [
  "nix 0.28.0",
  "oid-registry",
  "once_cell",
+ "pin-project-lite",
+ "pingora-pool",
  "ppp",
  "pprof",
  "prometheus-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "once_cell",
  "tiny-keccak",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,8 @@ url = "2.2"
 x509-parser = { version = "0.16", default-features = false }
 tracing-log = "0.2"
 backoff = "0.4.0"
+pin-project-lite = "0.2"
+pingora-pool = "0.1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ tracing-log = "0.2"
 backoff = "0.4.0"
 pin-project-lite = "0.2"
 pingora-pool = "0.1.0"
+flurry = "0.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
+ "const-random",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -365,6 +366,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.12",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +642,18 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flurry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7874ce5eeafa5e546227f7c62911e586387bf03d6c9a45ac78aa1c3bc2fedb61"
+dependencies = [
+ "ahash",
+ "num_cpus",
+ "parking_lot",
+ "seize",
+]
 
 [[package]]
 name = "fnv"
@@ -2255,6 +2288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "seize"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5739de653b129b0a59da381599cf17caf24bc586f6a797c52d3d6147c5b85a"
+dependencies = [
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2557,15 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3212,6 +3264,7 @@ dependencies = [
  "chrono",
  "drain",
  "duration-str",
+ "flurry",
  "futures",
  "futures-core",
  "futures-util",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -445,6 +445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1658,35 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pingora-pool"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4569e3bef52b0abab239a5cf3287c71307615ca61be7fc7799d71fdaab33d81"
+dependencies = [
+ "crossbeam-queue",
+ "log",
+ "lru",
+ "parking_lot",
+ "pingora-timeout",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
+name = "pingora-timeout"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be182194d34e1b28608eaa49ee0fb86e5b7ab1d21a1d7a2b4d402446fda47e1"
+dependencies = [
+ "futures",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "thread_local",
+ "tokio",
+]
 
 [[package]]
 name = "plotters"
@@ -3189,6 +3236,8 @@ dependencies = [
  "netns-rs",
  "nix 0.28.0",
  "once_cell",
+ "pin-project-lite",
+ "pingora-pool",
  "ppp",
  "pprof",
  "prometheus-client",

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -395,7 +395,11 @@ fn change_log_level(reset: bool, level: &str) -> Response<Full<Bytes>> {
 async fn handle_jemalloc_pprof_heapgen(
     _req: Request<Incoming>,
 ) -> anyhow::Result<Response<Full<Bytes>>> {
-    let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref().expect("should init").lock().await;
+    let mut prof_ctl = jemalloc_pprof::PROF_CTL
+        .as_ref()
+        .expect("should init")
+        .lock()
+        .await;
     if !prof_ctl.activated() {
         return Ok(Response::builder()
             .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -395,7 +395,7 @@ fn change_log_level(reset: bool, level: &str) -> Response<Full<Bytes>> {
 async fn handle_jemalloc_pprof_heapgen(
     _req: Request<Incoming>,
 ) -> anyhow::Result<Response<Full<Bytes>>> {
-    let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref()?.lock().await;
+    let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref().expect("should init").lock().await;
     if !prof_ctl.activated() {
         return Ok(Response::builder()
             .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
@@ -405,7 +405,7 @@ async fn handle_jemalloc_pprof_heapgen(
     let pprof = prof_ctl.dump_pprof()?;
     Ok(Response::builder()
         .status(hyper::StatusCode::OK)
-        .body(Bytes::from(pprof?).into())
+        .body(Bytes::from(pprof).into())
         .expect("builder with known status code should not fail"))
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,7 +371,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             DEFAULT_READINESS_PORT, // There is no config for this in ProxyConfig currently
         ),
 
-        socks5_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 15080),
+        socks5_addr,
         inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15008),
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15006),
         outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15001),

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -117,6 +117,8 @@ impl fmt::Display for Identity {
     }
 }
 
+// TODO we shouldn't have a "default identity" outside of tests
+// #[cfg(test)]
 impl Default for Identity {
     fn default() -> Self {
         const TRUST_DOMAIN: &str = "cluster.local";

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -49,7 +49,7 @@ mod inbound_passthrough;
 #[allow(non_camel_case_types)]
 pub mod metrics;
 mod outbound;
-mod pool;
+pub mod pool;
 mod socks5;
 mod util;
 
@@ -105,7 +105,7 @@ pub(super) struct ProxyInputs {
     hbone_port: u16,
     pub state: DemandProxyState,
     metrics: Arc<Metrics>,
-    pool: pool::Pool,
+    pool: pool::WorkloadHBONEPool,
     socket_factory: Arc<dyn SocketFactory + Send + Sync>,
     proxy_workload_info: Option<Arc<WorkloadInfo>>,
 }
@@ -119,6 +119,7 @@ impl ProxyInputs {
         metrics: Arc<Metrics>,
         socket_factory: Arc<dyn SocketFactory + Send + Sync>,
         proxy_workload_info: Option<WorkloadInfo>,
+        pool: pool::WorkloadHBONEPool,
     ) -> Self {
         Self {
             cfg,
@@ -126,7 +127,7 @@ impl ProxyInputs {
             cert_manager,
             metrics,
             connection_manager,
-            pool: pool::Pool::new(),
+            pool,
             hbone_port: 0,
             socket_factory,
             proxy_workload_info: proxy_workload_info.map(Arc::new),
@@ -143,15 +144,23 @@ impl Proxy {
         drain: Watch,
     ) -> Result<Proxy, Error> {
         let metrics = Arc::new(metrics);
+        let socket_factory = Arc::new(DefaultSocketFactory);
+
+        let pool = pool::WorkloadHBONEPool::new(
+            cfg.clone(),
+            socket_factory.clone(),
+            cert_manager.clone(),
+            drain.clone(),
+        );
         let pi = ProxyInputs {
             cfg,
             state,
             cert_manager,
             connection_manager: ConnectionManager::default(),
             metrics,
-            pool: pool::Pool::new(),
+            pool,
             hbone_port: 0,
-            socket_factory: Arc::new(DefaultSocketFactory),
+            socket_factory,
             proxy_workload_info: None,
         };
         Self::from_inputs(pi, drain).await
@@ -245,11 +254,13 @@ pub enum Error {
     AuthorizationPolicyRejection,
 
     #[error("pool is already connecting")]
-    PoolAlreadyConnecting,
+    WorkloadHBONEPoolAlreadyConnecting,
 
-    #[error("pool: {0}")]
-    Pool(#[from] hyper_util::client::legacy::pool::Error),
+    #[error("connection streams maxed out")]
+    WorkloadHBONEPoolConnStreamsMaxed,
 
+    // #[error("pool: {0}")]
+    // WorkloadHBONEPool(#[from] custom_http2_pool::Error),
     #[error("{0}")]
     Generic(Box<dyn std::error::Error + Send + Sync>),
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -263,8 +263,6 @@ pub enum Error {
     #[error("pool draining")]
     WorkloadHBONEPoolDraining,
 
-    // #[error("pool: {0}")]
-    // WorkloadHBONEPool(#[from] custom_http2_pool::Error),
     #[error("{0}")]
     Generic(Box<dyn std::error::Error + Send + Sync>),
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -110,6 +110,7 @@ pub(super) struct ProxyInputs {
     proxy_workload_info: Option<Arc<WorkloadInfo>>,
 }
 
+#[allow(clippy::too_many_arguments)]
 impl ProxyInputs {
     pub fn new(
         cfg: config::Config,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -260,6 +260,9 @@ pub enum Error {
     #[error("connection streams maxed out")]
     WorkloadHBONEPoolConnStreamsMaxed,
 
+    #[error("pool draining")]
+    WorkloadHBONEPoolDraining,
+
     // #[error("pool: {0}")]
     // WorkloadHBONEPool(#[from] custom_http2_pool::Error),
     #[error("{0}")]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -105,7 +105,6 @@ pub(super) struct ProxyInputs {
     hbone_port: u16,
     pub state: DemandProxyState,
     metrics: Arc<Metrics>,
-    pool: pool::WorkloadHBONEPool,
     socket_factory: Arc<dyn SocketFactory + Send + Sync>,
     proxy_workload_info: Option<Arc<WorkloadInfo>>,
 }
@@ -120,7 +119,6 @@ impl ProxyInputs {
         metrics: Arc<Metrics>,
         socket_factory: Arc<dyn SocketFactory + Send + Sync>,
         proxy_workload_info: Option<WorkloadInfo>,
-        pool: pool::WorkloadHBONEPool,
     ) -> Self {
         Self {
             cfg,
@@ -128,7 +126,6 @@ impl ProxyInputs {
             cert_manager,
             metrics,
             connection_manager,
-            pool,
             hbone_port: 0,
             socket_factory,
             proxy_workload_info: proxy_workload_info.map(Arc::new),
@@ -147,19 +144,12 @@ impl Proxy {
         let metrics = Arc::new(metrics);
         let socket_factory = Arc::new(DefaultSocketFactory);
 
-        let pool = pool::WorkloadHBONEPool::new(
-            cfg.clone(),
-            socket_factory.clone(),
-            cert_manager.clone(),
-            drain.clone(),
-        );
         let pi = ProxyInputs {
             cfg,
             state,
             cert_manager,
             connection_manager: ConnectionManager::default(),
             metrics,
-            pool,
             hbone_port: 0,
             socket_factory,
             proxy_workload_info: None,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use drain::Watch;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Instant, Duration};
 
 use bytes::Bytes;
 use drain::Watch;
@@ -119,6 +119,11 @@ impl Inbound {
                 let serve = crate::hyper_util::http2_server()
                     .initial_stream_window_size(self.pi.cfg.window_size)
                     .initial_connection_window_size(self.pi.cfg.connection_window_size)
+                    // well behaved clients should close connections.
+                    // not all clients are well-behaved. This will prune
+                    // connections when the client is not responding, to keep
+                    // us from holding many stale conns from deceased clients
+                    .keep_alive_interval(Some(Duration::from_secs(10)))
                     .max_frame_size(self.pi.cfg.frame_size)
                     // 64KB max; default is 16MB driven from Golang's defaults
                     // Since we know we are going to recieve a bounded set of headers, more is overkill.

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -117,6 +117,7 @@ impl Inbound {
                 debug!(%conn, "accepted connection");
                 let enable_original_source = self.pi.cfg.enable_original_source;
                 let serve = crate::hyper_util::http2_server()
+                    // .max_concurrent_streams(100) // TODO BML test
                     .initial_stream_window_size(self.pi.cfg.window_size)
                     .initial_connection_window_size(self.pi.cfg.connection_window_size)
                     .max_frame_size(self.pi.cfg.frame_size)

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -117,7 +117,6 @@ impl Inbound {
                 debug!(%conn, "accepted connection");
                 let enable_original_source = self.pi.cfg.enable_original_source;
                 let serve = crate::hyper_util::http2_server()
-                    // .max_concurrent_streams(100) // TODO BML test
                     .initial_stream_window_size(self.pi.cfg.window_size)
                     .initial_connection_window_size(self.pi.cfg.connection_window_size)
                     .max_frame_size(self.pi.cfg.frame_size)

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -171,7 +171,7 @@ impl OutboundConnection {
             Some(drain) => {
                 tokio::select! {
                         _ = drain.signaled() => {
-                            info!("socks drain signaled");
+                            info!("drain signaled");
                         }
                         res = self.proxy_to(stream, remote_addr, orig_dst_addr, block_passthrough) => res
                 }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -82,8 +82,7 @@ impl Outbound {
         let pool = proxy::pool::WorkloadHBONEPool::new(
                     self.pi.cfg.clone(),
                     self.pi.socket_factory.clone(),
-                    self.pi.cert_manager.clone(),
-                    sub_drain.clone());
+                    self.pi.cert_manager.clone());
         let accept = async move {
             loop {
                 // Asynchronously wait for an inbound socket.
@@ -674,9 +673,7 @@ mod tests {
             pool: pool::WorkloadHBONEPool::new(
                 cfg,
                 sock_fact,
-                cert_mgr.clone(),
-                sub_drain,
-            ),
+                cert_mgr.clone()),
         };
 
         let req = outbound

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -657,7 +657,6 @@ mod tests {
 
         let sock_fact = std::sync::Arc::new(crate::proxy::DefaultSocketFactory);
         let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
-        let (_, sub_drain) = drain::channel();
         let outbound = OutboundConnection {
             pi: ProxyInputs {
                 cert_manager: identity::mock::new_secret_manager(Duration::from_secs(10)),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -666,17 +666,17 @@ mod tests {
                 hbone_port: 15008,
                 cfg: cfg.clone(),
                 metrics: test_proxy_metrics(),
-                pool: pool::WorkloadHBONEPool::new(
-                    cfg,
-                    sock_fact.clone(),
-                    cert_mgr.clone(),
-                    sub_drain,
-                ),
-                socket_factory: sock_fact,
+                socket_factory: sock_fact.clone(),
                 proxy_workload_info: None,
                 connection_manager: ConnectionManager::default(),
             },
             id: TraceParent::new(),
+            pool: pool::WorkloadHBONEPool::new(
+                cfg,
+                sock_fact,
+                cert_mgr.clone(),
+                sub_drain,
+            ),
         };
 
         let req = outbound

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -221,6 +221,7 @@ impl PoolState {
     //
     // This function should ALWAYS return a connection if it wins the writelock for the provided key.
     // This function should NEVER return a connection if it does not win the writelock for the provided key.
+    // This function should ALWAYS propagate Error results to the caller
     //
     // It is important that the *initial* check here is authoritative, hence the locks, as
     // we must know if this is a connection for a key *nobody* has tried to start yet
@@ -288,6 +289,7 @@ impl PoolState {
     //
     // This function should ALWAYS return a connection if a writelock exists for the provided key.
     // This function should NEVER return a connection if no writelock exists for the provided key.
+    // This function should ALWAYS propagate Error results to the caller
     //
     // It is important that the *initial* check here is authoritative, hence the locks, as
     // we must know if this is a connection for a key *nobody* has tried to start yet

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -526,7 +526,7 @@ impl WorkloadHBONEPool {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 // A sort of faux-client, that represents a single checked-out 'request sender' which might
 // send requests over some underlying stream using some underlying http/2 client
 pub struct ConnClient {
@@ -576,6 +576,24 @@ impl Drop for ConnClient {
             self.stream_count,
             self.stream_count_max
         )
+    }
+}
+
+// This is currently only for debugging
+impl Clone for ConnClient {
+    fn clone(&self) -> Self {
+        trace!(
+            "cloning ConnClient for key {:#?} with streamcount: {:?} / {:?}",
+            self.wl_key,
+            self.stream_count,
+            self.stream_count_max
+        );
+        ConnClient {
+            sender: self.sender.clone(),
+            stream_count: self.stream_count.clone(),
+            stream_count_max: self.stream_count_max,
+            wl_key: self.wl_key.clone(),
+        }
     }
 }
 

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -51,7 +51,7 @@ static GLOBAL_CONN_COUNT: AtomicI32 = AtomicI32::new(0);
 //   by flow control throttling.
 #[derive(Clone)]
 pub struct WorkloadHBONEPool {
-    pool_notifier: watch::Sender<bool>,
+    pool_notifier: Arc<watch::Sender<bool>>,
     pool_watcher: watch::Receiver<bool>,
     max_streamcount: u16,
     // this is effectively just a convenience data type - a rwlocked hashmap with keying and LRU drops
@@ -78,7 +78,7 @@ impl WorkloadHBONEPool {
             cfg.pool_max_streams_per_conn
         );
         Self {
-            pool_notifier: tx,
+            pool_notifier: Arc::new(tx),
             pool_watcher: rx,
             max_streamcount: cfg.pool_max_streams_per_conn,
             // the number here is simply the number of unique src/dest keys

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -66,6 +66,9 @@ pub struct WorkloadHBONEPool {
 }
 
 impl WorkloadHBONEPool {
+    // Creates a new pool instance, which should be owned by a single proxied workload.
+    // The pool will watch the provided drain signal and drain itself when notified.
+    // Callers should then be safe to drop() the pool instance.
     pub fn new(
         cfg: crate::config::Config,
         socket_factory: Arc<dyn SocketFactory + Send + Sync>,
@@ -92,9 +95,14 @@ impl WorkloadHBONEPool {
         }
     }
 
+    // Obtain a pooled connection. Will prefer to retrieve an existing conn from the pool, but
+    // if none exist, or the existing conn is maxed out on streamcount, will spawn a new one,
+    // even if it is to the same dest+port.
+    //
+    // If many `connects` request a connection  to the same dest at once, all will wait until exactly
+    // one connection is created, before deciding if they should create more or just use that one.
     pub async fn connect(&mut self, key: WorkloadKey) -> Result<Client, Error> {
-        // TODO BML this may not be collision resistant
-        // it may also be slow as shit
+        // TODO BML this may not be collision resistant/slow. It should be resistant enough for workloads tho.
         let mut s = DefaultHasher::new();
         key.hash(&mut s);
         let hash_key = s.finish();
@@ -103,6 +111,16 @@ impl WorkloadHBONEPool {
             GLOBAL_CONN_COUNT.fetch_add(1, Ordering::Relaxed),
         );
 
+        // First, see if we can naively just check out a connection.
+        // This should be the common case, except for the first establishment of a new connection/key.
+        // This will be done under outer readlock (nonexclusive)/inner keyed writelock (exclusive).
+        //
+        // It is important that the *initial* check here is authoritative, hence the locks, as
+        // we must know if this is a connection for a key *nobody* has tried to start yet,
+        // or if other things have already established conns for this key.
+        //
+        // This is so we can backpressure correctly if 1000 tasks all demand a new connection
+        // to the same key at once, and not eagerly open 1000 tunnel connections.
         let existing_conn = self
             .first_checkout_conn_from_pool(&key, hash_key, &pool_key)
             .await;
@@ -111,12 +129,22 @@ impl WorkloadHBONEPool {
             debug!("using existing conn, connect future will be dropped on the floor");
             Ok(existing_conn.unwrap())
         } else {
+            // We couldn't get a conn. This means either nobody has tried to establish any conns for this key yet,
+            // or they have, but no conns are currently available
+            // (because someone else has checked all of them out and not put any back yet)
+            //
+            // So, we wil writelock the outer lock to see if an inner lock entry exists for our key.
+            //
             // critical block - this writelocks the entire pool for all tasks/threads
-            // as we check to see if anyone has inserted a sharded mutex for this key.
-            // So we want to hold this for as short as possible a time, and drop it
+            // as we check to see if anyone has ever inserted a sharded mutex for this key.
+            //
+            // If not, we insert one.
+            //
+            // We want to hold this for as short as possible a time, and drop it
             // before we hold it over an await.
             //
-            // this is is the only block where we should hold a writelock on the whole mutex map
+            // this is is the ONLY block where we should hold a writelock on the whole mutex map
+            // for the rest, a readlock (nonexclusive) is sufficient.
             {
                 let mut map_write_lock = self.established_conn_writelock.write().await;
                 match map_write_lock.get(&hash_key) {
@@ -128,12 +156,15 @@ impl WorkloadHBONEPool {
                         map_write_lock.insert(hash_key, Some(Mutex::new(())));
                     }
                 };
-                drop(map_write_lock);
+                drop(map_write_lock); // strictly redundant
             }
 
-            // Now we know _someone_ won the race to insert a conn mutex, we don't need a writelock
-            // on the outer map anymore - so we can just readlock the outer map,
-            // and get the inner mutex for this connkey that we care about.
+
+
+            // If we get here, it means the following are true:
+            // 1. We have a guaranteed sharded mutex in the outer map for our current key.
+            // 2. We can now, under readlock(nonexclusive) in the outer map, attempt to
+            // take the inner writelock for our specific key (exclusive).
             //
             // This unblocks other tasks spawning connections against other keys, but blocks other
             // tasks spawning connections against THIS key - which is what we want.
@@ -149,13 +180,18 @@ impl WorkloadHBONEPool {
             // and we WANT other tasks to go back to sleep if there is an outstanding lock.
             // So the downsides are actually useful (we WANT task contention -
             // to block other parallel tasks from trying to spawn a connection if we are already doing so)
+            //
+            // BEGIN take outer readlock
             let map_read_lock = self.established_conn_writelock.read().await;
             let exist_conn_lock = map_read_lock.get(&hash_key).unwrap();
+            // BEGIN take inner writelock
             let found_conn = match exist_conn_lock.as_ref().unwrap().try_lock() {
                 Ok(_guard) => {
-                    // if we get here, either we won the connlock race and can create one,
-                    // or someone else won, but the streamcount for the one they added is already hit,
-                    // so we should start and insert another.
+                    // If we get here, it means the following are true:
+                    // 1. We did not get a connection for our key.
+                    // 2. We have the exclusive inner writelock to create a new connection for our key.
+                    //
+                    // So, carry on doing that.
                     debug!("appears we need a new conn, retaining connlock");
                     debug!("nothing else is creating a conn, make one");
                     let pool_conn = self.spawn_new_pool_conn(key.clone()).await;
@@ -171,14 +207,18 @@ impl WorkloadHBONEPool {
                     );
                     debug!("dropping lock");
                     Some(client)
+                    // END take inner writelock
                 }
                 Err(_) => {
-                    // The sharded mutex for this connkey is already locked - someone else must be making a conn
-                    // if they are, try to wait for it, but bail if we find one and it's got a maxed streamcount.
                     debug!("something else is creating a conn, wait for it");
-                    // let waiter = self.pool_watcher.changed();
-                    // tokio::pin!(waiter);
-
+                    // If we get here, it means the following are true:
+                    // 1. At one point, there was a preexisting conn in the pool for this key.
+                    // 2. When we checked, we got nothing for that key.
+                    // 3. We could not get the exclusive inner writelock to add a new one for this key.
+                    // 4. Someone else got the exclusive inner writelock, and is adding a new one for this key.
+                    //
+                    // So, loop and wait for the pool_watcher to tell us a new conn was enpooled,
+                    // so we can pull it out and check it.
                     loop {
                         match self.pool_watcher.changed().await {
                             Ok(_) => {
@@ -186,18 +226,17 @@ impl WorkloadHBONEPool {
                                     "notified a new conn was enpooled, checking for hash {:#?}",
                                     hash_key
                                 );
-
-                                let existing_conn = self.connected_pool.get(&hash_key); // .and_then(|e_conn| {
-
-                                //         debug!("while waiting for new conn, got existing conn for key {:#?}", key);
-                                // });
-                                match existing_conn {
+                                // The sharded mutex for this connkey is already locked - someone else must be making a conn
+                                // if they are, try to wait for it, but bail if we find one and it's got a maxed streamcount.
+                                let existing_conn = self.connected_pool.get(&hash_key);                               match existing_conn {
                                     None => {
-                                        debug!("got nothin");
+                                        debug!("got nothing");
                                         continue;
                                     }
                                     Some(e_conn) => {
                                         debug!("found existing conn after waiting");
+                                        // We found a conn, but it's already maxed out.
+                                        // Return None and create another.
                                         if e_conn.at_max_streamcount() {
                                             debug!("found existing conn for key {:#?}, but streamcount is maxed", key);
                                             break None;
@@ -207,6 +246,7 @@ impl WorkloadHBONEPool {
                                 }
                             }
                             Err(_) => {
+                                // END take outer readlock
                                 return Err(Error::WorkloadHBONEPoolDraining)
                             }
                         }
@@ -214,13 +254,35 @@ impl WorkloadHBONEPool {
                 }
             };
 
+
+            // If we get here, it means the following are true:
+            // 1. At one point, there was a preexisting conn in the pool for this key.
+            // 2. When we checked, we got nothing for that key.
+            // 3. We could not get the exclusive inner writelock to add a new one
+            // 4. Someone else got the exclusive inner writelock, and is adding a new one
+            // 5. We waited until we got that connection for our key, that someone else added.
+            //
+            // So now we are down to 2 options:
+            //
+            // 1. We got an existing connection, it's usable, we use it.
+            // 2. We got an existing connection, it's not usable, we start another.
+            //
+            // Note that for (2) we do not really need to take the inner writelock again for this key -
+            // if we checked out a conn inserted by someone else that we cannot use,
+            // everyone else will implicitly be waiting for us to check one back in,
+            // since they are in their own loops.
             match found_conn {
+                // After waiting, we found an available conn we can use, so no need to start another.
+                // Clone the underlying client, return a copy, and put the other back in the pool.
                 Some(f_conn) => {
                     self.connected_pool.put(&pool_key, f_conn.clone());
                     let _ = self.pool_notifier.send(true);
                     Ok(f_conn)
                 }
 
+                // After waiting, we found an available conn, but for whatever reason couldn't use it.
+                // (streamcount maxed, etc)
+                // Start a new one, clone the underlying client, return a copy, and put the other back in the pool.
                 None => {
                     debug!("spawning new conn for key {:#?} to replace", key);
                     let pool_conn = self.spawn_new_pool_conn(key.clone()).await;
@@ -234,6 +296,7 @@ impl WorkloadHBONEPool {
                     Ok(r_conn)
                 }
             }
+            // END take outer readlock
         }
     }
     async fn first_checkout_conn_from_pool(

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -104,7 +104,7 @@ impl WorkloadHBONEPool {
             max_streamcount: cfg.pool_max_streams_per_conn,
             // the number here is simply the number of unique src/dest keys
             // the pool is expected to track before the inner hashmap resizes.
-            connected_pool: Arc::new(pingora_pool::ConnectionPool::new(50000)),
+            connected_pool: Arc::new(pingora_pool::ConnectionPool::new(500)),
             cfg,
             socket_factory,
             cert_manager,

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -634,11 +634,6 @@ mod test {
 
     #[tokio::test]
     async fn test_pool_100_clients_singleconn() {
-        let _cfg = crate::config::Config {
-            local_node: Some("local-node".to_string()),
-            ..crate::config::parse_config().unwrap()
-        };
-
         // crate::telemetry::setup_logging();
 
         let (server_drain_signal, server_drain) = drain::channel();
@@ -684,11 +679,6 @@ mod test {
 
     #[tokio::test]
     async fn test_pool_100_clients_100_srcs() {
-        let _cfg = crate::config::Config {
-            local_node: Some("local-node".to_string()),
-            ..crate::config::parse_config().unwrap()
-        };
-
         // crate::telemetry::setup_logging();
 
         let (server_drain_signal, server_drain) = drain::channel();
@@ -741,11 +731,6 @@ mod test {
 
     #[tokio::test]
     async fn test_pool_1000_clients_3_srcs() {
-        let _cfg = crate::config::Config {
-            local_node: Some("local-node".to_string()),
-            ..crate::config::parse_config().unwrap()
-        };
-
         // crate::telemetry::setup_logging();
 
         let (server_drain_signal, server_drain) = drain::channel();
@@ -871,7 +856,7 @@ mod test {
         }
 
         let conn_count: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let _drop_conn_count: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
+        // let _drop_conn_count: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
 
         // We create a TcpListener and bind it to 127.0.0.1:3000
         let listener = TcpListener::bind(addr).await.unwrap();

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -594,10 +594,10 @@ mod test {
     use hyper::{Request, Response};
     use std::sync::atomic::AtomicU32;
     use std::time::Duration;
-    use tokio::time::sleep;
     use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
     use tokio::task::{self};
+    use tokio::time::sleep;
 
     #[cfg(tokio_unstable)]
     use tracing::Instrument;
@@ -614,7 +614,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
@@ -657,7 +662,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         // crate::telemetry::setup_logging();
 
@@ -704,7 +714,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
@@ -742,7 +757,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
@@ -783,7 +803,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
@@ -831,7 +856,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
@@ -881,7 +911,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
@@ -938,7 +973,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
@@ -985,6 +1025,7 @@ mod test {
 
         drop(pool);
 
+        server_drain_signal.drain().await;
         server_handle.await.unwrap();
 
         let real_conncount = conn_counter.load(Ordering::Relaxed);
@@ -999,7 +1040,12 @@ mod test {
 
         let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
         let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
+        let (server_addr, server_handle) = spawn_server(
+            server_drain,
+            conn_counter.clone(),
+            conn_drop_counter.clone(),
+        )
+        .await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
@@ -1047,8 +1093,14 @@ mod test {
 
         let before_conncount = conn_counter.load(Ordering::Relaxed);
         let before_dropcount = conn_drop_counter.load(Ordering::Relaxed);
-        assert!(before_conncount == 3, "actual before conncount was {before_conncount}");
-        assert!(before_dropcount == 0, "actual before dropcount was {before_dropcount}");
+        assert!(
+            before_conncount == 3,
+            "actual before conncount was {before_conncount}"
+        );
+        assert!(
+            before_dropcount == 0,
+            "actual before dropcount was {before_dropcount}"
+        );
 
         drop(pool);
         // Attempt to wait long enough for pool conns to timeout+drop
@@ -1061,71 +1113,6 @@ mod test {
 
         server_drain_signal.drain().await;
         server_handle.await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_pool_1000_clients_3_srcs_does_not_drop_before_timeout() {
-        // crate::telemetry::setup_logging();
-
-        let (server_drain_signal, server_drain) = drain::channel();
-        let conn_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let conn_drop_counter: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
-        let (server_addr, server_handle) = spawn_server(server_drain, conn_counter.clone(), conn_drop_counter.clone()).await;
-
-        let cfg = crate::config::Config {
-            local_node: Some("local-node".to_string()),
-            pool_max_streams_per_conn: 1000,
-            pool_unused_release_timeout: Duration::from_secs(5),
-            ..crate::config::parse_config().unwrap()
-        };
-        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
-        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
-        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr);
-
-        let mut key1 = WorkloadKey {
-            src_id: Identity::default(),
-            dst_id: vec![Identity::default()],
-            src: IpAddr::from([127, 0, 0, 1]),
-            dst: server_addr,
-        };
-
-        let client_count = 100;
-        let mut count = 0u32;
-        let mut tasks = futures::stream::FuturesUnordered::new();
-        loop {
-            count += 1;
-            if count % 2 == 0 {
-                debug!("using key 2");
-                key1.src = IpAddr::from([127, 0, 0, 4]);
-            } else if count % 3 == 0 {
-                debug!("using key 3");
-                key1.src = IpAddr::from([127, 0, 0, 6]);
-            } else {
-                debug!("using key 1");
-                key1.src = IpAddr::from([127, 0, 0, 2]);
-            }
-
-            tasks.push(spawn_client(pool.clone(), key1.clone(), server_addr, 100));
-
-            if count == client_count {
-                break;
-            }
-        }
-        while let Some(Err(res)) = tasks.next().await {
-            assert!(!res.is_panic(), "CLIENT PANICKED!");
-            continue;
-        }
-
-        drop(pool);
-        // Attempt to wait long enough for pool conns to timeout+drop
-        sleep(Duration::from_secs(6)).await;
-
-        server_drain_signal.drain().await;
-        server_handle.await.unwrap();
-        let real_conncount = conn_counter.load(Ordering::Relaxed);
-        let real_dropcount = conn_drop_counter.load(Ordering::Relaxed);
-        assert!(real_conncount == 3, "actual conncount was {real_conncount}");
-        assert!(real_dropcount == 3, "actual dropcount was {real_dropcount}");
     }
 
     fn spawn_client(
@@ -1176,7 +1163,64 @@ mod test {
         })
     }
 
-    async fn spawn_server(stop: Watch, conn_count: Arc<AtomicU32>, conn_drop_count: Arc<AtomicU32>) -> (SocketAddr, task::JoinHandle<()>) {
+    fn spawn_persistent_client(
+        mut pool: WorkloadHBONEPool,
+        key: WorkloadKey,
+        remote_addr: SocketAddr,
+        stop: Watch,
+    ) -> task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let req = || {
+                hyper::Request::builder()
+                    .uri(format!("{remote_addr}"))
+                    .method(hyper::Method::CONNECT)
+                    .version(hyper::Version::HTTP_2)
+                    .body(Empty::<Bytes>::new())
+                    .unwrap()
+            };
+
+            let start = Instant::now();
+
+            let mut c1 = pool
+                .connect(key.clone())
+                // needs tokio_unstable, but useful
+                // .instrument(tracing::debug_span!("client_tid", tid=%tokio::task::id()))
+                .await
+                .unwrap();
+            debug!(
+                "client spent {}ms waiting for conn",
+                start.elapsed().as_millis()
+            );
+
+            let mut count = 0u32;
+            // send forever, once we get a conn, until someone signals us to stop
+            let send_loop = async move {
+                loop {
+                    count += 1;
+                    let res = c1.send_request(req()).await;
+
+                    if res.is_err() {
+                        panic!("SEND ERR: {:#?} sendcount {count}", res);
+                    } else if res.unwrap().status() != 200 {
+                        panic!("CLIENT RETURNED ERROR")
+                    }
+                }
+            };
+
+            tokio::select! {
+                _ = send_loop => {}
+                _ = stop.signaled() => {
+                    debug!("GOT STOP PERSISTENT CLIENT");
+                }
+            };
+        })
+    }
+
+    async fn spawn_server(
+        stop: Watch,
+        conn_count: Arc<AtomicU32>,
+        conn_drop_count: Arc<AtomicU32>,
+    ) -> (SocketAddr, task::JoinHandle<()>) {
         // We'll bind to 127.0.0.1:3000
         let addr = SocketAddr::from(([127, 0, 0, 1], 0));
         let test_cfg = test_config();

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -207,7 +207,7 @@ impl WorkloadHBONEPool {
                                 }
                             }
                             Err(_) => {
-                                break None
+                                return Err(Error::WorkloadHBONEPoolDraining)
                             }
                         }
                     }
@@ -526,7 +526,7 @@ mod test {
 
     #[tokio::test]
     async fn test_pool_100_clients_streamexhaust() {
-        crate::telemetry::setup_logging();
+        // crate::telemetry::setup_logging();
 
         let (server_drain_signal, server_drain) = drain::channel();
         let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
@@ -683,14 +683,14 @@ mod test {
             ..crate::config::parse_config().unwrap()
         };
 
-        crate::telemetry::setup_logging();
+        // crate::telemetry::setup_logging();
 
         let (server_drain_signal, server_drain) = drain::channel();
         let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
 
         let cfg = crate::config::Config {
             local_node: Some("local-node".to_string()),
-            pool_max_streams_per_conn: 100,
+            pool_max_streams_per_conn: 1000,
             ..crate::config::parse_config().unwrap()
         };
         let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -108,7 +108,7 @@ impl WorkloadHBONEPool {
     // if none exist, or the existing conn is maxed out on streamcount, will spawn a new one,
     // even if it is to the same dest+port.
     //
-    // If many `connects` request a connection  to the same dest at once, all will wait until exactly
+    // If many `connects` request a connection to the same dest at once, all will wait until exactly
     // one connection is created, before deciding if they should create more or just use that one.
     pub async fn connect(&mut self, key: WorkloadKey) -> Result<Client, Error> {
         debug!("pool connect START");

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -12,80 +12,334 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::{Error, SocketFactory};
 use bytes::Bytes;
-use futures::pin_mut;
-use futures_util::future;
-use futures_util::future::Either;
+use drain::Watch;
 use http_body_util::Empty;
 use hyper::body::Incoming;
 use hyper::client::conn::http2;
 use hyper::http::{Request, Response};
-use hyper_util::client::legacy::pool;
-use hyper_util::client::legacy::pool::{Pool as HyperPool, Poolable, Pooled, Reservation};
-use hyper_util::rt::TokioTimer;
+
+use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
+use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use std::net::SocketAddr;
-use std::time::Duration;
-use tracing::debug;
+use std::sync::atomic::{AtomicI32, AtomicU16, Ordering};
+use std::sync::Arc;
 
-use crate::identity::Identity;
-use crate::proxy::Error;
+use tokio::sync::watch;
+use tokio::sync::{Mutex, RwLock};
+use tracing::{debug, error};
 
+use crate::config;
+use crate::identity::{Identity, SecretManager};
+
+use std::collections::HashMap;
+
+use pingora_pool;
+
+static GLOBAL_CONN_COUNT: AtomicI32 = AtomicI32::new(0);
+
+// A relatively nonstandard HTTP/2 connection pool designed to allow multiplexing proxied workload connections
+// over a (smaller) number of HTTP/2 mTLS tunnels.
+//
+// The following invariants apply to this pool:
+// - Every workload (inpod mode) gets its own connpool.
+// - Every unique src/dest key gets their own dedicated connections inside the pool.
+// - Every unique src/dest key gets 1-n dedicated connections, where N is (currently) unbounded but practically limited
+//   by flow control throttling.
 #[derive(Clone)]
-pub struct Pool {
-    pool: HyperPool<Client, Key>,
+pub struct WorkloadHBONEPool {
+    pool_notifier: watch::Sender<bool>,
+    pool_watcher: watch::Receiver<bool>,
+    max_streamcount: u16,
+    // this is effectively just a convenience data type - a rwlocked hashmap with keying and LRU drops
+    // and has no actual hyper/http/connection logic.
+    connected_pool: Arc<pingora_pool::ConnectionPool<Client>>,
+    cfg: config::Config,
+    socket_factory: Arc<dyn SocketFactory + Send + Sync>,
+    cert_manager: Arc<SecretManager>,
+    drainer: Watch,
+    // this must be a readlockable list-of-locks, so we can lock per-key, not globally, and avoid holding up all conn attempts
+    established_conn_writelock: Arc<RwLock<HashMap<u64, Option<Mutex<()>>>>>,
 }
 
-impl Pool {
-    pub fn new() -> Pool {
+impl WorkloadHBONEPool {
+    pub fn new(
+        cfg: crate::config::Config,
+        socket_factory: Arc<dyn SocketFactory + Send + Sync>,
+        cert_manager: Arc<SecretManager>,
+        drainer: Watch, //when signaled, will stop driving all conns in the pool, effectively draining the pool.
+    ) -> WorkloadHBONEPool {
+        let (tx, rx) = watch::channel(false);
+        debug!(
+            "constructing pool with {:#?} streams per conn",
+            cfg.pool_max_streams_per_conn
+        );
         Self {
-            pool: HyperPool::new(
-                hyper_util::client::legacy::pool::Config {
-                    idle_timeout: Some(Duration::from_secs(90)),
-                    max_idle_per_host: std::usize::MAX,
-                },
-                TokioExec,
-                Some(TokioTimer::new()),
-            ),
+            pool_notifier: tx,
+            pool_watcher: rx,
+            max_streamcount: cfg.pool_max_streams_per_conn,
+            // the number here is simply the number of unique src/dest keys
+            // the pool is expected to track before the inner hashmap resizes.
+            connected_pool: Arc::new(pingora_pool::ConnectionPool::new(50000)),
+            cfg,
+            socket_factory,
+            cert_manager,
+            drainer,
+            established_conn_writelock: Arc::new(RwLock::new(HashMap::new())),
         }
     }
-}
 
-#[derive(Clone)]
-pub struct TokioExec;
+    pub async fn connect(&mut self, key: WorkloadKey) -> Result<Client, Error> {
+        // TODO BML this may not be collision resistant
+        // it may also be slow as shit
+        let mut s = DefaultHasher::new();
+        key.hash(&mut s);
+        let hash_key = s.finish();
+        let pool_key = pingora_pool::ConnectionMeta::new(
+            hash_key,
+            GLOBAL_CONN_COUNT.fetch_add(1, Ordering::Relaxed),
+        );
 
-impl<F> hyper::rt::Executor<F> for TokioExec
-where
-    F: std::future::Future + Send + 'static,
-    F::Output: Send + 'static,
-{
-    fn execute(&self, fut: F) {
-        tokio::spawn(fut);
+        let existing_conn = self
+            .first_checkout_conn_from_pool(&key, hash_key, &pool_key)
+            .await;
+
+        if existing_conn.is_some() {
+            debug!("using existing conn, connect future will be dropped on the floor");
+            return Ok(existing_conn.unwrap());
+        } else {
+            // critical block - this writelocks the entire pool for all tasks/threads
+            // as we check to see if anyone has inserted a sharded mutex for this key.
+            // So we want to hold this for as short as possible a time, and drop it
+            // before we hold it over an await.
+            //
+            // this is is the only block where we should hold a writelock on the whole mutex map
+            {
+                let mut map_write_lock = self.established_conn_writelock.write().await;
+                match map_write_lock.get(&hash_key) {
+                    Some(_) => {
+                        debug!("already have conn for key {:#?}", hash_key);
+                    }
+                    None => {
+                        debug!("inserting conn mutex for key {:#?}", hash_key);
+                        map_write_lock.insert(hash_key, Some(Mutex::new(())));
+                    }
+                };
+                drop(map_write_lock);
+            }
+
+            // Now we know _someone_ won the race to insert a conn mutex, we don't need a writelock
+            // on the outer map anymore - so we can just readlock the outer map,
+            // and get the inner mutex for this connkey that we care about.
+            //
+            // This unblocks other tasks spawning connections against other keys, but blocks other
+            // tasks spawning connections against THIS key - which is what we want.
+
+            // NOTE: This inner, key-specific mutex is a tokio::async::Mutex, and not a stdlib sync mutex.
+            // these differ from the stdlib sync mutex in that they are (slightly) slower
+            // (they effectively sleep the current task) and they can be held over an await.
+            // The tokio docs (rightly) advise you to not use these,
+            // because holding a lock over an await is a great way to create deadlocks if the await you
+            // hold it over does not resolve.
+            //
+            // HOWEVER. Here we know this connection will either establish or timeout
+            // and we WANT other tasks to go back to sleep if there is an outstanding lock.
+            // So the downsides are actually useful (we WANT task contention -
+            // to block other parallel tasks from trying to spawn a connection if we are already doing so)
+            let map_read_lock = self.established_conn_writelock.read().await;
+            let exist_conn_lock = map_read_lock.get(&hash_key).unwrap();
+            let found_conn = match exist_conn_lock.as_ref().unwrap().try_lock() {
+                Ok(_guard) => {
+                    // if we get here, either we won the connlock race and can create one,
+                    // or someone else won, but the streamcount for the one they added is already hit,
+                    // so we should start and insert another.
+                    debug!("appears we need a new conn, retaining connlock");
+                    debug!("nothing else is creating a conn, make one");
+                    let pool_conn = self.spawn_new_pool_conn(key.clone()).await;
+                    let client = Client(
+                        pool_conn?,
+                        Arc::new(AtomicU16::new(0)),
+                        self.max_streamcount,
+                    );
+
+                    debug!(
+                        "starting new conn for key {:#?} with pk {:#?}",
+                        key, pool_key
+                    );
+                    debug!("dropping lock");
+                    Some(client)
+                }
+                Err(_) => {
+                    // The sharded mutex for this connkey is already locked - someone else must be making a conn
+                    // if they are, try to wait for it, but bail if we find one and it's got a maxed streamcount.
+                    debug!("something else is creating a conn, wait for it");
+                    let waiter = self.pool_watcher.changed();
+                    tokio::pin!(waiter);
+
+                    loop {
+                        tokio::select! {
+                            _ = &mut  waiter => {
+                                debug!("notified a new conn was enpooled, checking for hash {:#?}", hash_key);
+
+                                let existing_conn = self.connected_pool.get(&hash_key);// .and_then(|e_conn| {
+
+                                        //         debug!("while waiting for new conn, got existing conn for key {:#?}", key);
+                                        // });
+                                match existing_conn {
+                                    None => {
+                                        debug!("got nothin");
+                                        continue;
+                                    }
+                                    Some(e_conn) => {
+                                        debug!("found existing conn after waiting");
+                                        if e_conn.at_max_streamcount() {
+                                            debug!("found existing conn for key {:#?}, but streamcount is maxed", key);
+                                            break None;
+                                        }
+                                        break Some(e_conn);
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                }
+            };
+
+            match found_conn {
+                Some(f_conn) => {
+                    self.connected_pool.put(&pool_key, f_conn.clone());
+                    let _ = self.pool_notifier.send(true);
+                    return Ok(f_conn);
+                }
+
+                None => {
+                    debug!("spawning new conn for key {:#?} to replace", key);
+                    let pool_conn = self.spawn_new_pool_conn(key.clone()).await;
+                    let r_conn = Client(
+                        pool_conn?,
+                        Arc::new(AtomicU16::new(0)),
+                        self.max_streamcount,
+                    );
+                    self.connected_pool.put(&pool_key, r_conn.clone());
+                    let _ = self.pool_notifier.send(true);
+                    return Ok(r_conn);
+                }
+            }
+        }
+    }
+
+    async fn first_checkout_conn_from_pool(
+        &self,
+        key: &WorkloadKey,
+        hash_key: u64,
+        pool_key: &pingora_pool::ConnectionMeta,
+    ) -> Option<Client> {
+        let map_read_lock = self.established_conn_writelock.read().await;
+        match map_read_lock.get(&hash_key) {
+            Some(exist_conn_lock) => {
+                let _conn_lock = exist_conn_lock.as_ref().unwrap().lock().await;
+
+                debug!("getting conn for key {:#?} and hash {:#?}", key, hash_key);
+                self.connected_pool.get(&hash_key).and_then(|e_conn| {
+                    debug!("got existing conn for key {:#?}", key);
+                    if e_conn.at_max_streamcount() {
+                        debug!("got conn for key {:#?}, but streamcount is maxed", key);
+                        None
+                        // Some(Err(Error::WorkloadHBONEPoolConnStreamsMaxed))
+                    } else {
+                        self.connected_pool.put(&pool_key, e_conn.clone());
+                        let _ = self.pool_notifier.send(true);
+                        Some(e_conn)
+                    }
+                })
+            }
+            None => None,
+        }
+    }
+
+    async fn spawn_new_pool_conn(
+        &self,
+        key: WorkloadKey,
+    ) -> Result<http2::SendRequest<Empty<Bytes>>, Error> {
+        let clone_key = key.clone();
+        let mut c_builder = http2::Builder::new(crate::hyper_util::TokioExecutor);
+        let builder = c_builder
+            .initial_stream_window_size(self.cfg.window_size)
+            .max_frame_size(self.cfg.frame_size)
+            .initial_connection_window_size(self.cfg.connection_window_size);
+
+        let local = self
+            .cfg
+            .enable_original_source
+            .unwrap_or_default()
+            .then_some(key.src);
+        let cert = self.cert_manager.fetch_certificate(&key.src_id).await?;
+        let connector = cert.outbound_connector(key.dst_id)?;
+        let tcp_stream =
+            super::freebind_connect(local, key.dst, self.socket_factory.as_ref()).await?;
+        tcp_stream.set_nodelay(true)?; // TODO: this is backwards of expectations
+        let tls_stream = connector.connect(tcp_stream).await?;
+        let (request_sender, connection) = builder
+            .handshake(::hyper_util::rt::TokioIo::new(tls_stream))
+            .await
+            .map_err(Error::HttpHandshake)?;
+
+        // spawn a task to poll the connection and drive the HTTP state
+        // if we got a drain for that connection, respect it in a race
+        // it is important to have a drain here, or this connection will never terminate
+        let driver_drain = self.drainer.clone();
+        tokio::spawn(async move {
+            debug!("starting a connection driver for {:?}", clone_key);
+            tokio::select! {
+                    _ = driver_drain.signaled() => {
+                        debug!("draining outer HBONE connection");
+                    }
+                    res = connection=> {
+                        match res {
+                            Err(e) => {
+                                error!("Error in HBONE connection handshake: {:?}", e);
+                            }
+                            Ok(_) => {
+                                debug!("done with HBONE connection handshake: {:?}", res);
+                            }
+                        }
+                    }
+            }
+        });
+
+        Ok(request_sender)
     }
 }
 
 #[derive(Debug, Clone)]
-struct Client(http2::SendRequest<Empty<Bytes>>);
+pub struct Client(http2::SendRequest<Empty<Bytes>>, Arc<AtomicU16>, u16);
 
-impl Poolable for Client {
-    fn is_open(&self) -> bool {
-        self.0.is_ready()
+impl Client {
+    pub fn at_max_streamcount(&self) -> bool {
+        let curr_count = self.1.load(Ordering::Relaxed);
+        debug!("checking streamcount: {curr_count}");
+        if curr_count >= self.2 {
+            return true;
+        }
+        false
     }
 
-    fn reserve(self) -> Reservation<Self> {
-        let b = self.clone();
-        let a = self;
-        Reservation::Shared(a, b)
-    }
-
-    fn can_share(&self) -> bool {
-        true // http2 always shares
+    pub fn send_request(
+        &mut self,
+        req: Request<Empty<Bytes>>,
+    ) -> impl Future<Output = hyper::Result<Response<Incoming>>> {
+        // TODO should we enforce streamcount per-sent-request? This would be slow.
+        self.1.fetch_add(1, Ordering::Relaxed);
+        self.0.send_request(req)
     }
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
-pub struct Key {
+pub struct WorkloadKey {
     pub src_id: Identity,
     pub dst_id: Vec<Identity>,
     // In theory we can just use src,dst,node. However, the dst has a check that
@@ -96,157 +350,506 @@ pub struct Key {
     pub src: IpAddr,
 }
 
-#[derive(Debug)]
-pub struct Connection(Pooled<Client, Key>);
-
-impl Connection {
-    pub fn send_request(
-        &mut self,
-        req: Request<Empty<Bytes>>,
-    ) -> impl Future<Output = hyper::Result<Response<Incoming>>> {
-        self.0 .0.send_request(req)
-    }
-}
-
-impl Pool {
-    pub async fn connect<F>(&self, key: Key, connect: F) -> Result<Connection, Error>
-    where
-        F: Future<Output = Result<http2::SendRequest<Empty<Bytes>>, Error>>,
-    {
-        let reuse_connection = self.pool.checkout(key.clone());
-
-        let connect_pool = async {
-            let ver = pool::Ver::Http2;
-            let Some(connecting) = self.pool.connecting(&key, ver) else {
-                // There is already an existing connection establishment in flight.
-                // Return an error so
-                return Err(Error::PoolAlreadyConnecting);
-            };
-            let pc = Client(connect.await?);
-            let pooled = self.pool.pooled(connecting, pc);
-            Ok::<_, Error>(pooled)
-        };
-        pin_mut!(connect_pool);
-        let request_sender: Pooled<Client, _> =
-            match future::select(reuse_connection, connect_pool).await {
-                // Checkout won.
-                Either::Left((Ok(conn), _)) => {
-                    debug!(?key, "fetched existing connection");
-                    conn
-                }
-                // Checkout won, but had an error.
-                Either::Left((Err(err), connecting)) => match err {
-                    // Checked out a closed connection. Just keep connecting then
-                    pool::Error::CheckedOutClosedValue => connecting.await?,
-                    // Some other error, bubble it up
-                    _ => return Err(Error::Pool(err)),
-                },
-                // Connect won, checkout can just be dropped.
-                Either::Right((Ok(request_sender), _checkout)) => {
-                    debug!(?key, "established new connection");
-                    request_sender
-                }
-                // Connect won, checkout can just be dropped.
-                Either::Right((Err(err), checkout)) => {
-                    debug!(
-                        ?key,
-                        "connect won, but wait for existing pooled connection to establish"
-                    );
-                    match err {
-                        // Connect won but we already had an in-flight connection, so use that.
-                        Error::PoolAlreadyConnecting => checkout.await?,
-                        // Some other connection error
-                        err => return Err(err),
-                    }
-                }
-            };
-
-        Ok(Connection(request_sender))
-    }
-}
 #[cfg(test)]
 mod test {
     use std::convert::Infallible;
     use std::net::SocketAddr;
+    use std::time::Instant;
 
+    use crate::identity;
+
+    use drain::Watch;
+    use futures_util::StreamExt;
     use hyper::body::Incoming;
+
     use hyper::service::service_fn;
     use hyper::{Request, Response};
-    use tokio::net::{TcpListener, TcpStream};
+    use std::sync::atomic::AtomicU32;
+    use std::time::Duration;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+    use tokio::task::{self};
     use tracing::{error, info};
+
+    use ztunnel::test_helpers::*;
 
     use super::*;
 
     #[tokio::test]
-    async fn test_pool() {
-        // We'll bind to 127.0.0.1:3000
-        let addr = SocketAddr::from(([127, 0, 0, 1], 0));
-        async fn hello_world(req: Request<Incoming>) -> Result<Response<Empty<Bytes>>, Infallible> {
-            info!("got req {req:?}");
-            Ok(Response::builder().status(200).body(Empty::new()).unwrap())
-        }
+    async fn test_pool_reuses_conn_for_same_key() {
+        // crate::telemetry::setup_logging();
 
-        // We create a TcpListener and bind it to 127.0.0.1:3000
-        let listener = TcpListener::bind(addr).await.unwrap();
+        let (server_drain_signal, server_drain) = drain::channel();
 
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            // We start a loop to continuously accept incoming connections
-            loop {
-                let (stream, _) = listener.accept().await.unwrap();
+        let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
 
-                // Spawn a tokio task to serve multiple connections concurrently
-                tokio::task::spawn(async move {
-                    // Finally, we bind the incoming connection to our `hello` service
-                    if let Err(err) = crate::hyper_util::http2_server()
-                        .serve_connection(
-                            hyper_util::rt::TokioIo::new(stream),
-                            service_fn(hello_world),
-                        )
-                        .await
-                    {
-                        println!("Error serving connection: {:?}", err);
-                    }
-                });
-            }
-        });
-        let pool = Pool::new();
-        let key = Key {
+        let cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            pool_max_streams_per_conn: 6,
+            ..crate::config::parse_config().unwrap()
+        };
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+
+        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr, server_drain);
+
+        let key1 = WorkloadKey {
             src_id: Identity::default(),
             dst_id: vec![Identity::default()],
             src: IpAddr::from([127, 0, 0, 2]),
-            dst: addr,
+            dst: server_addr,
         };
-        let connect = || async {
-            let builder = http2::Builder::new(TokioExec);
+        let client1 = spawn_client(pool.clone(), key1.clone(), server_addr, 2).await;
+        let client2 = spawn_client(pool.clone(), key1.clone(), server_addr, 2).await;
+        let client3 = spawn_client(pool.clone(), key1, server_addr, 2).await;
 
-            let tcp_stream = TcpStream::connect(addr).await?;
-            let (request_sender, connection) = builder
-                .handshake(hyper_util::rt::TokioIo::new(tcp_stream))
-                .await?;
-            // spawn a task to poll the connection and drive the HTTP state
-            tokio::spawn(async move {
-                if let Err(e) = connection.await {
-                    error!("Error in connection handshake: {:?}", e);
+        drop(pool);
+        server_drain_signal.drain().await;
+        let real_conncount = server_handle.await.unwrap();
+        assert!(real_conncount == 1, "actual conncount was {real_conncount}");
+
+        assert!(!client1.is_err());
+        assert!(!client2.is_err());
+        assert!(!client3.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_pool_does_not_reuse_conn_for_diff_key() {
+        let (server_drain_signal, server_drain) = drain::channel();
+        let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
+
+        // crate::telemetry::setup_logging();
+
+        let cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            pool_max_streams_per_conn: 10,
+            ..crate::config::parse_config().unwrap()
+        };
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr, server_drain);
+
+        let key1 = WorkloadKey {
+            src_id: Identity::default(),
+            dst_id: vec![Identity::default()],
+            src: IpAddr::from([127, 0, 0, 2]),
+            dst: server_addr,
+        };
+        let key2 = WorkloadKey {
+            src_id: Identity::default(),
+            dst_id: vec![Identity::default()],
+            src: IpAddr::from([127, 0, 0, 3]),
+            dst: server_addr,
+        };
+
+        let client1 = spawn_client(pool.clone(), key1, server_addr, 2).await;
+        let client2 = spawn_client(pool.clone(), key2, server_addr, 2).await;
+
+        drop(pool);
+        server_drain_signal.drain().await;
+        let real_conncount = server_handle.await.unwrap();
+        assert!(real_conncount == 2, "actual conncount was {real_conncount}");
+
+        assert!(!client1.is_err());
+        assert!(!client2.is_err()); // expect this to panic - we used a new key
+    }
+
+    #[tokio::test]
+    async fn test_pool_respects_per_conn_stream_limit() {
+        let (server_drain_signal, server_drain) = drain::channel();
+        let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
+
+        let cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            pool_max_streams_per_conn: 3,
+            ..crate::config::parse_config().unwrap()
+        };
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr, server_drain);
+
+        let key1 = WorkloadKey {
+            src_id: Identity::default(),
+            dst_id: vec![Identity::default()],
+            src: IpAddr::from([127, 0, 0, 2]),
+            dst: server_addr,
+        };
+        let client1 = spawn_client(pool.clone(), key1.clone(), server_addr, 4).await;
+        let client2 = spawn_client(pool.clone(), key1, server_addr, 2).await;
+
+        drop(pool);
+        server_drain_signal.drain().await;
+
+        let real_conncount = server_handle.await.unwrap();
+        assert!(real_conncount == 2, "actual conncount was {real_conncount}");
+
+        assert!(!client1.is_err());
+        assert!(!client2.is_err()); // expect this to panic - same key, but stream limit of 3
+    }
+
+    #[tokio::test]
+    async fn test_pool_handles_many_conns_per_key() {
+        let (server_drain_signal, server_drain) = drain::channel();
+        let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
+
+        let cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            pool_max_streams_per_conn: 2,
+            ..crate::config::parse_config().unwrap()
+        };
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+
+        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr, server_drain);
+
+        let key1 = WorkloadKey {
+            src_id: Identity::default(),
+            dst_id: vec![Identity::default()],
+            src: IpAddr::from([127, 0, 0, 2]),
+            dst: server_addr,
+        };
+        let client1 = spawn_client(pool.clone(), key1.clone(), server_addr, 4).await;
+        let client2 = spawn_client(pool.clone(), key1.clone(), server_addr, 4).await;
+
+        drop(pool);
+        server_drain_signal.drain().await;
+
+        let real_conncount = server_handle.await.unwrap();
+        assert!(real_conncount == 2, "actual conncount was {real_conncount}");
+
+        assert!(!client1.is_err());
+        assert!(!client2.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_pool_100_clients_streamexhaust() {
+        // crate::telemetry::setup_logging();
+
+        let (server_drain_signal, server_drain) = drain::channel();
+        let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
+
+        let cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            pool_max_streams_per_conn: 50,
+            ..crate::config::parse_config().unwrap()
+        };
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr, server_drain);
+
+        let key1 = WorkloadKey {
+            src_id: Identity::default(),
+            dst_id: vec![Identity::default()],
+            src: IpAddr::from([127, 0, 0, 2]),
+            dst: server_addr,
+        };
+        let client_count = 100;
+        let mut count = 0u32;
+        let mut tasks = futures::stream::FuturesUnordered::new();
+        loop {
+            count += 1;
+            tasks.push(spawn_client(pool.clone(), key1.clone(), server_addr, 100));
+
+            if count == client_count {
+                break;
+            }
+        }
+        while let Some(_) = tasks.next().await {
+            continue;
+        }
+
+        drop(pool);
+
+        server_drain_signal.drain().await;
+        let real_conncount = server_handle.await.unwrap();
+        assert!(real_conncount == 2, "actual conncount was {real_conncount}");
+    }
+
+    #[tokio::test]
+    async fn test_pool_100_clients_singleconn() {
+        let _cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            ..crate::config::parse_config().unwrap()
+        };
+
+        // crate::telemetry::setup_logging();
+
+        let (server_drain_signal, server_drain) = drain::channel();
+        let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
+
+        let cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            pool_max_streams_per_conn: 1000,
+            ..crate::config::parse_config().unwrap()
+        };
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr, server_drain);
+
+        let key1 = WorkloadKey {
+            src_id: Identity::default(),
+            dst_id: vec![Identity::default()],
+            src: IpAddr::from([127, 0, 0, 2]),
+            dst: server_addr,
+        };
+        let client_count = 100;
+        let mut count = 0u32;
+        let mut tasks = futures::stream::FuturesUnordered::new();
+        loop {
+            count += 1;
+            tasks.push(spawn_client(pool.clone(), key1.clone(), server_addr, 100));
+
+            if count == client_count {
+                break;
+            }
+        }
+        while let Some(_) = tasks.next().await {
+            continue;
+        }
+
+        drop(pool);
+
+        server_drain_signal.drain().await;
+        let real_conncount = server_handle.await.unwrap();
+        assert!(real_conncount == 1, "actual conncount was {real_conncount}");
+    }
+
+    #[tokio::test]
+    async fn test_pool_100_clients_100_srcs() {
+        let _cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            ..crate::config::parse_config().unwrap()
+        };
+
+        // crate::telemetry::setup_logging();
+
+        let (server_drain_signal, server_drain) = drain::channel();
+        let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
+
+        let cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            pool_max_streams_per_conn: 100,
+            ..crate::config::parse_config().unwrap()
+        };
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr, server_drain);
+
+        let client_count = 100;
+        let mut count = 0u8;
+        let mut tasks = futures::stream::FuturesUnordered::new();
+        loop {
+            count += 1;
+
+            let key1 = WorkloadKey {
+                src_id: Identity::default(),
+                dst_id: vec![Identity::default()],
+                src: IpAddr::from([127, 0, 0, count.into()]),
+                dst: server_addr,
+            };
+            // key1.src = IpAddr::from([127, 0, 0, count]);
+
+            tasks.push(spawn_client(pool.clone(), key1.clone(), server_addr, 100));
+
+            if count == client_count {
+                break;
+            }
+        }
+        while let Some(_) = tasks.next().await {
+            continue;
+        }
+
+        drop(pool);
+
+        server_drain_signal.drain().await;
+        let real_conncount = server_handle.await.unwrap();
+        assert!(
+            real_conncount == 100,
+            "actual conncount was {real_conncount}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pool_1000_clients_3_srcs() {
+        let _cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            ..crate::config::parse_config().unwrap()
+        };
+
+        // crate::telemetry::setup_logging();
+
+        let (server_drain_signal, server_drain) = drain::channel();
+        let (server_addr, server_handle) = spawn_server(server_drain.clone()).await;
+
+        let cfg = crate::config::Config {
+            local_node: Some("local-node".to_string()),
+            pool_max_streams_per_conn: 1000,
+            ..crate::config::parse_config().unwrap()
+        };
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let pool = WorkloadHBONEPool::new(cfg.clone(), sock_fact, cert_mgr, server_drain);
+
+        let mut key1 = WorkloadKey {
+            src_id: Identity::default(),
+            dst_id: vec![Identity::default()],
+            src: IpAddr::from([127, 0, 0, 1]),
+            dst: server_addr,
+        };
+
+        let client_count = 1000;
+        let mut count = 0u32;
+        let mut tasks = futures::stream::FuturesUnordered::new();
+        loop {
+            count += 1;
+            if count % 2 == 0 {
+                debug!("using key 2");
+                key1.src = IpAddr::from([127, 0, 0, 4]);
+            } else if count % 3 == 0 {
+                debug!("using key 3");
+                key1.src = IpAddr::from([127, 0, 0, 6]);
+            } else {
+                debug!("using key 1");
+                key1.src = IpAddr::from([127, 0, 0, 2]);
+            }
+
+            tasks.push(spawn_client(pool.clone(), key1.clone(), server_addr, 1));
+
+            if count == client_count {
+                break;
+            }
+        }
+        while let Some(_) = tasks.next().await {
+            continue;
+        }
+
+        drop(pool);
+
+        server_drain_signal.drain().await;
+        let real_conncount = server_handle.await.unwrap();
+        assert!(real_conncount == 3, "actual conncount was {real_conncount}");
+    }
+
+    fn spawn_client(
+        mut pool: WorkloadHBONEPool,
+        key: WorkloadKey,
+        remote_addr: SocketAddr,
+        req_count: u32,
+    ) -> task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let req = || {
+                hyper::Request::builder()
+                    .uri(format!("{remote_addr}"))
+                    .method(hyper::Method::CONNECT)
+                    .version(hyper::Version::HTTP_2)
+                    .body(Empty::<Bytes>::new())
+                    .unwrap()
+            };
+
+            let start = Instant::now();
+
+            let mut c1 = pool
+                .connect(key.clone())
+                // needs tokio_unstable, but useful
+                // .instrument(tracing::debug_span!("client_tid", tid=%tokio::task::id()))
+                .await
+                .unwrap();
+            debug!(
+                "client spent {}ms waiting for conn",
+                start.elapsed().as_millis()
+            );
+
+            let mut count = 0u32;
+            loop {
+                count += 1;
+                if c1.send_request(req()).await.unwrap().status() != 200 {
+                    panic!("nope")
+                }
+
+                if count >= req_count {
+                    break;
+                }
+            }
+        })
+    }
+
+    async fn spawn_server(stop: Watch) -> (SocketAddr, task::JoinHandle<u32>) {
+        // We'll bind to 127.0.0.1:3000
+        let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+        let test_cfg = test_config();
+        async fn hello_world(req: Request<Incoming>) -> Result<Response<Empty<Bytes>>, Infallible> {
+            info!("hello world: received request");
+            tokio::task::spawn(async move {
+                match hyper::upgrade::on(req).await {
+                    Ok(upgraded) => {
+                        let (mut ri, mut wi) =
+                            tokio::io::split(hyper_util::rt::TokioIo::new(upgraded));
+                        // Signal we are the waypoint so tests can validate this
+                        wi.write_all(b"waypoint\n").await.unwrap();
+                        tcp::handle_stream(tcp::Mode::ReadWrite, &mut ri, &mut wi).await;
+                    }
+                    Err(e) => error!("No upgrade {e}"),
                 }
             });
-            Ok(request_sender)
-        };
-        let req = || {
-            hyper::Request::builder()
-                .uri(format!("http://{addr}"))
-                .method(hyper::Method::GET)
-                .version(hyper::Version::HTTP_2)
-                .body(Empty::<Bytes>::new())
-                .unwrap()
-        };
-        let mut c1 = pool.connect(key.clone(), connect()).await.unwrap();
-        let mut c2 = pool
-            .connect(key, async { unreachable!("should use pooled connection") })
-            .await
-            .unwrap();
-        assert_eq!(c1.send_request(req()).await.unwrap().status(), 200);
-        assert_eq!(c1.send_request(req()).await.unwrap().status(), 200);
-        assert_eq!(c2.send_request(req()).await.unwrap().status(), 200);
+            Ok::<_, Infallible>(Response::new(http_body_util::Empty::<Bytes>::new()))
+        }
+
+        let conn_count: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
+        let _drop_conn_count: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
+
+        // We create a TcpListener and bind it to 127.0.0.1:3000
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let bound_addr = listener.local_addr().unwrap();
+
+        let certs = crate::tls::mock::generate_test_certs(
+            &Identity::default().into(),
+            Duration::from_secs(0),
+            Duration::from_secs(100),
+        );
+        let acceptor = crate::tls::mock::MockServerCertProvider::new(certs);
+        let mut tls_stream = crate::hyper_util::tls_server(acceptor, listener);
+
+        let srv_handle = tokio::spawn(async move {
+            // We start a loop to continuously accept incoming connections
+            // and also count them
+            let movable_count = conn_count.clone();
+            let accept = async move {
+                loop {
+                    let stream = tls_stream.next().await.unwrap();
+                    movable_count.fetch_add(1, Ordering::Relaxed);
+                    debug!("bump serverconn");
+
+                    // Spawn a tokio task to serve multiple connections concurrently
+                    tokio::task::spawn(async move {
+                        // Finally, we bind the incoming connection to our `hello` service
+                        if let Err(err) = crate::hyper_util::http2_server()
+                            .initial_stream_window_size(test_cfg.window_size)
+                            .initial_connection_window_size(test_cfg.connection_window_size)
+                            .max_frame_size(test_cfg.frame_size)
+                            // 64KB max; default is 16MB driven from Golang's defaults
+                            // Since we know we are going to recieve a bounded set of headers, more is overkill.
+                            .max_header_list_size(65536)
+                            .serve_connection(
+                                hyper_util::rt::TokioIo::new(stream),
+                                service_fn(hello_world),
+                            )
+                            .await
+                        {
+                            println!("Error serving connection: {:?}", err);
+                        }
+                    });
+                }
+            };
+            tokio::select! {
+                _ = accept => {}
+                _ = stop.signaled() => {
+                    debug!("GOT STOP SERVER");
+                }
+            };
+
+            return conn_count.load(Ordering::Relaxed);
+        });
+
+        (bound_addr, srv_handle)
     }
 }

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -51,7 +51,7 @@ static GLOBAL_CONN_COUNT: AtomicI32 = AtomicI32::new(0);
 //   by flow control throttling.
 #[derive(Clone)]
 pub struct WorkloadHBONEPool {
-    pool_notifier: watch::Sender<bool>,
+    pool_notifier: Arc::<watch::Sender<bool>>, // This is already impl clone? rustc complains that it isn't, tho
     pool_watcher: watch::Receiver<bool>,
     max_streamcount: u16,
     // this is effectively just a convenience data type - a rwlocked hashmap with keying and LRU drops
@@ -78,7 +78,7 @@ impl WorkloadHBONEPool {
             cfg.pool_max_streams_per_conn
         );
         Self {
-            pool_notifier: tx,
+            pool_notifier: Arc::new(tx),
             pool_watcher: rx,
             max_streamcount: cfg.pool_max_streams_per_conn,
             // the number here is simply the number of unique src/dest keys

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -70,8 +70,7 @@ impl Socks5 {
                 let pool = crate::proxy::pool::WorkloadHBONEPool::new(
                             self.pi.cfg.clone(),
                             self.pi.socket_factory.clone(),
-                            self.pi.cert_manager.clone(),
-                            stream_drain.clone());
+                            self.pi.cert_manager.clone());
                 match socket {
                     Ok((stream, remote)) => {
                         info!("accepted outbound connection from {}", remote);

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -68,9 +68,10 @@ impl Socks5 {
                 // TODO creating a new HBONE pool for SOCKS5 here may not be ideal,
                 // but ProxyInfo is overloaded and only `outbound` should ever use the pool.
                 let pool = crate::proxy::pool::WorkloadHBONEPool::new(
-                            self.pi.cfg.clone(),
-                            self.pi.socket_factory.clone(),
-                            self.pi.cert_manager.clone());
+                    self.pi.cfg.clone(),
+                    self.pi.socket_factory.clone(),
+                    self.pi.cert_manager.clone(),
+                );
                 match socket {
                     Ok((stream, remote)) => {
                         info!("accepted outbound connection from {}", remote);

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -65,6 +65,8 @@ impl Socks5 {
                 let socket = self.listener.accept().await;
                 let inpod = self.pi.cfg.inpod_enabled;
                 let stream_drain = inner_drain.clone();
+                // TODO creating a new HBONE pool for SOCKS5 here may not be ideal,
+                // but ProxyInfo is overloaded and only `outbound` should ever use the pool.
                 let pool = crate::proxy::pool::WorkloadHBONEPool::new(
                             self.pi.cfg.clone(),
                             self.pi.socket_factory.clone(),

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -65,12 +65,18 @@ impl Socks5 {
                 let socket = self.listener.accept().await;
                 let inpod = self.pi.cfg.inpod_enabled;
                 let stream_drain = inner_drain.clone();
+                let pool = crate::proxy::pool::WorkloadHBONEPool::new(
+                            self.pi.cfg.clone(),
+                            self.pi.socket_factory.clone(),
+                            self.pi.cert_manager.clone(),
+                            stream_drain.clone());
                 match socket {
                     Ok((stream, remote)) => {
                         info!("accepted outbound connection from {}", remote);
                         let oc = OutboundConnection {
                             pi: self.pi.clone(),
                             id: TraceParent::new(),
+                            pool,
                         };
                         tokio::spawn(async move {
                             if let Err(err) = handle(oc, stream, stream_drain, inpod).await {

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -100,6 +100,12 @@ impl ProxyFactory {
                 self.proxy_metrics.clone().unwrap(),
                 socket_factory.clone(),
                 proxy_workload_info,
+                crate::proxy::pool::WorkloadHBONEPool::new(
+                    self.config.clone(),
+                    socket_factory.clone(),
+                    self.cert_manager.clone(),
+                    drain.clone(),
+                ),
             );
             result.connection_manager = Some(cm);
             result.proxy = Some(Proxy::from_inputs(pi, drain.clone()).await?);

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -100,12 +100,6 @@ impl ProxyFactory {
                 self.proxy_metrics.clone().unwrap(),
                 socket_factory.clone(),
                 proxy_workload_info,
-                crate::proxy::pool::WorkloadHBONEPool::new(
-                    self.config.clone(),
-                    socket_factory.clone(),
-                    self.cert_manager.clone(),
-                    drain.clone(),
-                ),
             );
             result.connection_manager = Some(cm);
             result.proxy = Some(Proxy::from_inputs(pi, drain.clone()).await?);


### PR DESCRIPTION
This works around several issues found in https://github.com/istio/ztunnel/issues/864 relating to clients (loadgen mostly) that open many connections very rapidly.

1. `hyper`'s pooling library has rather basic scheduling controls, to the point where we can rather easily overwhelm "send_request" such that it never resolves. Tweaking server/client streamlimits does not work around this, as the pooling scheduler does not respect them when selecting pooled streams, and will simply allow a single conn to get backed up.

2. `hyper`'s pooling library doesn't really have the concept of multiple HTTP/2 connections to the same dest, which makes sense as the HTTP/2 spec doesn't recommend this (the spec says SHOULD NOT instead of MUST NOT, which in spec-speak is "we can't stop you, I guess")

3. Racing to create connections creates problems in scenarios where a lot of connection attempts are made at once due to lack of throttling - many connections can actually be established or "cross the finish line at the same time", when we only need one, and this noise can compromise the ability of the local or dest ztunnel to respond to other workloads.

Notes:

- By design, this pool does not manage Hyper client state, nor is it tightly coupled with it. All it does is hold references to Hyper clients that can be reused, and evict its own held references to those Hyper clients when they cannot be reused. The rest is managing async access.


- By design, this pool is designed to create backpressure when one client opens many connections to the same destination at the same time. It does this by locking connection-mutative operations per src/dest key.

- The only write lock should be on that inner src/dest key. The only operations inside the pool that must be ordered/force ordering are 1. Ensuring that we have a key writelock in the outer map. 2. Locking the inner key writelock. The rest should not demand any sort of ordering to be safe. 

- This pool does not decrement stream counts - when a connection hits its max stream count, the pool pops the reference and removes it from the rotation, leaving the connection to die when whatever is using it drops all the refs, and will create a new connection on the next go round. This leads to simpler accounting, while still maintaining the protections against connection storms that we need.
