### PR TITLE
admin: make extended handlers inline into `/config_dump`

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -306,7 +306,6 @@ async fn handle_config_dump(
         anyhow::bail!("config dump is not a key-value pair")
     };
 
-    kv.insert("static".to_string(), serde_json::json!([handlers.len()]));
     for h in handlers {
         let x = h.handle()?;
         kv.insert(h.key().to_string(), x);


### PR DESCRIPTION
Current the extensions need to be their own path. Its a bit easier to
operate on things all under config_dump so we don't have a ton of URLs.

This changes things to inline all of them. Extensions can build a custom
key.
