### PR TITLE
h2: poll ready before using

### DIFF
--- a/src/proxy/h2_client.rs
+++ b/src/proxy/h2_client.rs
@@ -258,6 +258,9 @@ impl H2ConnectClient {
         &mut self,
         req: Request<()>,
     ) -> Result<(SendStream<SendBuf>, h2::RecvStream), Error> {
+        // "This function must return `Ready` before `send_request` is called"
+        // We should always be ready though, because we make sure we don't go over the max stream limit out of band.
+        futures::future::poll_fn(|cx| self.sender.poll_ready(cx)).await?;
         let (response, stream) = self.sender.send_request(req, false)?;
         let response = response.await?;
         if response.status() != 200 {


### PR DESCRIPTION
This is "required" per the docs. I don't think it really is, but good to
be safe and follow the docs
