### PR TITLE
waypoint bypass detection and authz skip

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -551,6 +551,9 @@ impl OutboundConnection {
         let from_waypoint = proxy::check_from_waypoint(
             self.pi.state.clone(),
             &us.workload,
+            // if we're outbound from a Service zTunnel we must have picked a workload
+            // so we only check for Workload waypoint here.
+            &[],
             Some(&source_workload.identity()),
             &downstream_network_addr.address,
         )

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -21,6 +21,7 @@ use tracing::trace;
 
 use xds::istio::workload::Service as XdsService;
 
+use crate::identity::Identity;
 use crate::state::workload::is_default;
 use crate::state::workload::{
     byte_to_ip, network_addr, GatewayAddress, NamespacedHostname, NetworkAddress, Workload,
@@ -147,6 +148,8 @@ pub struct Endpoint {
 
     /// The port mapping.
     pub port: HashMap<u16, u16>,
+
+    pub identity: Identity,
 }
 
 pub fn endpoint_uid(workload_uid: &str, address: Option<&NetworkAddress>) -> String {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -14,6 +14,7 @@
 
 use crate::config::ConfigSource;
 use crate::config::{self, RootCert};
+use crate::identity::Identity;
 use crate::state::service::{Endpoint, Service};
 use crate::state::workload::Protocol;
 use crate::state::workload::Protocol::{HBONE, TCP};
@@ -39,6 +40,7 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::ops::Add;
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
 use tokio::sync::mpsc::error::SendError;
@@ -268,6 +270,8 @@ fn test_custom_svc(
                 },
                 address: addr,
                 port: HashMap::from([(80u16, echo_port)]),
+                identity: Identity::from_str("spiffe://cluster.local/ns/default/sa/default")
+                    .unwrap(),
             },
         )]),
         subject_alt_names: vec!["spiffe://cluster.local/ns/default/sa/default".to_string()],

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -424,6 +424,7 @@ impl<'a> TestWorkloadBuilder<'a> {
                     service: service_name.clone(),
                     address: Some(ep_network_addr.clone()),
                     port: ports.to_owned(),
+                    identity: self.w.workload.identity(),
                 };
                 let mut svc = self.manager.services.get(&service_name).unwrap().clone();
                 let ep_uid = endpoint_uid(&self.w.workload.uid, Some(&ep_network_addr));

--- a/src/test_helpers/netns.rs
+++ b/src/test_helpers/netns.rs
@@ -26,6 +26,7 @@ use netns_rs::NetNs;
 use tokio::runtime::{Handle, RuntimeFlavor};
 use tracing::{debug, error, warn, Instrument};
 
+use crate::identity::Identity;
 use crate::test_helpers::helpers;
 
 pub struct NamespaceManager {
@@ -89,6 +90,14 @@ impl Ready {
 impl Namespace {
     pub fn ip(&self) -> IpAddr {
         id_to_ip(self.node_id, self.id)
+    }
+
+    pub fn identity(&self) -> Identity {
+        Identity::Spiffe {
+            trust_domain: "cluster.local".to_string(),
+            namespace: "default".to_string(),
+            service_account: self.name.clone(),
+        }
     }
 
     pub fn netns(&self) -> Arc<NetNs> {

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -317,6 +317,7 @@ fn service_endpoints(
                 service: namespaced_host.clone(),
                 address: Some(network_addr(&workload.network, *wip)),
                 port: ports.into(),
+                identity: workload.identity(),
             })
         }
         if workload.workload_ips.is_empty() {
@@ -325,6 +326,7 @@ fn service_endpoints(
                 service: namespaced_host.clone(),
                 address: None,
                 port: ports.into(),
+                identity: workload.identity(),
             })
         }
     }


### PR DESCRIPTION
An alternative to https://github.com/istio/istio/pull/50475.

```
if has_waypoint && !from_waypoint {
  deny();
else if !has_waypoint {
  check_rbac();
}
```

We had a similar check in the past. One key difference in this version is that `has_waypoint` and `from_waypoint` checks both the destination workload and all it's services for waypoint attachment. 