### PR TITLE
Verify workload consistency with CNI for outbound

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -280,6 +280,9 @@ pub enum Error {
     #[error("unknown source: {0}")]
     UnknownSource(IpAddr),
 
+    #[error("invalid source: {0}, should match {1:?}")]
+    MismatchedSource(IpAddr, Arc<WorkloadInfo>),
+
     #[error("unknown waypoint: {0}")]
     UnknownWaypoint(String),
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -454,6 +454,12 @@ impl OutboundConnection {
             Some(wl) => wl,
             None => return Err(Error::UnknownSource(downstream)),
         };
+        if let Some(ref wl_info) = self.pi.proxy_workload_info {
+            // make sure that the workload we fetched matches the workload info we got over ZDS.
+            if !wl_info.matches(&source_workload) {
+                return Err(Error::MismatchedSource(downstream, wl_info.clone()));
+            }
+        }
 
         // If this is to-service traffic check for a service waypoint
         // Capture result of whether or not this is svc addressed


### PR DESCRIPTION
We only did this for inbound. This double check provides a stronger
guarantee than IP address matching
