### PR TITLE
performance: reduce and test size of futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ http-body-04 = { package = "http-body", version = "0.4" }
 http-body-1 = { package = "http-body", version = "1.0.0-rc.2" }
 http-body-util = "0.1"
 http-types = { version = "2.12", default-features = false }
-hyper = { version = "1.2", features = ["full"] }
+hyper = { version = "1.3", features = ["full"] }
 hyper-rustls = { version = "0.27.0", default-features = false, features = ["logging", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["full"] }
 ipnet = { version = "2.9", features = ["serde"] }

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -126,7 +126,7 @@ fn initialize_environment(
             None,
             config_source,
         );
-        let app = app::build_with_cert(config, cert_manager.clone())
+        let app = app::build_with_cert(Arc::new(config), cert_manager.clone())
             .await
             .unwrap();
 
@@ -456,7 +456,7 @@ fn hbone_connections(c: &mut Criterion) {
             None,
             config_source,
         );
-        let app = app::build_with_cert(config, cert_manager.clone())
+        let app = app::build_with_cert(Arc::new(config), cert_manager.clone())
             .await
             .unwrap();
         let ta = TestApp::from((&app, cert_manager));

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1066,9 +1066,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -61,7 +61,7 @@ pub trait AdminHandler2: Sync + Send {
 
 struct State {
     proxy_state: DemandProxyState,
-    config: Config,
+    config: Arc<Config>,
     shutdown_trigger: signal::ShutdownTrigger,
     cert_manager: Arc<SecretManager>,
     handlers: Vec<Arc<dyn AdminHandler2>>,
@@ -78,7 +78,7 @@ pub struct ConfigDump {
     proxy_state: DemandProxyState,
     static_config: LocalConfig,
     version: BuildInfo,
-    config: Config,
+    config: Arc<Config>,
     certificates: Vec<CertsDump>,
 }
 
@@ -102,7 +102,7 @@ pub struct CertsDump {
 
 impl Service {
     pub async fn new(
-        config: Config,
+        config: Arc<Config>,
         proxy_state: DemandProxyState,
         shutdown_trigger: signal::ShutdownTrigger,
         drain_rx: Watch,
@@ -472,6 +472,7 @@ mod tests {
     use bytes::Bytes;
     use http_body_util::BodyExt;
     use std::collections::HashMap;
+    use std::sync::Arc;
     use std::time::Duration;
 
     fn diff_json<'a>(a: &'a serde_json::Value, b: &'a serde_json::Value) -> String {
@@ -738,7 +739,7 @@ mod tests {
             proxy_state,
             static_config: Default::default(),
             version: Default::default(),
-            config: default_config,
+            config: Arc::new(default_config),
             certificates: dump_certs(&manager).await,
         };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,7 @@ pub async fn build_with_cert(
     config: config::Config,
     cert_manager: Arc<SecretManager>,
 ) -> anyhow::Result<Bound> {
+    let config = Arc::new(config);
     // Start the data plane worker pool.
     let data_plane_pool = new_data_plane_pool(config.num_worker_threads);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,10 +33,9 @@ use crate::{admin, config, metrics, proxy, readiness, signal};
 use crate::{dns, xds};
 
 pub async fn build_with_cert(
-    config: config::Config,
+    config: Arc<config::Config>,
     cert_manager: Arc<SecretManager>,
 ) -> anyhow::Result<Bound> {
-    let config = Arc::new(config);
     // Start the data plane worker pool.
     let data_plane_pool = new_data_plane_pool(config.num_worker_threads);
 
@@ -281,7 +280,7 @@ fn new_data_plane_pool(num_worker_threads: usize) -> mpsc::Sender<DataPlaneTask>
     tx
 }
 
-pub async fn build(config: config::Config) -> anyhow::Result<Bound> {
+pub async fn build(config: Arc<config::Config>) -> anyhow::Result<Bound> {
     let cert_manager = if config.fake_ca {
         mock_secret_manager()
     } else {

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1,0 +1,47 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Below helper functions are used to help make about the size of types.
+// There are some compile time ways to do this, but they don't work in the way we need for the most part;
+// analyzing the size of Futures which we don't have explicit declarations for.
+// Future size is determined by the max required stack size for the async function. This means deeply
+// branched code can create huge Future's, leading to high per-connection memory usage in ztunnel.
+// Debugging these usages can be done by `RUSTFLAGS=-Zprint-type-sizes cargo +nightly build -j 1`,
+// or by logging with the functions below.
+
+#[cfg(all(any(test, feature = "testing"), debug_assertions))]
+pub fn size_between_ref<T>(min: usize, max: usize, t: &T) {
+    let size = std::mem::size_of_val(t);
+    if size < min || size > max {
+        // If it is too small: that is good, we just want to update the assertion to be more aggressive
+        // If it is too big: that is bad. We may need to increase the limit, or consider refactors.
+        panic!(
+            "type {} size is unexpected, wanted {min}..{max}, got {size}",
+            std::any::type_name::<T>(),
+        )
+    }
+    tracing::trace!(
+        "type {} size is within expectations, wanted {min}..{max}, got {size}",
+        std::any::type_name::<T>(),
+    )
+}
+
+#[cfg(not(all(any(test, feature = "testing"), debug_assertions)))]
+pub fn size_between_ref<T>(_min: usize, _max: usize, _t: &T) {}
+
+#[inline(always)]
+pub fn size_between<T>(min: usize, max: usize, t: T) -> T {
+    size_between_ref(min, max, &t);
+    t
+}

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -465,13 +465,15 @@ impl fmt::Debug for SecretManager {
 }
 
 impl SecretManager {
-    pub async fn new(cfg: crate::config::Config) -> Result<Self, Error> {
+    pub async fn new(cfg: Arc<crate::config::Config>) -> Result<Self, Error> {
         let caclient = CaClient::new(
-            cfg.ca_address.expect("ca_address must be set to use CA"),
+            cfg.ca_address
+                .clone()
+                .expect("ca_address must be set to use CA"),
             Box::new(tls::ControlPlaneAuthentication::RootCert(
                 cfg.ca_root_cert.clone(),
             )),
-            cfg.auth,
+            cfg.auth.clone(),
             cfg.proxy_mode == ProxyMode::Shared,
             cfg.secret_ttl.as_secs().try_into().unwrap_or(60 * 60 * 24),
         )

--- a/src/inpod/test_helpers.rs
+++ b/src/inpod/test_helpers.rs
@@ -76,7 +76,7 @@ impl Default for Fixture {
 
         let ipc = InPodConfig::new(&cfg).unwrap();
         let proxy_gen = ProxyFactory::new(
-            cfg,
+            Arc::new(cfg),
             dstate,
             cert_manager,
             Some(metrics),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod admin;
 pub mod app;
+pub mod assertions;
 pub mod baggage;
 pub mod cert_fetcher;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 
 extern crate core;
 
+use std::sync::Arc;
 use tracing::info;
 use ztunnel::*;
 
@@ -29,7 +30,7 @@ pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0
 
 fn main() -> anyhow::Result<()> {
     telemetry::setup_logging();
-    let config: config::Config = config::parse_config()?;
+    let config = Arc::new(config::parse_config()?);
 
     // For now we don't need a complex CLI, so rather than pull in dependencies just use basic argv[1]
     match std::env::args().nth(1).as_deref() {
@@ -69,7 +70,7 @@ fn version() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn proxy(cfg: config::Config) -> anyhow::Result<()> {
+async fn proxy(cfg: Arc<config::Config>) -> anyhow::Result<()> {
     info!("version: {}", version::BuildInfo::new());
     info!("running with config: {}", serde_yaml::to_string(&cfg)?);
     app::build(cfg).await?.wait_termination().await

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use tracing::info;
 use ztunnel::*;
 
 #[cfg(feature = "jemalloc")]
-use tikv_jemallocator;
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/src/metrics/server.rs
+++ b/src/metrics/server.rs
@@ -31,7 +31,11 @@ pub struct Server {
 }
 
 impl Server {
-    pub async fn new(config: Config, drain_rx: Watch, registry: Registry) -> anyhow::Result<Self> {
+    pub async fn new(
+        config: Arc<Config>,
+        drain_rx: Watch,
+        registry: Registry,
+    ) -> anyhow::Result<Self> {
         hyper_util::Server::<Mutex<Registry>>::bind(
             "stats",
             config.stats_addr,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -99,7 +99,7 @@ pub struct Proxy {
 
 #[derive(Clone)]
 pub(super) struct ProxyInputs {
-    cfg: config::Config,
+    cfg: Arc<config::Config>,
     cert_manager: Arc<SecretManager>,
     connection_manager: ConnectionManager,
     hbone_port: u16,
@@ -112,7 +112,7 @@ pub(super) struct ProxyInputs {
 #[allow(clippy::too_many_arguments)]
 impl ProxyInputs {
     pub fn new(
-        cfg: config::Config,
+        cfg: Arc<config::Config>,
         cert_manager: Arc<SecretManager>,
         connection_manager: ConnectionManager,
         state: DemandProxyState,
@@ -135,7 +135,7 @@ impl ProxyInputs {
 
 impl Proxy {
     pub async fn new(
-        cfg: config::Config,
+        cfg: Arc<config::Config>,
         state: DemandProxyState,
         cert_manager: Arc<SecretManager>,
         metrics: Metrics,

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -334,6 +334,11 @@ pub struct ConnectionResult {
     dst: (SocketAddr, Option<String>),
     hbone_target: Option<SocketAddr>,
     start: Instant,
+
+    // TODO: storing CommonTrafficLabels adds ~600 bytes retained throughout a connection life time.
+    // We can pre-fetch the metrics we need at initialization instead of storing this, then keep a more
+    // efficient representation for the fields we need to log. Ideally, this would even be optional
+    // in case logs were disabled.
     tl: CommonTrafficLabels,
     metrics: Arc<Metrics>,
 

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -26,7 +26,7 @@ use prometheus_client::registry::Registry;
 use tracing::event;
 
 use crate::identity::Identity;
-use crate::metrics::{DefaultedUnknown, DeferRecorder, Deferred, IncrementRecorder, Recorder};
+use crate::metrics::{DefaultedUnknown, DeferRecorder, Deferred, IncrementRecorder};
 
 use crate::state::service::ServiceDescription;
 use crate::state::workload::Workload;
@@ -187,8 +187,8 @@ impl CommonTrafficLabels {
     }
 }
 
-impl From<&ConnectionOpen> for CommonTrafficLabels {
-    fn from(c: &ConnectionOpen) -> Self {
+impl From<ConnectionOpen> for CommonTrafficLabels {
+    fn from(c: ConnectionOpen) -> Self {
         CommonTrafficLabels {
             reporter: c.reporter,
             request_protocol: RequestProtocol::tcp,
@@ -326,14 +326,6 @@ impl Metrics {
     }
 }
 
-impl Recorder<ConnectionOpen, u64> for Metrics {
-    fn record(&self, reason: &ConnectionOpen, count: u64) {
-        self.connection_opens
-            .get_or_create(&CommonTrafficLabels::from(reason))
-            .inc_by(count);
-    }
-}
-
 /// ConnectionResult abstracts recording a metric and emitting an access log upon a connection completion
 pub struct ConnectionResult {
     // Src address and name
@@ -417,27 +409,22 @@ impl ConnectionResult {
         // That is, dst is the L4 address, while is the :authority.
         hbone_target: Option<SocketAddr>,
         start: Instant,
-        conn: &ConnectionOpen,
+        conn: ConnectionOpen,
         metrics: Arc<Metrics>,
     ) -> Self {
+        // for src and dest, try to get pod name but fall back to "canonical service"
+        let mut src = (src, conn.source.as_ref().map(|wl| wl.name.clone()));
+        let mut dst = (
+            dst,
+            conn.destination.as_ref().map(|wl| wl.name.clone()), // TODO: canonical
+        );
         let tl = CommonTrafficLabels::from(conn);
         metrics.connection_opens.get_or_create(&tl).inc();
+
         let mtls = tl.connection_security_policy == SecurityPolicy::mutual_tls;
-        // for src and dest, try to get pod name but fall back to "canonical service"
-        let src = (
-            src,
-            conn.source
-                .as_ref()
-                .map(|wl| wl.name.clone())
-                .or(tl.source_canonical_service.clone().inner()),
-        );
-        let dst = (
-            dst,
-            conn.destination
-                .as_ref()
-                .map(|wl| wl.name.clone())
-                .or(tl.destination_canonical_service.clone().inner()),
-        );
+
+        src.1 = src.1.or(tl.source_canonical_service.clone().inner());
+        dst.1 = dst.1.or(tl.destination_canonical_service.clone().inner());
         event!(
             target: "access",
             parent: None,

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -277,7 +277,8 @@ impl OutboundConnection {
             req.destination, req.gateway, req.request_type
         );
 
-        let (_conn_client, upgraded) = Box::pin(self.build_hbone_request(remote_addr, &req)).await?;
+        let (_conn_client, upgraded) =
+            Box::pin(self.build_hbone_request(remote_addr, &req)).await?;
 
         socket::copy_bidirectional(
             stream,

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -29,7 +29,7 @@ use crate::proxy::Proxy;
 // Proxy factory creates ztunnel proxies using a socket factory.
 // this allows us to create our proxies the same way in regular mode and in inpod mode.
 pub struct ProxyFactory {
-    config: config::Config,
+    config: Arc<config::Config>,
     state: DemandProxyState,
     cert_manager: Arc<SecretManager>,
     proxy_metrics: Option<Arc<Metrics>>,
@@ -39,7 +39,7 @@ pub struct ProxyFactory {
 
 impl ProxyFactory {
     pub fn new(
-        config: config::Config,
+        config: Arc<config::Config>,
         state: DemandProxyState,
         cert_manager: Arc<SecretManager>,
         proxy_metrics: Option<Metrics>,

--- a/src/readiness/server.rs
+++ b/src/readiness/server.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use drain::Watch;
@@ -31,7 +32,7 @@ pub struct Server {
 
 impl Server {
     pub async fn new(
-        config: config::Config,
+        config: Arc<config::Config>,
         drain_rx: Watch,
         ready: readiness::Ready,
     ) -> anyhow::Result<Self> {

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -74,7 +74,7 @@ where
 {
     initialize_telemetry();
     let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
-    let app = app::build_with_cert(cfg, cert_manager.clone())
+    let app = app::build_with_cert(Arc::new(cfg), cert_manager.clone())
         .await
         .unwrap();
     let shutdown = app.shutdown.trigger().clone();

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -137,7 +137,7 @@ impl WorkloadManager {
                 helpers::run_command(&format!("scripts/ztunnel-redirect.sh {ip}"))?;
             }
             let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
-            let app = crate::app::build_with_cert(cfg, cert_manager.clone()).await?;
+            let app = crate::app::build_with_cert(Arc::new(cfg), cert_manager.clone()).await?;
 
             // inpod mode doesn't have ore need these, so just put bogus values.
             let proxy_addresses = app.proxy_addresses.unwrap_or(proxy::Addresses {

--- a/src/test_helpers/xds.rs
+++ b/src/test_helpers/xds.rs
@@ -120,7 +120,7 @@ impl AdsServer {
         let tls_client_fetcher = Box::new(tls::ControlPlaneAuthentication::RootCert(
             cfg.xds_root_cert.clone(),
         ));
-        let xds_client = xds::Config::new(cfg, tls_client_fetcher)
+        let xds_client = xds::Config::new(Arc::new(cfg), tls_client_fetcher)
             .with_watched_handler::<XdsAddress>(xds::ADDRESS_TYPE, store_updater.clone())
             .with_watched_handler::<XdsAuthorization>(xds::AUTHORIZATION_TYPE, store_updater)
             .build(metrics, block_tx);

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -15,6 +15,7 @@
 use itertools::Itertools;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, mem};
 
@@ -236,7 +237,7 @@ impl State {
 
 impl Config {
     pub fn new(
-        config: crate::config::Config,
+        config: Arc<crate::config::Config>,
         tls_builder: Box<dyn tls::ClientCertProvider>,
     ) -> Config {
         Config {
@@ -245,11 +246,11 @@ impl Config {
                 .clone()
                 .expect("xds_address must be set to use xds"),
             tls_builder,
-            auth: config.auth,
+            auth: config.auth.clone(),
             handlers: HashMap::new(),
             initial_requests: Vec::new(),
             on_demand: config.xds_on_demand,
-            proxy_metadata: config.proxy_metadata,
+            proxy_metadata: config.proxy_metadata.clone(),
         }
     }
 

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -15,6 +15,7 @@
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -38,7 +39,7 @@ use ztunnel::test_helpers::*;
 async fn test_shutdown_lifecycle() {
     helpers::initialize_telemetry();
 
-    let app = ztunnel::app::build(test_config()).await.unwrap();
+    let app = ztunnel::app::build(Arc::new(test_config())).await.unwrap();
 
     let shutdown = app.shutdown.trigger().clone();
     let (app, _shutdown) = tokio::join!(
@@ -57,7 +58,7 @@ async fn test_bind_conflict<F: FnOnce(&mut ztunnel::config::Config) -> &mut Sock
     let sa = f(&mut cfg);
     *sa = l.local_addr().unwrap();
 
-    assert!(ztunnel::app::build(cfg).await.is_err());
+    assert!(ztunnel::app::build(Arc::new(cfg)).await.is_err());
 }
 
 #[tokio::test]
@@ -85,7 +86,7 @@ async fn test_shutdown_drain() {
     helpers::initialize_telemetry();
 
     let cert_manager = new_secret_manager(Duration::from_secs(10));
-    let app = ztunnel::app::build_with_cert(test_config(), cert_manager.clone())
+    let app = ztunnel::app::build_with_cert(Arc::new(test_config()), cert_manager.clone())
         .await
         .unwrap();
     let ta = TestApp::from((&app, cert_manager));
@@ -128,7 +129,7 @@ async fn test_shutdown_forced_drain() {
     let cfg = test_config();
 
     let cert_manager = new_secret_manager(Duration::from_secs(10));
-    let app = ztunnel::app::build_with_cert(cfg, cert_manager.clone())
+    let app = ztunnel::app::build_with_cert(Arc::new(cfg), cert_manager.clone())
         .await
         .unwrap();
     let ta = TestApp::from((&app, cert_manager));
@@ -164,7 +165,7 @@ async fn test_shutdown_forced_drain() {
 async fn test_quit_lifecycle() {
     helpers::initialize_telemetry();
 
-    let app = ztunnel::app::build(test_config()).await.unwrap();
+    let app = ztunnel::app::build(Arc::new(test_config())).await.unwrap();
     let addr = app.admin_address;
 
     let (app, _shutdown) = tokio::join!(


### PR DESCRIPTION
Prior to this PR, each outbound connection future was 22k. This is
really big.

The reason behind this is how Rust sizes Futures; the stack size is
allocated based on the maximum required size through any branch. This
means even obscure code paths can bloat up the entire future for
everyone.

This PR optimizes a bunch of these. This is done in a few ways:
* Box::pin expensive futures. While we have to allocate these when we
  hit them, of course, when we don't hit these codepaths they are now
"free". We have a lot of uncommon expensive code paths. Especially HBONE
vs passthrough; hbone is way more expensive. But also on demand XDS,
DNS, etc
* Arc the Config which is large
* A variety of other micro-optimizations

A new `assertions` module is added to verify we do not regress.

Spawning 10k connections before this PR used about 660Mb, now we are at 300mb
