### PR TITLE
performance: drop double buffering on outbound HBONE

### DIFF
--- a/src/proxy/h2_client.rs
+++ b/src/proxy/h2_client.rs
@@ -18,6 +18,7 @@
 
 use crate::config;
 use crate::proxy::Error;
+use crate::proxy::Error::H2;
 use bytes::Buf;
 use bytes::Bytes;
 use futures_core::ready;
@@ -30,6 +31,7 @@ use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
+use tokio::io;
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;
@@ -38,16 +40,35 @@ use tokio_rustls::client::TlsStream;
 use tracing::{debug, error, trace, warn};
 
 // H2Stream represents an active HTTP2 stream. Consumers can only Read/Write
-// pin_project_lite::pin_project! {
-    pub struct H2Stream {
-        send_stream: h2::SendStream<SendBuf>,
-        recv_stream: h2::RecvStream,
-        buf: Bytes,
-        active_count: Arc<AtomicU16>,
-    }
-// }
 
-impl H2Stream {
+pub struct H2Stream {
+    read: H2StreamReadHalf,
+    write: H2StreamWriteHalf,
+}
+
+pub struct H2StreamReadHalf {
+    recv_stream: h2::RecvStream,
+    buf: Bytes,
+    half_dropped: Arc<()>,
+    active_count: Arc<AtomicU16>,
+}
+
+pub struct H2StreamWriteHalf {
+    send_stream: h2::SendStream<SendBuf>,
+    half_dropped: Arc<()>,
+    active_count: Arc<AtomicU16>,
+}
+
+impl crate::socket::BufferedSplitter for H2Stream {
+    type R = H2StreamReadHalf;
+    type W = H2StreamWriteHalf;
+    fn split(self) -> (H2StreamReadHalf, H2StreamWriteHalf) {
+        let H2Stream { read, write } = self;
+        (read, write)
+    }
+}
+
+impl H2StreamWriteHalf {
     fn write_slice(&mut self, buf: &[u8], end_of_stream: bool) -> Result<(), std::io::Error> {
         let send_buf: SendBuf = Cursor::new(buf.into());
         self.send_stream
@@ -56,14 +77,35 @@ impl H2Stream {
     }
 }
 
-impl Drop for H2Stream {
+impl Drop for H2StreamReadHalf {
     fn drop(&mut self) {
-        let left = self.active_count.fetch_sub(1, Ordering::SeqCst);
-        trace!("dropping h2stream, has {} active streams left", left - 1);
+        let mut half_dropped = Arc::new(());
+        std::mem::swap(&mut self.half_dropped, &mut half_dropped);
+        if Arc::into_inner(half_dropped).is_none() {
+            // other half already dropped
+            let left = self.active_count.fetch_sub(1, Ordering::SeqCst);
+            trace!("dropping H2StreamReadHalf, has {} active streams left", left - 1);
+        } else {
+            trace!("dropping H2StreamReadHalf, write half remains");
+        }
     }
 }
 
-impl AsyncBufRead for H2Stream {
+impl Drop for H2StreamWriteHalf {
+    fn drop(&mut self) {
+        let mut half_dropped = Arc::new(());
+        std::mem::swap(&mut self.half_dropped, &mut half_dropped);
+        if Arc::into_inner(half_dropped).is_none() {
+            // other half already dropped
+            let left = self.active_count.fetch_sub(1, Ordering::SeqCst);
+            trace!("dropping H2StreamWriteHalf, has {} active streams left", left - 1);
+        } else {
+            trace!("dropping H2StreamWriteHalf, read half remains");
+        }
+    }
+}
+
+impl AsyncBufRead for H2StreamReadHalf {
     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<&[u8]>> {
         const EOF: Poll<std::io::Result<&[u8]>> = Poll::Ready(Ok(&[]));
         let this = self.get_mut();
@@ -104,7 +146,7 @@ impl AsyncBufRead for H2Stream {
     }
 }
 
-impl AsyncRead for H2Stream {
+impl AsyncRead for H2StreamReadHalf {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -144,7 +186,7 @@ impl AsyncRead for H2Stream {
     }
 }
 
-impl AsyncWrite for H2Stream {
+impl AsyncWrite for H2StreamWriteHalf {
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -287,12 +329,20 @@ impl H2ConnectClient {
             }
         };
 
-        let h2 = H2Stream {
-            send_stream: send,
+
+        let dropped = Arc::new(());
+        let read = H2StreamReadHalf {
             recv_stream: recv,
-            buf: Bytes::new(),
-            active_count: self.stream_count.clone(),
+            buf: Default::default(),
+            half_dropped: dropped.clone(),
+            active_count: self.stream_count.clone()
         };
+        let write = H2StreamWriteHalf {
+            send_stream: send,
+            half_dropped: dropped,
+            active_count: self.stream_count.clone()
+        };
+        let h2 = H2Stream { read, write };
         Ok(h2)
     }
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -253,7 +253,7 @@ impl OutboundConnection {
 
         let res = match req.protocol {
             Protocol::HBONE => {
-                self.proxy_to_hbone(&mut source_stream, source_addr, &req, &result_tracker)
+                self.proxy_to_hbone(source_stream, source_addr, &req, &result_tracker)
                     .await
             }
             Protocol::TCP => {
@@ -266,7 +266,7 @@ impl OutboundConnection {
 
     async fn proxy_to_hbone(
         &mut self,
-        stream: &mut TcpStream,
+        stream: TcpStream,
         remote_addr: SocketAddr,
         req: &Request,
         connection_stats: &ConnectionResult,
@@ -278,7 +278,7 @@ impl OutboundConnection {
 
         let mut upgraded = Box::pin(self.build_hbone_request(remote_addr, &req)).await?;
 
-        socket::copy_bidirectional(stream, &mut upgraded, connection_stats).await
+        socket::copy_bidirectional(stream, upgraded, connection_stats).await
     }
 
     async fn build_hbone_request(

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -32,6 +32,7 @@ use {
     std::io::ErrorKind,
     tracing::warn,
 };
+use crate::proxy::h2_client::H2Stream;
 
 #[cfg(target_os = "linux")]
 pub fn set_transparent(l: &TcpListener) -> io::Result<()> {
@@ -172,26 +173,49 @@ mod linux {
     }
 }
 
+pub trait BufferedSplitter: Unpin
+where
+{
+    type R: AsyncBufRead + Unpin;
+    type W: AsyncWrite + Unpin;
+    fn split(self) -> (Self::R, Self::W);
+}
+
+impl<I> BufferedSplitter for I
+where
+    I: AsyncRead + AsyncWrite + Unpin,
+
+{
+    type R = io::BufReader<io::ReadHalf<I>>;
+    type W = io::WriteHalf<I>;
+    fn split(self) -> (Self::R, Self::W) {
+        let (rh, wh) = tokio::io::split(self);
+        let rb = io::BufReader::with_capacity(BUFFER_SIZE, rh);
+        (rb, wh)
+    }
+}
+
+
 // TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
 const BUFFER_SIZE: usize = 16_384 - 64;
 
 pub async fn copy_bidirectional<A, B>(
-    downstream: &mut A,
-    upstream: &mut B,
+    downstream: A,
+    upstream: B,
     stats: &ConnectionResult,
 ) -> Result<(), crate::proxy::Error>
 where
-    A: AsyncRead + AsyncWrite + Unpin,
-    B: AsyncRead + AsyncWrite + Unpin,
+    A: BufferedSplitter,
+    B: BufferedSplitter,
 {
     use tokio::io::AsyncWriteExt;
-    let (mut rd, mut wd) = tokio::io::split(downstream);
-    let (mut ru, mut wu) = tokio::io::split(upstream);
+    let (mut rd, mut wd) = downstream.split();
+    let (mut ru, mut wu) = upstream.split();
 
     let (mut sent, mut received): (u64, u64) = (0, 0);
 
     let downstream_to_upstream = async {
-        let mut rd = io::BufReader::with_capacity(BUFFER_SIZE, &mut rd);
+        // let mut rd = io::BufReader::with_capacity(BUFFER_SIZE, &mut rd);
         let res = copy_buf(&mut rd, &mut wu, stats, false).await;
         trace!(?res, "send");
         sent = res?;
@@ -199,7 +223,7 @@ where
     };
 
     let upstream_to_downstream = async {
-        let mut ru = io::BufReader::with_capacity(BUFFER_SIZE, &mut ru);
+        // let mut ru = io::BufReader::with_capacity(BUFFER_SIZE, &mut ru);
         let res = copy_buf(&mut ru, &mut wd, stats, true).await;
         trace!(?res, "recieve");
         received = res?;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -173,14 +173,16 @@ mod linux {
     }
 }
 
+// BufferedSplitter is a trait to expose splitting an IO object into a buffered reader and a writer
 pub trait BufferedSplitter: Unpin
 where
 {
     type R: AsyncBufRead + Unpin;
     type W: AsyncWrite + Unpin;
-    fn split(self) -> (Self::R, Self::W);
+    fn split_into_buffered_reader(self) -> (Self::R, Self::W);
 }
 
+// Generic BufferedSplitter for anything that can Read/Write.
 impl<I> BufferedSplitter for I
 where
     I: AsyncRead + AsyncWrite + Unpin,
@@ -188,13 +190,12 @@ where
 {
     type R = io::BufReader<io::ReadHalf<I>>;
     type W = io::WriteHalf<I>;
-    fn split(self) -> (Self::R, Self::W) {
+    fn split_into_buffered_reader(self) -> (Self::R, Self::W) {
         let (rh, wh) = tokio::io::split(self);
         let rb = io::BufReader::with_capacity(BUFFER_SIZE, rh);
         (rb, wh)
     }
 }
-
 
 // TLS record size max is 16k. But we also have a H2 frame header, so leave a bit of room for that.
 const BUFFER_SIZE: usize = 16_384 - 64;
@@ -209,13 +210,12 @@ where
     B: BufferedSplitter,
 {
     use tokio::io::AsyncWriteExt;
-    let (mut rd, mut wd) = downstream.split();
-    let (mut ru, mut wu) = upstream.split();
+    let (mut rd, mut wd) = downstream.split_into_buffered_reader();
+    let (mut ru, mut wu) = upstream.split_into_buffered_reader();
 
     let (mut sent, mut received): (u64, u64) = (0, 0);
 
     let downstream_to_upstream = async {
-        // let mut rd = io::BufReader::with_capacity(BUFFER_SIZE, &mut rd);
         let res = copy_buf(&mut rd, &mut wu, stats, false).await;
         trace!(?res, "send");
         sent = res?;
@@ -223,7 +223,6 @@ where
     };
 
     let upstream_to_downstream = async {
-        // let mut ru = io::BufReader::with_capacity(BUFFER_SIZE, &mut ru);
         let res = copy_buf(&mut ru, &mut wd, stats, true).await;
         trace!(?res, "recieve");
         received = res?;


### PR DESCRIPTION
`h2` already buffers everything. It provides an interface like `get_bytes() -> Bytes`. `Read` is `read([u8])`, so the caller needs to provide their own buffer. `BufRead` is `fill_buf() -> [u8]` -- this is a perfect fit for h2, where we can just plumb the data through.

This gets rid of 1 of 4 buffers we allocate on each connection (if we are sending+receiving -- its 2 per ztunnel). The same could be applied to inbound hbone, but we would need either upstream changes to hyper or drop down to h2 directly there as well. 