### PR TITLE
test: run `namespaced` tests without root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3616,6 +3626,7 @@ dependencies = [
  "bytes",
  "chrono",
  "criterion",
+ "ctor",
  "diff",
  "drain",
  "duration-str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ itertools = "0.12"
 keyed_priority_queue = "0.4"
 libc = "0.2"
 log = "0.4"
-nix = { version = "0.28", features = ["socket", "sched", "uio", "fs", "ioctl", "user"] }
+nix = { version = "0.28", features = ["socket", "sched", "uio", "fs", "ioctl", "user", "net", "mount"] }
 once_cell = "1.19"
 ppp = "2.2"
 pprof = { version = "0.13", features = ["protobuf", "protobuf-codec", "criterion"] }
@@ -134,4 +134,4 @@ matches = "0.1"
 test-case = "3.3"
 oid-registry = "0.7"
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
-#debug = true
+ctor = "0.2"

--- a/Development.md
+++ b/Development.md
@@ -166,7 +166,6 @@ POD_NAMESPACE=istio-system
 POD_NAME=ztunnel-worker1
 CA_ROOT_CA=/tmp/istio-root.pem
 XDS_ROOT_CA=/tmp/istio-root.pem
-CARGO_TARGET_$(rustc -vV | sed -n 's|host: ||p' | tr '[:lower:]' '[:upper:]'| tr - _)_RUNNER="sudo -E"
 cargo run proxy ztunnel
 EOF
 ```

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -4,9 +4,6 @@ FEATURES ?=
 ifeq ($(TLS_MODE), boring)
 	FEATURES:=--no-default-features -F tls-boring
 endif
-ifeq ($(TEST_MODE), root)
-	export CARGO_TARGET_$(shell rustc -vV | sed -n 's|host: ||p' | tr [:lower:] [:upper:]| tr - _)_RUNNER=sudo -E
-endif
 
 test:
 	RUST_BACKTRACE=1 cargo test --benches --tests --bins $(FEATURES)

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -67,7 +67,7 @@ mod namespaced {
 
         // Map our current user to root in the new network namespace
         data_file
-            .write(format!("{} {} 1", 0, original_uid).as_bytes())
+            .write_all(format!("{} {} 1", 0, original_uid).as_bytes())
             .expect("write failed");
 
         // Setup a new network namespace
@@ -80,6 +80,10 @@ mod namespaced {
         let tp = std::env::temp_dir().join("ztunnel_namespaced.XXXXXX");
         let tmp = mkdtemp(&tp).expect("tmp dir");
 
+        // Create /var/run/netns and if it doesn't exist. Technically this requires root, but any system should have this
+        fs::create_dir_all("/var/run/netns")
+            .expect("host netns dir doesn't exist and we are not root");
+        let _ = File::create_new("/run/xtables.lock");
         // Bind mount /var/run/netns so we can make our own independent network namespaces
         fs::create_dir(tmp.join("netns")).expect("netns dir");
         mount(


### PR DESCRIPTION
This gives full coverage, without requiring root. It also prevents
issues around failure to cleanup network namespaces, etc, and generally
allows us to mess with the environment a lot more than we were doing
now.
