### PR TITLE
block illegal calls in inpod mode

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -194,8 +194,11 @@ impl OutboundConnection {
     ) {
         let start = Instant::now();
 
+        // Block calls to ztunnel directly, unless we are in "in-pod".
+        // For in-pod, this isn't an issue and is useful: this allows things like prometheus scraping ztunnel.
         if self.pi.cfg.proxy_mode == ProxyMode::Shared
             && Some(dest_addr.ip()) == self.pi.cfg.local_ip
+            && !self.pi.cfg.inpod_enabled
         {
             metrics::log_early_deny(source_addr, dest_addr, Reporter::source, Error::SelfCall);
             return;

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -15,6 +15,7 @@
 use anyhow::Result;
 use byteorder::{BigEndian, ByteOrder};
 use drain::Watch;
+
 use std::net::{IpAddr, SocketAddr};
 
 use tokio::io::AsyncReadExt;


### PR DESCRIPTION
Part of https://github.com/istio/ztunnel/issues/928

This removes the obsolete call protections for inpod, and adds
equivilents
