### PR TITLE
Make connection tracking resiliant to connection reuse

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -338,7 +338,7 @@ impl OutboundConnection {
         req: &Request,
         connection_stats: &ConnectionResult,
     ) -> Result<(), Error> {
-        info!(
+        debug!(
             "Proxying to {} using TCP via {} type {:?}",
             req.destination, req.gateway, req.request_type
         );


### PR DESCRIPTION
We have a race where if I open a connection with the same 4 tuple too
quickly, we would occasionally fail to track. This is due to ordering:

* New connection register
* Old connection close
* New connection track -- fails

Now, we make sure we account (in count) for the new connection in
register so we don't have this race.

Hard to test in unit tests or even integration; I used netperf TCP_CRR
and its pretty easy to trigger.
