### PR TITLE
metrics: make traffic metrics faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,16 +2326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "realm_io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419b106090b985e393ac20b68845ca77d5a7fc9af6126ae97fbd8825bbdbaf69"
-dependencies = [
- "libc",
- "tokio",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,7 +3656,6 @@ dependencies = [
  "prost-types",
  "rand 0.8.5",
  "rcgen",
- "realm_io",
  "ring",
  "rustc_version",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ prost = "0.12"
 prost-types = "0.12"
 rand = "0.8"
 rcgen = { version = "0.13", optional = true, features = ["pem"] }
-realm_io = "0.4"
 rustls = { version = "0.23", default-features = false }
 rustls-native-certs = "0.7.0"
 rustls-pemfile = "2.1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1976,16 +1976,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "realm_io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419b106090b985e393ac20b68845ca77d5a7fc9af6126ae97fbd8825bbdbaf69"
-dependencies = [
- "libc",
- "tokio",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3208,7 +3198,6 @@ dependencies = [
  "prost-types",
  "rand 0.8.5",
  "rcgen",
- "realm_io",
  "ring",
  "rustc_version",
  "rustls",

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -82,8 +82,8 @@ pub struct ConnectionGuard {
 impl ConnectionGuard {
     pub async fn handle_connection(
         mut self,
-        send: impl Future<Output = Result<(u64, u64), Error>> + Sized,
-    ) -> Result<(u64, u64), Error> {
+        send: impl Future<Output = Result<(), Error>> + Sized,
+    ) -> Result<(), Error> {
         let watch = self.watch.take().expect("watch cannot be taken twice");
         tokio::select! {
             res = send => {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -385,7 +385,7 @@ impl Inbound {
                     }
                 };
                 let res = conn_guard.handle_connection(send).await;
-                result_tracker.record(res.map(|_| ()));
+                result_tracker.record(res);
             })
             .in_current_span(),
         );

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -231,6 +231,6 @@ impl InboundPassthrough {
         };
 
         let res = conn_guard.handle_connection(send).await;
-        result_tracker.record(res.map(|_| ()));
+        result_tracker.record(res);
     }
 }

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -231,6 +231,6 @@ impl InboundPassthrough {
         };
 
         let res = conn_guard.handle_connection(send).await;
-        result_tracker.record(res);
+        result_tracker.record(res.map(|_| ()));
     }
 }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -263,7 +263,7 @@ impl OutboundConnection {
                     .await
             }
         };
-        result_tracker.record(res.map(|_| ()))
+        result_tracker.record(res)
     }
 
     async fn proxy_to_hbone(
@@ -273,7 +273,7 @@ impl OutboundConnection {
         outer_conn_drain: Option<Watch>,
         req: &Request,
         connection_stats: &ConnectionResult,
-    ) -> Result<(u64, u64), Error> {
+    ) -> Result<(), Error> {
         debug!(
             "proxy to {} using HBONE via {} type {:#?}",
             req.destination, req.gateway, req.request_type
@@ -406,7 +406,7 @@ impl OutboundConnection {
         stream: &mut TcpStream,
         req: &Request,
         connection_stats: &ConnectionResult,
-    ) -> Result<(u64, u64), Error> {
+    ) -> Result<(), Error> {
         info!(
             "Proxying to {} using TCP via {} type {:?}",
             req.destination, req.gateway, req.request_type

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -263,7 +263,7 @@ impl OutboundConnection {
                     .await
             }
         };
-        result_tracker.record(res)
+        result_tracker.record(res.map(|_| ()))
     }
 
     async fn proxy_to_hbone(

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -179,7 +179,7 @@ pub async fn copy_bidirectional<A, B>(
     downstream: &mut A,
     upstream: &mut B,
     stats: &ConnectionResult,
-) -> Result<(u64, u64), crate::proxy::Error>
+) -> Result<(), crate::proxy::Error>
 where
     A: AsyncRead + AsyncWrite + Unpin,
     B: AsyncRead + AsyncWrite + Unpin,
@@ -209,7 +209,7 @@ where
     tokio::try_join!(downstream_to_upstream, upstream_to_downstream)?;
 
     trace!(sent, received, "copy complete");
-    Ok((sent, received))
+    Ok(())
 }
 
 #[must_use = "futures do nothing unless you `.await` or poll them"]


### PR DESCRIPTION
Before, each r/w we lookup the metric and increment it.

Now, we look it up once and then just increment. The increment is just
Atomic.increment, which on x86 is the same as a simple `add`, which is
very fast (measured 1ns, but presumably its so fast benchmarking isn't
meaningful).

Since this is on the hot path, this is meaningful.

Given this, I don't think we will ever need to do
https://github.com/istio/ztunnel/pull/927#issuecomment-2060434505.

Also, addressed
https://github.com/istio/ztunnel/pull/927#discussion_r1569021128 and
cleaned up inbound which broke a function up into 2 which made things
more complex, not simpler.
