### PR TITLE
dns: remove unbounded cardinality in metrics

### DIFF
--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -438,7 +438,6 @@ impl Store {
         self.metrics.increment(&DnsRequest {
             request,
             source: client,
-            destination: None,
         });
 
         // Increment counter for forwarded requests.
@@ -485,7 +484,6 @@ impl Resolver for Store {
                 self.metrics.increment(&DnsRequest {
                     request,
                     source: None,
-                    destination: None,
                 });
 
                 return Err(LookupError::ResponseCode(ResponseCode::ServFail));
@@ -510,7 +508,6 @@ impl Resolver for Store {
         self.metrics.increment(&DnsRequest {
             request,
             source: Some(&client),
-            destination: Some(&service_match.server),
         });
 
         // Get the addresses for the service.


### PR DESCRIPTION
This removes all destination attributes, but keeps source. We don't
report source in sidecar, but implicitly get it because its per-pod.

Fixes https://github.com/istio/ztunnel/issues/932

Prior art: cilium does not have src/dst meta:
https://docs.cilium.io/en/latest/observability/metrics/#dns
