### PR TITLE
Make socks5 optional, off by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,8 @@ const ZTUNNEL_WORKER_THREADS: &str = "ZTUNNEL_WORKER_THREADS";
 const ENABLE_ORIG_SRC: &str = "ENABLE_ORIG_SRC";
 const PROXY_CONFIG: &str = "PROXY_CONFIG";
 
+const UNSTABLE_ENABLE_SOCKS5: &str = "UNSTABLE_ENABLE_SOCKS5";
+
 const DEFAULT_WORKER_THREADS: u16 = 2;
 const DEFAULT_ADMIN_PORT: u16 = 15000;
 const DEFAULT_READINESS_PORT: u16 = 15021;
@@ -117,7 +119,7 @@ pub struct Config {
     pub connection_window_size: u32,
     pub frame_size: u32,
 
-    pub socks5_addr: SocketAddr,
+    pub socks5_addr: Option<SocketAddr>,
     pub admin_addr: SocketAddr,
     pub stats_addr: SocketAddr,
     pub readiness_addr: SocketAddr,
@@ -300,6 +302,12 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         None => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), DEFAULT_DNS_PORT),
     };
 
+    let socks5_addr = if let Some(true) = parse(UNSTABLE_ENABLE_SOCKS5)? {
+        Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 15080))
+    } else {
+        None
+    };
+
     validate_config(Config {
         proxy: parse_default(ENABLE_PROXY, true)?,
         dns_proxy: pc
@@ -328,7 +336,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             DEFAULT_READINESS_PORT, // There is no config for this in ProxyConfig currently
         ),
 
-        socks5_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 15080),
+        socks5_addr,
         inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15008),
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15006),
         outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15001),

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -37,8 +37,8 @@ impl Socks5 {
     pub(super) async fn new(pi: ProxyInputs, drain: Watch) -> Result<Socks5, Error> {
         let listener: TcpListener = pi
             .socket_factory
-            .tcp_bind(pi.cfg.socks5_addr)
-            .map_err(|e| Error::Bind(pi.cfg.socks5_addr, e))?;
+            .tcp_bind(pi.cfg.socks5_addr.unwrap())
+            .map_err(|e| Error::Bind(pi.cfg.socks5_addr.unwrap(), e))?;
 
         info!(
             address=%listener.local_addr().expect("local_addr available"),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -99,7 +99,7 @@ pub fn test_config_with_port_xds_addr_and_root_cert(
         // and port 0 (to avoid port conflicts)
         // inbound_addr cannot do localhost since we abuse that its listening on all of 127.0.0.0/8 range.
         inbound_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
-        socks5_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        socks5_addr: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)),
         admin_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         readiness_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         stats_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -205,7 +205,7 @@ impl TestApp {
         // Always use IPv4 address. In theory, we can resolve `localhost` to pick to support any machine
         // However, we need to make sure the WorkloadStore knows about both families then.
         let socks_addr = with_ip(
-            self.proxy_addresses.socks5,
+            self.proxy_addresses.socks5.unwrap(),
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         );
         // Set source IP to TEST_WORKLOAD_SOURCE

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -119,7 +119,7 @@ impl WorkloadManager {
             let proxy_addresses = app.proxy_addresses.unwrap_or(proxy::Addresses {
                 inbound: "0.0.0.0:0".parse()?,
                 outbound: "0.0.0.0:0".parse()?,
-                socks5: "0.0.0.0:0".parse()?,
+                socks5: Some("0.0.0.0:0".parse()?),
             });
 
             let ta = TestApp {
@@ -130,7 +130,7 @@ impl WorkloadManager {
                 proxy_addresses: proxy::Addresses {
                     outbound: helpers::with_ip(proxy_addresses.outbound, ip),
                     inbound: helpers::with_ip(proxy_addresses.inbound, ip),
-                    socks5: helpers::with_ip(proxy_addresses.socks5, ip),
+                    socks5: proxy_addresses.socks5.map(|i| helpers::with_ip(i, ip)),
                 },
                 tcp_dns_proxy_address: Some(helpers::with_ip(
                     app.tcp_dns_proxy_address.unwrap_or("0.0.0.0:0".parse()?),

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -75,11 +75,6 @@ async fn test_conflicting_bind_error_outbound() {
 }
 
 #[tokio::test]
-async fn test_conflicting_bind_error_socks5() {
-    test_bind_conflict(|c| &mut c.socks5_addr).await;
-}
-
-#[tokio::test]
 async fn test_conflicting_bind_error_admin() {
     test_bind_conflict(|c| &mut c.admin_addr).await;
 }


### PR DESCRIPTION
This is a super security sensitive codepath, and mostly and experiment.
Make it opt in so we don't stumble into a CVE when we ship beta.
