### PR TITLE
Miscellanuous optimizations to reduce memory footprint

### DIFF
--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -355,7 +355,7 @@ impl Store {
                     // Didn't find a service, try a workload.
                     if let Some(wl) = state.workloads.find_hostname(&search_name_str) {
                         return Some(ServerMatch {
-                            server: Address::Workload(Box::new(wl)),
+                            server: Address::Workload(wl),
                             name: search_name,
                             alias,
                         });

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -347,7 +347,7 @@ impl Store {
                         .unwrap();
 
                     return Some(ServerMatch {
-                        server: Address::Service(Box::new(service)),
+                        server: Address::Service(Arc::new(service)),
                         name: search_name,
                         alias,
                     });

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -506,7 +506,7 @@ pub async fn freebind_connect(
 pub fn guess_inbound_service(
     conn: &Connection,
     for_host_header: &Option<String>,
-    upstream_service: Vec<Service>,
+    upstream_service: Vec<Arc<Service>>,
     dest: &Workload,
 ) -> Option<ServiceDescription> {
     // First, if the client told us what Service they were reaching, look for that
@@ -514,7 +514,7 @@ pub fn guess_inbound_service(
     if let Some(found) = upstream_service
         .iter()
         .find(|s| for_host_header.as_ref() == Some(&s.hostname))
-        .map(ServiceDescription::from)
+        .map(|s| ServiceDescription::from(s.as_ref()))
     {
         return Some(found);
     }
@@ -539,7 +539,7 @@ pub fn guess_inbound_service(
             }
             false
         })
-        .map(ServiceDescription::from)
+        .map(|s| ServiceDescription::from(s.as_ref()))
 }
 
 // Checks that the source identiy and address match the upstream's waypoint

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -544,7 +544,7 @@ pub fn guess_inbound_service(
 
 // Checks that the source identiy and address match the upstream's waypoint
 async fn check_from_waypoint(
-    state: DemandProxyState,
+    state: &DemandProxyState,
     upstream: &Workload,
     src_identity: Option<&Identity>,
     src_ip: &IpAddr,
@@ -558,7 +558,7 @@ async fn check_from_waypoint(
 // Checks if the connection's source identity is the identity for the upstream's network
 // gateway
 async fn check_from_network_gateway(
-    state: DemandProxyState,
+    state: &DemandProxyState,
     upstream: &Workload,
     src_identity: Option<&Identity>,
 ) -> bool {
@@ -569,7 +569,7 @@ async fn check_from_network_gateway(
 // Check if the source's identity matches any workloads that make up the given gateway
 // TODO: This can be made more accurate by also checking addresses.
 async fn check_gateway_address<F>(
-    state: DemandProxyState,
+    state: &DemandProxyState,
     gateway_address: Option<&GatewayAddress>,
     predicate: F,
 ) -> bool

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -640,7 +640,7 @@ mod tests {
         let upstream_with_address = mock_wokload_with_gateway(Some(mock_default_gateway_address()));
         assert!(
             check_from_network_gateway(
-                state.clone(),
+                &state,
                 &upstream_with_address,
                 from_gw_conn.as_ref(),
             )
@@ -648,7 +648,7 @@ mod tests {
         );
         assert!(
             !check_from_network_gateway(
-                state.clone(),
+                &state,
                 &upstream_with_address,
                 not_from_gw_conn.as_ref(),
             )
@@ -660,14 +660,14 @@ mod tests {
             mock_wokload_with_gateway(Some(mock_default_gateway_hostname()));
         assert!(
             check_from_network_gateway(
-                state.clone(),
+                &state,
                 &upstream_with_hostname,
                 from_gw_conn.as_ref(),
             )
             .await
         );
         assert!(
-            !check_from_network_gateway(state, &upstream_with_hostname, not_from_gw_conn.as_ref())
+            !check_from_network_gateway(&state, &upstream_with_hostname, not_from_gw_conn.as_ref())
                 .await
         );
     }

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -416,7 +416,7 @@ impl Inbound {
         state: &DemandProxyState,
         conn: &Connection,
         hbone_addr: SocketAddr,
-    ) -> Result<(SocketAddr, AppProtocol, Workload, Vec<Service>), Error> {
+    ) -> Result<(SocketAddr, AppProtocol, Workload, Vec<Arc<Service>>), Error> {
         let dst = &NetworkAddress {
             network: conn.dst_network.to_string(),
             address: hbone_addr.ip(),
@@ -459,7 +459,7 @@ impl Inbound {
         state: &DemandProxyState,
         conn: &Connection,
         hbone_addr: SocketAddr,
-    ) -> Option<(Workload, Vec<Service>)> {
+    ) -> Option<(Workload, Vec<Arc<Service>>)> {
         let connection_dst = &NetworkAddress {
             network: conn.dst_network.to_string(),
             address: conn.dst.ip(),
@@ -471,7 +471,7 @@ impl Inbound {
 
         // Outer option tells us whether or not we can retry
         // Some(None) means we have enough information to decide this isn't sandwich
-        let lookup = || -> Option<Option<(Workload, Vec<Service>)>> {
+        let lookup = || -> Option<Option<(Workload, Vec<Arc<Service>>)>> {
             let state = state.read();
 
             // TODO Allow HBONE address to be a hostname. We have to respect rules about
@@ -509,7 +509,8 @@ impl Inbound {
                         // target points to a different waypoint
                         return Some(None);
                     }
-                    Some((conn_wl, vec![*svc]))
+                    // TODO: should we store this as an Arc in Address::Service?
+                    Some((conn_wl, vec![svc]))
                 }
                 Address::Workload(wl) => {
                     if !wl.workload_ips.contains(&conn.dst.ip()) {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -487,8 +487,8 @@ impl Inbound {
             };
 
             let Some(target_waypoint) = (match hbone_target {
-                Address::Service(svc) => svc.waypoint.clone(),
-                Address::Workload(wl) => wl.waypoint,
+                Address::Service(ref svc) => &svc.waypoint,
+                Address::Workload(ref wl) => &wl.waypoint,
             }) else {
                 // can't sandwich if the HBONE target doesn't want a Waypoint.
                 return Some(None);
@@ -509,7 +509,6 @@ impl Inbound {
                         // target points to a different waypoint
                         return Some(None);
                     }
-                    // TODO: should we store this as an Arc in Address::Service?
                     Some((conn_wl, vec![svc]))
                 }
                 Address::Workload(wl) => {
@@ -518,7 +517,8 @@ impl Inbound {
                         return Some(None);
                     }
                     let svc = state.services.get_by_workload(&wl);
-                    Some((*wl, svc))
+                    // TODO: use Arc more pervasive and remove this clone.
+                    Some((Arc::unwrap_or_clone(wl), svc))
                 }
             })
         };

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -670,7 +670,7 @@ mod tests {
             dst: format!("{connection_dst}:15008").parse().unwrap(),
         };
         let res = Inbound::find_inbound_upstream(
-            state,
+            &state,
             &conn,
             format!("{hbone_dst}:{TARGET_PORT}").parse().unwrap(),
         )

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -484,7 +484,7 @@ impl OutboundConnection {
             .await?;
 
         let from_waypoint = proxy::check_from_waypoint(
-            self.pi.state.clone(),
+            &self.pi.state,
             &us.workload,
             Some(&source_workload.identity()),
             &downstream_network_addr.address,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -173,8 +173,7 @@ mod linux {
 }
 
 // TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
-const BUFFER_SIZE: usize = 4096;
-// const BUFFER_SIZE: usize = 16_384 - 64;
+const BUFFER_SIZE: usize = 16_384 - 64;
 
 pub async fn copy_bidirectional<A, B>(
     downstream: &mut A,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -173,7 +173,8 @@ mod linux {
 }
 
 // TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
-const BUFFER_SIZE: usize = 16_384 - 64;
+const BUFFER_SIZE: usize = 4096;
+// const BUFFER_SIZE: usize = 16_384 - 64;
 
 pub async fn copy_bidirectional<A, B>(
     downstream: &mut A,

--- a/src/state.rs
+++ b/src/state.rs
@@ -210,7 +210,7 @@ impl ProxyState {
             None => {
                 // 2. handle service
                 if let Some(svc) = self.services.get_by_vip(network_addr) {
-                    return Some(Address::Service(Box::new(svc)));
+                    return Some(Address::Service(svc));
                 }
                 None
             }
@@ -229,7 +229,7 @@ impl ProxyState {
                     .find_hostname(&name.hostname)
                     .map(|wl| Address::Workload(Box::new(wl)))
             }
-            Some(svc) => Some(Address::Service(Box::new(svc))),
+            Some(svc) => Some(Address::Service(svc)),
         }
     }
 
@@ -264,7 +264,7 @@ impl ProxyState {
                 workload: wl,
                 port: *target_port,
                 sans: svc.subject_alt_names.clone(),
-                destination_service: Some((&svc).into()),
+                destination_service: Some(ServiceDescription::from(svc.as_ref())),
             };
             return Some(us);
         }
@@ -607,7 +607,7 @@ impl DemandProxyState {
     pub async fn fetch_workload_services(
         &self,
         addr: &NetworkAddress,
-    ) -> Option<(Workload, Vec<Service>)> {
+    ) -> Option<(Workload, Vec<Arc<Service>>)> {
         // Wait for it on-demand, *if* needed
         debug!(%addr, "fetch workload and service");
         let fetch = |addr: &NetworkAddress| {

--- a/src/state.rs
+++ b/src/state.rs
@@ -206,7 +206,7 @@ impl ProxyState {
     /// Find either a workload or a service by address.
     pub fn find_address(&self, network_addr: &NetworkAddress) -> Option<Address> {
         // 1. handle workload ip, if workload not found fallback to service.
-        match self.workloads.find_address(network_addr) {
+        match self.workloads.find_address_arc(network_addr) {
             None => {
                 // 2. handle service
                 if let Some(svc) = self.services.get_by_vip(network_addr) {
@@ -214,7 +214,7 @@ impl ProxyState {
                 }
                 None
             }
-            Some(wl) => Some(Address::Workload(Box::new(wl))),
+            Some(wl) => Some(Address::Workload(wl)),
         }
     }
 
@@ -227,7 +227,7 @@ impl ProxyState {
                 // Workload hostnames are globally unique, so ignore the namespace.
                 self.workloads
                     .find_hostname(&name.hostname)
-                    .map(|wl| Address::Workload(Box::new(wl)))
+                    .map(|wl| Address::Workload(wl))
             }
             Some(svc) => Some(Address::Service(svc)),
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -886,7 +886,7 @@ mod tests {
         test_helpers::assert_eventually(
             Duration::from_secs(5),
             || mock_proxy_state.fetch_destination(&dst),
-            Some(Address::Workload(Box::new(
+            Some(Address::Workload(Arc::new(
                 test_helpers::test_default_workload(),
             ))),
         )
@@ -900,7 +900,7 @@ mod tests {
         test_helpers::assert_eventually(
             Duration::from_secs(5),
             || mock_proxy_state.fetch_destination(&dst),
-            Some(Address::Service(Box::new(
+            Some(Address::Service(Arc::new(
                 test_helpers::mock_default_service(),
             ))),
         )

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -141,7 +141,7 @@ pub mod address {
     #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     pub enum Address {
-        Workload(Box<Workload>),
+        Workload(Arc<Workload>),
         Service(Arc<Service>),
     }
 }
@@ -630,11 +630,16 @@ impl WorkloadStore {
         self.by_addr.get(addr).map(|wl| wl.deref().clone())
     }
 
+    /// Finds the workload by address, as an arc. TODO: make find_address and other functions directly return an Arc too
+    pub fn find_address_arc(&self, addr: &NetworkAddress) -> Option<Arc<Workload>> {
+        self.by_addr.get(addr).map(|wl| wl.clone())
+    }
+
     /// Finds the workload by hostname.
-    pub fn find_hostname<T: AsRef<str>>(&self, hostname: T) -> Option<Workload> {
+    pub fn find_hostname<T: AsRef<str>>(&self, hostname: T) -> Option<Arc<Workload>> {
         self.by_hostname
             .get(hostname.as_ref())
-            .map(|wl| wl.deref().clone())
+            .map(|wl| wl.clone())
     }
 
     /// Finds the workload by uid.

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -134,9 +134,9 @@ pub mod application_tunnel {
 }
 
 pub mod address {
-    use std::sync::Arc;
     use crate::state::service::Service;
     use crate::state::workload::Workload;
+    use std::sync::Arc;
 
     #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
@@ -632,14 +632,12 @@ impl WorkloadStore {
 
     /// Finds the workload by address, as an arc. TODO: make find_address and other functions directly return an Arc too
     pub fn find_address_arc(&self, addr: &NetworkAddress) -> Option<Arc<Workload>> {
-        self.by_addr.get(addr).map(|wl| wl.clone())
+        self.by_addr.get(addr).cloned()
     }
 
     /// Finds the workload by hostname.
     pub fn find_hostname<T: AsRef<str>>(&self, hostname: T) -> Option<Arc<Workload>> {
-        self.by_hostname
-            .get(hostname.as_ref())
-            .map(|wl| wl.clone())
+        self.by_hostname.get(hostname.as_ref()).cloned()
     }
 
     /// Finds the workload by uid.

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -134,6 +134,7 @@ pub mod application_tunnel {
 }
 
 pub mod address {
+    use std::sync::Arc;
     use crate::state::service::Service;
     use crate::state::workload::Workload;
 
@@ -141,7 +142,7 @@ pub mod address {
     #[serde(untagged)]
     pub enum Address {
         Workload(Box<Workload>),
-        Service(Box<Service>),
+        Service(Arc<Service>),
     }
 }
 


### PR DESCRIPTION
For the test workload I was running this shaves off roughly 100mb of allocations of 1.3gb (this is total, not active). Active memory dropped about 60mb->50mb. 

Each optimization is in its own commit.

Reference:

Service: 312bytes
DemandProxyState: 272bytes
Workload: 608 bytes
ProxyInputs: 344 bytes

----

* Move some lookups on the hotpath to stay in an arc to make them ~free
* Use references to DemandProxyState; full ownership is not needed
* Avoid double lookup when not using on demand; our logic was `lookup; fetch; lookup`. If on demand is off, fetch does nothing, so its silly to look up twice.