### PR TITLE
metrics: Don't log 'hbone_target' as a string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ An example access log looks like (with newlines for readability; the real logs a
 ```text
 2024-04-11T15:38:42.182974Z  INFO access: connection complete
     src.addr=10.244.0.24:46238 src.workload="shell-6d8bcd654d-t88gp" src.namespace="default" src.identity="spiffe://cluster.local/ns/default/sa/default"
-    dst.addr=10.244.0.42:15008 dst.hbone_addr="10.96.108.116:80" dst.service="echo.default.svc.cluster.local"
+    dst.addr=10.244.0.42:15008 dst.hbone_addr=10.96.108.116:80 dst.service="echo.default.svc.cluster.local"
     direction="outbound" bytes_sent=67 bytes_recv=490 duration="13ms"
 ```
 

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -436,7 +436,7 @@ impl ConnectionResult {
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             dst.addr = %dst.0,
-            dst.hbone_addr = hbone_target.map(|r| tracing::field::display(r)),
+            dst.hbone_addr = hbone_target.map(tracing::field::display),
             dst.workload = dst.1,
             dst.namespace = tl.destination_canonical_service.as_ref(),
             dst.identity = tl.destination_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
@@ -489,7 +489,7 @@ impl ConnectionResult {
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             dst.addr = %self.dst.0,
-            dst.hbone_addr = self.hbone_target.map(|r| tracing::field::display(r)),
+            dst.hbone_addr = self.hbone_target.map(tracing::field::display),
             dst.service = tl.destination_service.as_ref(),
             dst.workload = self.dst.1,
             dst.namespace = tl.destination_canonical_service.as_ref(),

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -436,7 +436,7 @@ impl ConnectionResult {
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             dst.addr = %dst.0,
-            dst.hbone_addr = hbone_target.map(|r| r.to_string()),
+            dst.hbone_addr = hbone_target.map(|r| tracing::field::display(r)),
             dst.workload = dst.1,
             dst.namespace = tl.destination_canonical_service.as_ref(),
             dst.identity = tl.destination_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
@@ -489,7 +489,7 @@ impl ConnectionResult {
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             dst.addr = %self.dst.0,
-            dst.hbone_addr = self.hbone_target.map(|r| r.to_string()),
+            dst.hbone_addr = self.hbone_target.map(|r| tracing::field::display(r)),
             dst.service = tl.destination_service.as_ref(),
             dst.workload = self.dst.1,
             dst.namespace = tl.destination_canonical_service.as_ref(),


### PR DESCRIPTION
The other SocketAddr fields (src.addr and dst.addr) don't log as strings, so make them all consistent.