### PR TITLE
Track outbound connections

### DIFF
--- a/src/inpod/admin.rs
+++ b/src/inpod/admin.rs
@@ -144,7 +144,7 @@ impl WorkloadManagerAdminHandler {
 
 impl crate::admin::AdminHandler2 for WorkloadManagerAdminHandler {
     fn key(&self) -> &'static str {
-        "workload_state"
+        "workloadState"
     }
 
     fn handle(&self) -> anyhow::Result<serde_json::Value> {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -40,7 +40,7 @@ use crate::rbac::Connection;
 use crate::state::service::{endpoint_uid, Service, ServiceDescription};
 use crate::state::workload::address::Address;
 use crate::state::workload::{network_addr, GatewayAddress, Workload};
-use crate::state::{DemandProxyState, ProxyRbacContext, WorkloadInfo};
+use crate::state::{DemandProxyState, WorkloadInfo};
 use crate::{config, identity, socket, tls};
 
 pub mod connection_manager;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -40,7 +40,7 @@ use crate::rbac::Connection;
 use crate::state::service::{endpoint_uid, Service, ServiceDescription};
 use crate::state::workload::address::Address;
 use crate::state::workload::{network_addr, GatewayAddress, Workload};
-use crate::state::{DemandProxyState, WorkloadInfo};
+use crate::state::{DemandProxyState, ProxyRbacContext, WorkloadInfo};
 use crate::{config, identity, socket, tls};
 
 pub mod connection_manager;
@@ -299,6 +299,9 @@ pub enum Error {
 
     #[error("ip mismatch: {0} != {1}")]
     IPMismatch(IpAddr, IpAddr),
+
+    #[error("bug: connection seen twice")]
+    DoubleConnection,
 }
 
 const PROXY_PROTOCOL_AUTHORITY_TLV: u8 = 0xD0;

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -226,6 +226,11 @@ impl OutboundConnection {
             return;
         }
         let connection_metrics = Self::conn_metrics_from_request(&req);
+        // TODO: should we use the original address or the actual address? Both seems nice!
+        let _conn_guard =
+            self.pi
+                .connection_manager
+                .track_outbound(source_addr, dest_addr, req.gateway);
 
         let metrics = self.pi.metrics.clone();
         let hbone_target = if req.request_type == RequestType::ToServerWaypoint {

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -162,7 +162,7 @@ impl TestApp {
         };
 
         let result: HashMap<String, inpod::admin::ProxyState> =
-            serde_json::from_value(v.remove("workload_state").unwrap())?;
+            serde_json::from_value(v.remove("workloadState").unwrap())?;
         Ok(result)
     }
 


### PR DESCRIPTION
- **Refactor connection tracker**
- **Track outbound connections as well**

Ultimately this enables istioctl to give us:

```
WORKLOAD                                      DIRECTION LOCAL                                              REMOTE                                             REMOTE TARGET
cartservice-bffc98bf4-bmqsg.anthos            Inbound   cartservice-bffc98bf4-bmqsg.anthos:7070            checkoutservice-c58746cd5-prxg9.anthos:41903
cartservice-bffc98bf4-bmqsg.anthos            Inbound   cartservice-bffc98bf4-bmqsg.anthos:7070            frontend-86c4744d65-f6xwb.anthos:50955
cartservice-bffc98bf4-bmqsg.anthos            Outbound  cartservice-bffc98bf4-bmqsg.anthos:50320           redis-cart-7ff8f4d6ff-lmlwg.anthos:6379            redis-cart.anthos.svc.cluster.local:6379
cartservice-bffc98bf4-bmqsg.anthos            Outbound  cartservice-bffc98bf4-bmqsg.anthos:50330           redis-cart-7ff8f4d6ff-lmlwg.anthos:6379            redis-cart.anthos.svc.cluster.local:6379
productcatalogservice-64898b8c5f-pqx6h.anthos Inbound   productcatalogservice-64898b8c5f-pqx6h.anthos:3550 recommendationservice-85846457-79l2f.anthos:58205
productcatalogservice-64898b8c5f-pqx6h.anthos Inbound   productcatalogservice-64898b8c5f-pqx6h.anthos:3550 checkoutservice-c58746cd5-prxg9.anthos:46941
productcatalogservice-64898b8c5f-pqx6h.anthos Inbound   productcatalogservice-64898b8c5f-pqx6h.anthos:3550 frontend-86c4744d65-f6xwb.anthos:39685
frontend-86c4744d65-f6xwb.anthos              Inbound   frontend-86c4744d65-f6xwb.anthos:8080              loadgenerator-866ccfdfc9-9mhz7.anthos:48071
frontend-86c4744d65-f6xwb.anthos              Outbound  frontend-86c4744d65-f6xwb.anthos:44436             checkoutservice-c58746cd5-prxg9.anthos:5050        checkoutservice.anthos.svc.cluster.local:5050
frontend-86c4744d65-f6xwb.anthos              Outbound  frontend-86c4744d65-f6xwb.anthos:40386             cartservice-bffc98bf4-bmqsg.anthos:7070            cartservice.anthos.svc.cluster.local:7070
frontend-86c4744d65-f6xwb.anthos              Outbound  frontend-86c4744d65-f6xwb.anthos:50976             productcatalogservice-64898b8c5f-pqx6h.anthos:3550 productcatalogservice.anthos.svc.cluster.local:3550
frontend-86c4744d65-f6xwb.anthos              Outbound  frontend-86c4744d65-f6xwb.anthos:37700             recommendationservice-85846457-79l2f.anthos:8080   recommendationservice.anthos.svc.cluster.local:8080
frontend-86c4744d65-f6xwb.anthos              Outbound  frontend-86c4744d65-f6xwb.anthos:40528             adservice-684fbd8977-r6vsh.anthos:9555             adservice.anthos.svc.cluster.local:9555
frontend-86c4744d65-f6xwb.anthos              Outbound  frontend-86c4744d65-f6xwb.anthos:41618             shippingservice-77d6cdd487-v4fj6.anthos:50051      shippingservice.anthos.svc.cluster.local:50051
frontend-86c4744d65-f6xwb.anthos              Outbound  frontend-86c4744d65-f6xwb.anthos:48212             currencyservice-5495597f5-nwnd5.anthos:7000        currencyservice.anthos.svc.cluster.local:7000
emailservice-d74c4c797-xpkp2.anthos           Inbound   emailservice-d74c4c797-xpkp2.anthos:8080           checkoutservice-c58746cd5-prxg9.anthos:54561
recommendationservice-85846457-79l2f.anthos   Inbound   recommendationservice-85846457-79l2f.anthos:8080   frontend-86c4744d65-f6xwb.anthos:54843
recommendationservice-85846457-79l2f.anthos   Outbound  recommendationservice-85846457-79l2f.anthos:36164  productcatalogservice-64898b8c5f-pqx6h.anthos:3550 productcatalogservice.anthos.svc.cluster.local:3550
checkoutservice-c58746cd5-prxg9.anthos        Inbound   checkoutservice-c58746cd5-prxg9.anthos:5050        frontend-86c4744d65-f6xwb.anthos:40593
checkoutservice-c58746cd5-prxg9.anthos        Outbound  checkoutservice-c58746cd5-prxg9.anthos:39576       cartservice-bffc98bf4-bmqsg.anthos:7070            cartservice.anthos.svc.cluster.local:7070
checkoutservice-c58746cd5-prxg9.anthos        Outbound  checkoutservice-c58746cd5-prxg9.anthos:59008       emailservice-d74c4c797-xpkp2.anthos:8080           emailservice.anthos.svc.cluster.local:5000
checkoutservice-c58746cd5-prxg9.anthos        Outbound  checkoutservice-c58746cd5-prxg9.anthos:56736       currencyservice-5495597f5-nwnd5.anthos:7000        currencyservice.anthos.svc.cluster.local:7000
checkoutservice-c58746cd5-prxg9.anthos        Outbound  checkoutservice-c58746cd5-prxg9.anthos:57080       productcatalogservice-64898b8c5f-pqx6h.anthos:3550 productcatalogservice.anthos.svc.cluster.local:3550
checkoutservice-c58746cd5-prxg9.anthos        Outbound  checkoutservice-c58746cd5-prxg9.anthos:41766       paymentservice-5dd485cf9c-ks47b.anthos:50051       paymentservice.anthos.svc.cluster.local:50051
checkoutservice-c58746cd5-prxg9.anthos        Outbound  checkoutservice-c58746cd5-prxg9.anthos:39090       shippingservice-77d6cdd487-v4fj6.anthos:50051      shippingservice.anthos.svc.cluster.local:50051
redis-cart-7ff8f4d6ff-lmlwg.anthos            Inbound   redis-cart-7ff8f4d6ff-lmlwg.anthos:6379            cartservice-bffc98bf4-bmqsg.anthos:41363
currencyservice-5495597f5-nwnd5.anthos        Inbound   currencyservice-5495597f5-nwnd5.anthos:7000        frontend-86c4744d65-f6xwb.anthos:43913
currencyservice-5495597f5-nwnd5.anthos        Inbound   currencyservice-5495597f5-nwnd5.anthos:7000        checkoutservice-c58746cd5-prxg9.anthos:41455
adservice-684fbd8977-r6vsh.anthos             Inbound   adservice-684fbd8977-r6vsh.anthos:9555             frontend-86c4744d65-f6xwb.anthos:59253
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:60636        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:60638        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:60586        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:40164        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:40178        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:60628        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:60594        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:60608        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:60612        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
loadgenerator-866ccfdfc9-9mhz7.anthos         Outbound  loadgenerator-866ccfdfc9-9mhz7.anthos:60630        frontend-86c4744d65-f6xwb.anthos:8080              frontend.anthos.svc.cluster.local:80
paymentservice-5dd485cf9c-ks47b.anthos        Inbound   paymentservice-5dd485cf9c-ks47b.anthos:50051       checkoutservice-c58746cd5-prxg9.anthos:41735
shippingservice-77d6cdd487-v4fj6.anthos       Inbound   shippingservice-77d6cdd487-v4fj6.anthos:50051      checkoutservice-c58746cd5-prxg9.anthos:35323
shippingservice-77d6cdd487-v4fj6.anthos       Inbound   shippingservice-77d6cdd487-v4fj6.anthos:50051      frontend-86c4744d65-f6xwb.anthos:51271
```

Or waypoints:
```
WORKLOAD                       DIRECTION LOCAL                                REMOTE                                  REMOTE TARGET
echo-66d88ff694-tf8bm.default  Inbound   echo-66d88ff694-tf8bm.default:80     waypoint-654dccf598-229fx.default:50712
shell-56bd5dbdbf-24v42.default Outbound  shell-56bd5dbdbf-24v42.default:46034 waypoint-654dccf598-229fx.default:15008 echo.default.svc.cluster.local:80
```