### PR TITLE
performance: optimized string and various other XDS improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,12 +29,22 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
+ "getrandom 0.2.14",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -87,6 +97,18 @@ name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+[[package]]
+name = "arc-interner"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655ae79d4a7661f2f9a8f6daf95af32897eafdea938df06aeb127cea02b5f4ac"
+dependencies = [
+ "ahash 0.3.8",
+ "dashmap 4.0.2",
+ "once_cell",
+ "serde",
+]
 
 [[package]]
 name = "arrayvec"
@@ -636,6 +658,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,7 +868,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7874ce5eeafa5e546227f7c62911e586387bf03d6c9a45ac78aa1c3bc2fedb61"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -1075,7 +1120,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -1428,6 +1473,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "internment"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc54d0cead3645042423bf171f88d91e3c491c0c4027bccf81b8e7029bc5e35"
+dependencies = [
+ "ahash 0.8.11",
+ "arc-interner",
+ "dashmap 5.5.3",
+ "hashbrown 0.14.3",
+ "once_cell",
 ]
 
 [[package]]
@@ -3747,6 +3805,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "internment",
  "ipnet",
  "itertools 0.12.1",
  "jemalloc_pprof",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,6 +2849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "split-iter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2b15926089e5526bb2dd738a2eb0e59034356e06eb71e1cd912358c0e62c4d"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,6 +3835,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "socket2",
+ "split-iter",
  "test-case",
  "textnonce",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1472,7 @@ checksum = "dcc54d0cead3645042423bf171f88d91e3c491c0c4027bccf81b8e7029bc5e35"
 dependencies = [
  "ahash",
  "dashmap",
+ "deepsize",
  "hashbrown 0.14.3",
  "once_cell",
  "serde",
@@ -3752,6 +3773,7 @@ dependencies = [
  "chrono",
  "criterion",
  "ctor",
+ "deepsize",
  "diff",
  "drain",
  "duration-str",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,15 +29,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-dependencies = [
- "const-random",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -97,18 +88,6 @@ name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
-
-[[package]]
-name = "arc-interner"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655ae79d4a7661f2f9a8f6daf95af32897eafdea938df06aeb127cea02b5f4ac"
-dependencies = [
- "ahash 0.3.8",
- "dashmap 4.0.2",
- "once_cell",
- "serde",
-]
 
 [[package]]
 name = "arrayvec"
@@ -659,16 +638,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if",
- "num_cpus",
-]
-
-[[package]]
-name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
@@ -868,7 +837,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7874ce5eeafa5e546227f7c62911e586387bf03d6c9a45ac78aa1c3bc2fedb61"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -1120,7 +1089,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -1481,11 +1450,11 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc54d0cead3645042423bf171f88d91e3c491c0c4027bccf81b8e7029bc5e35"
 dependencies = [
- "ahash 0.8.11",
- "arc-interner",
- "dashmap 5.5.3",
+ "ahash",
+ "dashmap",
  "hashbrown 0.14.3",
  "once_cell",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,6 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom 0.2.14",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -646,19 +645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,26 +657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
-]
-
-[[package]]
-name = "deepsize"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
-dependencies = [
- "deepsize_derive",
-]
-
-[[package]]
-name = "deepsize_derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1471,20 +1437,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "internment"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc54d0cead3645042423bf171f88d91e3c491c0c4027bccf81b8e7029bc5e35"
-dependencies = [
- "ahash",
- "dashmap",
- "deepsize",
- "hashbrown 0.14.3",
- "once_cell",
- "serde",
 ]
 
 [[package]]
@@ -3789,7 +3741,6 @@ dependencies = [
  "chrono",
  "criterion",
  "ctor",
- "deepsize",
  "diff",
  "drain",
  "duration-str",
@@ -3812,7 +3763,6 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "internment",
  "ipnet",
  "itertools 0.12.1",
  "jemalloc_pprof",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
+name = "arcstr"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f907281554a3d0312bb7aab855a8e0ef6cbf1614d06de54105039ca8b34460e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3767,6 +3776,7 @@ name = "ztunnel"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "async-stream",
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ pingora-pool = "0.1.0"
 flurry = "0.5.0"
 h2 = "0.4"
 http = "1.1"
+internment = { version = "0.8.3", features = ["arc-interner", "arc"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ h2 = "0.4"
 http = "1.1"
 internment = { version = "0.8.3", default-features = false, features = ["arc", "serde", "deepsize"] }
 deepsize = "0.2.0"
+split-iter = "0.1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ pingora-pool = "0.1.0"
 flurry = "0.5.0"
 h2 = "0.4"
 http = "1.1"
-internment = { version = "0.8.3", features = ["arc-interner", "arc"] }
+internment = { version = "0.8.3", default-features = false, features = ["arc", "serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,8 @@ pingora-pool = "0.1.0"
 flurry = "0.5.0"
 h2 = "0.4"
 http = "1.1"
-internment = { version = "0.8.3", default-features = false, features = ["arc", "serde"] }
+internment = { version = "0.8.3", default-features = false, features = ["arc", "serde", "deepsize"] }
+deepsize = "0.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,10 +102,8 @@ pingora-pool = "0.1.0"
 flurry = "0.5.0"
 h2 = "0.4"
 http = "1.1"
-internment = { version = "0.8.3", default-features = false, features = ["arc", "serde", "deepsize"] }
-deepsize = "0.2.0"
-split-iter = "0.1.0"
-arcstr = { version = "1.1.5", features = ["serde"] }
+split-iter = "0.1"
+arcstr = { version = "1.1", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ http = "1.1"
 internment = { version = "0.8.3", default-features = false, features = ["arc", "serde", "deepsize"] }
 deepsize = "0.2.0"
 split-iter = "0.1.0"
+arcstr = { version = "1.1.5", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -39,7 +39,7 @@ use ztunnel::test_helpers::TEST_WORKLOAD_SOURCE;
 use ztunnel::test_helpers::TEST_WORKLOAD_TCP;
 use ztunnel::test_helpers::{helpers, tcp};
 use ztunnel::xds::LocalWorkload;
-use ztunnel::{app, identity, metrics, proxy, test_helpers};
+use ztunnel::{app, identity, metrics, proxy, strng, test_helpers};
 
 const KB: usize = 1024;
 const MB: usize = 1024 * KB;
@@ -412,10 +412,10 @@ fn hbone_connection_config() -> ztunnel::config::ConfigSource {
             workload: Workload {
                 workload_ips: vec![hbone_connection_ip(i)],
                 protocol: Protocol::HBONE,
-                uid: format!("cluster1//v1/Pod/default/local-source{}", i),
-                name: format!("workload-{}", i),
-                namespace: format!("namespace-{}", i),
-                service_account: format!("service-account-{}", i),
+                uid: strng::format!("cluster1//v1/Pod/default/local-source{}", i),
+                name: strng::format!("workload-{}", i),
+                namespace: strng::format!("namespace-{}", i),
+                service_account: strng::format!("service-account-{}", i),
                 ..test_helpers::test_default_workload()
             },
             services: Default::default(),

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -68,15 +68,15 @@ fn create_test_policies() -> Vec<Authorization> {
     for _ in 0..N_RULES {
         rules.push(vec![vec![RbacMatch {
             namespaces: vec![
-                StringMatch::Prefix("random-prefix-2b123".to_string()),
-                StringMatch::Suffix("random-postix-2b723".to_string()),
-                StringMatch::Exact("random-exac-2bc13".to_string()),
+                StringMatch::Prefix("random-prefix-2b123".into()),
+                StringMatch::Suffix("random-postix-2b723".into()),
+                StringMatch::Exact("random-exac-2bc13".into()),
             ],
             not_namespaces: vec![],
             principals: vec![
-                StringMatch::Prefix("random-prefix-2b123".to_string()),
-                StringMatch::Suffix("random-postix-2b723".to_string()),
-                StringMatch::Exact("random-exac-2bc13".to_string()),
+                StringMatch::Prefix("random-prefix-2b123".into()),
+                StringMatch::Suffix("random-postix-2b723".into()),
+                StringMatch::Exact("random-exac-2bc13".into()),
             ],
             not_principals: vec![],
             source_ips: vec![DUMMY_NETWORK.parse().unwrap()],
@@ -90,10 +90,10 @@ fn create_test_policies() -> Vec<Authorization> {
 
     for i in 0..N_POLICIES {
         policies.push(Authorization {
-            name: format!("policy {i}"),
+            name: strng::format!("policy {i}"),
             action: ztunnel::rbac::RbacAction::Deny,
             scope: ztunnel::rbac::RbacScope::Global,
-            namespace: "default".to_string(),
+            namespace: "default".into(),
             rules: rules.clone(),
         });
     }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -85,6 +85,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "arcstr"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f907281554a3d0312bb7aab855a8e0ef6cbf1614d06de54105039ca8b34460e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2429,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "split-iter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2b15926089e5526bb2dd738a2eb0e59034356e06eb71e1cd912358c0e62c4d"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3255,6 +3270,7 @@ name = "ztunnel"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "async-stream",
  "async-trait",
  "backoff",
@@ -3311,6 +3327,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "socket2",
+ "split-iter",
  "textnonce",
  "thiserror",
  "tls-listener",

--- a/fuzz/fuzz_targets/protobuf.rs
+++ b/fuzz/fuzz_targets/protobuf.rs
@@ -27,11 +27,11 @@ fuzz_target!(|data: &[u8]| {
 });
 
 fn run_workload(data: &[u8]) -> anyhow::Result<()> {
-    Workload::try_from(&XdsWorkload::decode(data)?)?;
+    Workload::try_from(XdsWorkload::decode(data)?)?;
     Ok(())
 }
 
 fn run_rbac(data: &[u8]) -> anyhow::Result<()> {
-    Authorization::try_from(&XdsAuthorization::decode(data)?)?;
+    Authorization::try_from(XdsAuthorization::decode(data)?)?;
     Ok(())
 }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -457,6 +457,7 @@ mod tests {
     use crate::config::construct_config;
     use crate::config::ProxyConfig;
     use crate::identity;
+    use crate::strng;
     use crate::test_helpers::{get_response_str, helpers, new_proxy_state};
     use crate::xds::istio::security::string_match::MatchType as XdsMatchType;
     use crate::xds::istio::security::Address as XdsAddress;
@@ -475,7 +476,6 @@ mod tests {
     use crate::xds::istio::workload::Service as XdsService;
     use crate::xds::istio::workload::Workload as XdsWorkload;
     use crate::xds::istio::workload::WorkloadType as XdsWorkloadType;
-    use crate::strng;
     use bytes::Bytes;
     use http_body_util::BodyExt;
     use std::collections::HashMap;

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -475,6 +475,7 @@ mod tests {
     use crate::xds::istio::workload::Service as XdsService;
     use crate::xds::istio::workload::Workload as XdsWorkload;
     use crate::xds::istio::workload::WorkloadType as XdsWorkloadType;
+    use crate::strng;
     use bytes::Bytes;
     use http_body_util::BodyExt;
     use std::collections::HashMap;
@@ -519,9 +520,9 @@ mod tests {
         for i in 0..2 {
             manager
                 .fetch_certificate(&identity::Identity::Spiffe {
-                    trust_domain: "trust_domain".to_string(),
-                    namespace: "namespace".to_string(),
-                    service_account: format!("sa-{i}"),
+                    trust_domain: "trust_domain".into(),
+                    namespace: "namespace".into(),
+                    service_account: strng::format!("sa-{i}"),
                 })
                 .await
                 .unwrap();

--- a/src/baggage.rs
+++ b/src/baggage.rs
@@ -72,11 +72,11 @@ pub mod tests {
         let header_value = HeaderValue::from_str(baggage_str)?;
         hm.append(BAGGAGE_HEADER, header_value);
         let baggage = parse_baggage_header(hm.get_all(BAGGAGE_HEADER))?;
-        assert_eq!(baggage.cluster_id, Some("K1".to_string()));
-        assert_eq!(baggage.namespace, Some("NS1".to_string()));
-        assert_eq!(baggage.workload_name, Some("N1".to_string()));
-        assert_eq!(baggage.service_name, Some("N2".to_string()));
-        assert_eq!(baggage.revision, Some("V1".to_string()));
+        assert_eq!(baggage.cluster_id, Some("K1".into()));
+        assert_eq!(baggage.namespace, Some("NS1".into()));
+        assert_eq!(baggage.workload_name, Some("N1".into()));
+        assert_eq!(baggage.service_name, Some("N2".into()));
+        assert_eq!(baggage.revision, Some("V1".into()));
         Ok(())
     }
 
@@ -113,11 +113,11 @@ pub mod tests {
         hm.append(BAGGAGE_HEADER, HeaderValue::from_str("service.name=N2")?);
         hm.append(BAGGAGE_HEADER, HeaderValue::from_str("service.version=V1")?);
         let baggage = parse_baggage_header(hm.get_all(BAGGAGE_HEADER))?;
-        assert_eq!(baggage.cluster_id, Some("K1".to_string()));
-        assert_eq!(baggage.namespace, Some("NS1".to_string()));
-        assert_eq!(baggage.workload_name, Some("N1".to_string()));
-        assert_eq!(baggage.service_name, Some("N2".to_string()));
-        assert_eq!(baggage.revision, Some("V1".to_string()));
+        assert_eq!(baggage.cluster_id, Some("K1".into()));
+        assert_eq!(baggage.namespace, Some("NS1".into()));
+        assert_eq!(baggage.workload_name, Some("N1".into()));
+        assert_eq!(baggage.service_name, Some("N2".into()));
+        assert_eq!(baggage.revision, Some("V1".into()));
         Ok(())
     }
 

--- a/src/baggage.rs
+++ b/src/baggage.rs
@@ -16,14 +16,15 @@ use hyper::{
     header::{GetAll, ToStrError},
     http::HeaderValue,
 };
+use crate::strng::Strng;
 
 #[derive(Default)]
 pub struct Baggage {
-    pub cluster_id: Option<String>,
-    pub namespace: Option<String>,
-    pub workload_name: Option<String>,
-    pub service_name: Option<String>,
-    pub revision: Option<String>,
+    pub cluster_id: Option<Strng>,
+    pub namespace: Option<Strng>,
+    pub workload_name: Option<Strng>,
+    pub service_name: Option<Strng>,
+    pub revision: Option<Strng>,
 }
 
 pub fn parse_baggage_header(headers: GetAll<HeaderValue>) -> Result<Baggage, ToStrError> {
@@ -37,7 +38,7 @@ pub fn parse_baggage_header(headers: GetAll<HeaderValue>) -> Result<Baggage, ToS
             if parts.len() > 1 {
                 let val = match parts[1] {
                     "" => None,
-                    s => Some(s.to_string()),
+                    s => Some(s.into()),
                 };
                 match parts[0] {
                     "k8s.cluster.name" => baggage.cluster_id = val,

--- a/src/baggage.rs
+++ b/src/baggage.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::strng::Strng;
 use hyper::{
     header::{GetAll, ToStrError},
     http::HeaderValue,
 };
-use crate::strng::Strng;
 
 #[derive(Default)]
 pub struct Baggage {

--- a/src/cert_fetcher.rs
+++ b/src/cert_fetcher.rs
@@ -94,7 +94,7 @@ impl CertFetcherImpl {
         // Only shared mode fetches other workloads's certs
         self.proxy_mode == ProxyMode::Shared &&
             // We only get certs for our own node
-            Some(&w.node) == self.local_node.as_ref() &&
+            Some(w.node.as_ref()) == self.local_node.as_deref() &&
             // If it doesn't support HBONE it *probably* doesn't need a cert.
             (w.native_tunnel || w.protocol == Protocol::HBONE)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ use hyper::http::uri::InvalidUri;
 use hyper::Uri;
 
 use crate::identity;
+use crate::strng::Strng;
 #[cfg(any(test, feature = "testing"))]
 use {crate::test_helpers::MpscAckReceiver, crate::xds::LocalConfig, tokio::sync::Mutex};
 
@@ -155,7 +156,7 @@ pub struct Config {
     pub dns_proxy_addr: SocketAddr,
 
     /// The network of the node this ztunnel is running on.
-    pub network: String,
+    pub network: Strng,
     /// The name of the node this ztunnel is running as.
     pub local_node: Option<String>,
     /// The proxy mode of ztunnel, Shared or Dedicated, default to Shared.

--- a/src/dns/metrics.rs
+++ b/src/dns/metrics.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use crate::metrics::{DefaultedUnknown, DeferRecorder, Recorder};
 
 use crate::state::workload::Workload;
-use crate::strng::{RichStrng, Strng};
+use crate::strng::RichStrng;
 
 pub struct Metrics {
     pub requests: Family<DnsLabels, Counter>,

--- a/src/dns/metrics.rs
+++ b/src/dns/metrics.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 use crate::metrics::{DefaultedUnknown, DeferRecorder, Recorder};
 
 use crate::state::workload::Workload;
+use crate::strng::{RichStrng, Strng};
 
 pub struct Metrics {
     pub requests: Family<DnsLabels, Counter>,
@@ -77,19 +78,19 @@ impl DeferRecorder for Metrics {}
 
 #[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct DnsLabels {
-    request_query_type: String,
-    request_protocol: String,
+    request_query_type: RichStrng,
+    request_protocol: RichStrng,
 
     // Source workload.
-    source_canonical_service: DefaultedUnknown<String>,
-    source_canonical_revision: DefaultedUnknown<String>,
+    source_canonical_service: DefaultedUnknown<RichStrng>,
+    source_canonical_revision: DefaultedUnknown<RichStrng>,
 }
 
 impl DnsLabels {
     pub fn new(r: &Request) -> Self {
         Self {
-            request_query_type: r.query().query_type().to_string().to_lowercase(),
-            request_protocol: r.protocol().to_string().to_lowercase(),
+            request_query_type: r.query().query_type().to_string().to_lowercase().into(),
+            request_protocol: r.protocol().to_string().to_lowercase().into(),
             source_canonical_service: Default::default(),
             source_canonical_revision: Default::default(),
         }

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -329,7 +329,7 @@ impl Store {
             for mut search_name in get_wildcards(&alias.name) {
                 // Convert the name to a string for lookup, removing the trailing '.'.
                 search_name.set_fqdn(false);
-                let search_name_str = search_name.to_string();
+                let search_name_str = search_name.to_string().into();
                 search_name.set_fqdn(true);
 
                 // First, lookup the host as a service.

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -228,16 +228,16 @@ pub mod mock {
             if error {
                 let mut state = self.state.write().await;
                 state.fetches.push(Identity::Spiffe {
-                    trust_domain: "error".to_string(),
-                    namespace: "error".to_string(),
-                    service_account: "error".to_string(),
+                    trust_domain: "error".into(),
+                    namespace: "error".into(),
+                    service_account: "error".into(),
                 });
             } else {
                 let mut state = self.state.write().await;
                 state.fetches.push(Identity::Spiffe {
-                    trust_domain: "success".to_string(),
-                    namespace: "success".to_string(),
-                    service_account: "success".to_string(),
+                    trust_domain: "success".into(),
+                    namespace: "success".into(),
+                    service_account: "success".into(),
                 });
             }
         }
@@ -285,9 +285,9 @@ mod tests {
     #[tokio::test]
     async fn wrong_identity() {
         let id = Identity::Spiffe {
-            service_account: "wrong-sa".to_string(),
-            namespace: "foo".to_string(),
-            trust_domain: "cluster.local".to_string(),
+            service_account: "wrong-sa".into(),
+            namespace: "foo".into(),
+            trust_domain: "cluster.local".into(),
         };
         let certs = tls::mock::generate_test_certs(
             &id.into(),

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -32,9 +32,9 @@ use crate::tls;
 use super::CaClient;
 use super::Error::{self, Spiffe};
 
+use crate::strng::Strng;
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use keyed_priority_queue::KeyedPriorityQueue;
-use crate::strng::Strng;
 
 const CERT_REFRESH_FAILURE_RETRY_DELAY_MAX_INTERVAL: Duration = Duration::from_secs(150);
 

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -108,9 +108,7 @@ impl Identity {
                 trust_domain,
                 namespace,
                 service_account,
-            } => strng::format!(
-                "spiffe://{trust_domain}/ns/{namespace}/sa/{service_account}"
-            ),
+            } => strng::format!("spiffe://{trust_domain}/ns/{namespace}/sa/{service_account}"),
         }
     }
 }

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -27,7 +27,7 @@ use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::time::{sleep_until, Duration, Instant};
 
-use crate::tls;
+use crate::{strng, tls};
 
 use super::CaClient;
 use super::Error::{self, Spiffe};
@@ -95,6 +95,20 @@ impl fmt::Display for Identity {
                 service_account,
             } => write!(
                 f,
+                "spiffe://{trust_domain}/ns/{namespace}/sa/{service_account}"
+            ),
+        }
+    }
+}
+
+impl Identity {
+    pub fn to_strng(self: &Identity) -> Strng {
+        match self {
+            Identity::Spiffe {
+                trust_domain,
+                namespace,
+                service_account,
+            } => strng::format!(
                 "spiffe://{trust_domain}/ns/{namespace}/sa/{service_account}"
             ),
         }

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -34,15 +34,16 @@ use super::Error::{self, Spiffe};
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use keyed_priority_queue::KeyedPriorityQueue;
+use crate::strng::Strng;
 
 const CERT_REFRESH_FAILURE_RETRY_DELAY_MAX_INTERVAL: Duration = Duration::from_secs(150);
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum Identity {
     Spiffe {
-        trust_domain: String,
-        namespace: String,
-        service_account: String,
+        trust_domain: Strng,
+        namespace: Strng,
+        service_account: Strng,
     },
 }
 
@@ -78,9 +79,9 @@ impl FromStr for Identity {
             return Err(Spiffe(s.to_string()));
         }
         Ok(Identity::Spiffe {
-            trust_domain: split[0].to_string(),
-            namespace: split[2].to_string(),
-            service_account: split[4].to_string(),
+            trust_domain: split[0].into(),
+            namespace: split[2].into(),
+            service_account: split[4].into(),
         })
     }
 }
@@ -107,9 +108,9 @@ impl Default for Identity {
         const SERVICE_ACCOUNT: &str = "ztunnel";
         const NAMESPACE: &str = "istio-system";
         Identity::Spiffe {
-            trust_domain: TRUST_DOMAIN.to_string(),
-            namespace: NAMESPACE.to_string(),
-            service_account: SERVICE_ACCOUNT.to_string(),
+            trust_domain: TRUST_DOMAIN.into(),
+            namespace: NAMESPACE.into(),
+            service_account: SERVICE_ACCOUNT.into(),
         }
     }
 }

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -659,15 +659,16 @@ mod tests {
 
     use crate::identity::caclient::mock::CaClient as MockCaClient;
     use crate::identity::{self, *};
+    use crate::strng;
 
     use super::{mock, *};
 
     async fn stress_many_ids(sm: Arc<SecretManager>, iterations: u32) {
         for i in 0..iterations {
             let id = identity::Identity::Spiffe {
-                trust_domain: "cluster.local".to_string(),
-                namespace: "istio-system".to_string(),
-                service_account: format!("ztunnel{i}"),
+                trust_domain: "cluster.local".into(),
+                namespace: "istio-system".into(),
+                service_account: strng::format!("ztunnel{i}"),
             };
             sm.fetch_certificate(&id)
                 .await
@@ -834,17 +835,17 @@ mod tests {
 
     fn identity(name: &str) -> Identity {
         Identity::Spiffe {
-            trust_domain: "test".to_string(),
-            namespace: "test".to_string(),
-            service_account: name.to_string(),
+            trust_domain: "test".into(),
+            namespace: "test".into(),
+            service_account: name.into(),
         }
     }
 
     fn identity_n(name: &str, n: u8) -> Identity {
         Identity::Spiffe {
-            trust_domain: "test".to_string(),
-            namespace: "test".to_string(),
-            service_account: format!("{name}{n}"),
+            trust_domain: "test".into(),
+            namespace: "test".into(),
+            service_account: strng::format!("{name}{n}"),
         }
     }
 
@@ -1084,33 +1085,33 @@ mod tests {
         assert_eq!(
             Identity::from_str("spiffe://cluster.local/ns/namespace/sa/service-account").ok(),
             Some(Identity::Spiffe {
-                trust_domain: "cluster.local".to_string(),
-                namespace: "namespace".to_string(),
-                service_account: "service-account".to_string(),
+                trust_domain: "cluster.local".into(),
+                namespace: "namespace".into(),
+                service_account: "service-account".into(),
             })
         );
         assert_eq!(
             Identity::from_str("spiffe://td/ns/ns/sa/sa").ok(),
             Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "ns".to_string(),
-                service_account: "sa".to_string(),
+                trust_domain: "td".into(),
+                namespace: "ns".into(),
+                service_account: "sa".into(),
             })
         );
         assert_eq!(
             Identity::from_str("spiffe://td.with.dots/ns/ns.with.dots/sa/sa.with.dots").ok(),
             Some(Identity::Spiffe {
-                trust_domain: "td.with.dots".to_string(),
-                namespace: "ns.with.dots".to_string(),
-                service_account: "sa.with.dots".to_string(),
+                trust_domain: "td.with.dots".into(),
+                namespace: "ns.with.dots".into(),
+                service_account: "sa.with.dots".into(),
             })
         );
         assert_eq!(
             Identity::from_str("spiffe://td/ns//sa/").ok(),
             Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "".to_string(),
-                service_account: "".to_string()
+                trust_domain: "td".into(),
+                namespace: "".into(),
+                service_account: "".into()
             })
         );
         assert_matches!(Identity::from_str("td/ns/ns/sa/sa"), Err(_));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod time;
 pub mod tls;
 pub mod version;
 pub mod xds;
+pub mod strng;
 
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,12 @@ pub mod readiness;
 pub mod signal;
 pub mod socket;
 pub mod state;
+pub mod strng;
 pub mod telemetry;
 pub mod time;
 pub mod tls;
 pub mod version;
 pub mod xds;
-pub mod strng;
 
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:1\0";
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 fn main() -> anyhow::Result<()> {
     telemetry::setup_logging();

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:1\0";
 
 fn main() -> anyhow::Result<()> {
     telemetry::setup_logging();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -25,8 +25,8 @@ use crate::identity::Identity;
 pub mod meta;
 pub mod server;
 
-pub use server::*;
 use crate::strng::{RichStrng, Strng};
+pub use server::*;
 
 /// Creates a metrics sub registry for Istio.
 pub fn sub_registry(registry: &mut Registry) -> &mut Registry {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -25,6 +25,7 @@ pub mod meta;
 pub mod server;
 
 pub use server::*;
+use crate::strng::{RichStrng, Strng};
 
 /// Creates a metrics sub registry for Istio.
 pub fn sub_registry(registry: &mut Registry) -> &mut Registry {
@@ -117,6 +118,8 @@ impl<T> Default for DefaultedUnknown<T> {
     }
 }
 
+// Surely there is a less verbose way to do this, but I cannot find one.
+
 impl From<String> for DefaultedUnknown<String> {
     fn from(t: String) -> Self {
         if t.is_empty() {
@@ -124,6 +127,42 @@ impl From<String> for DefaultedUnknown<String> {
         } else {
             DefaultedUnknown(Some(t))
         }
+    }
+}
+
+impl From<RichStrng> for DefaultedUnknown<RichStrng> {
+    fn from(t: RichStrng) -> Self {
+        if t.is_empty() {
+            DefaultedUnknown(None)
+        } else {
+            DefaultedUnknown(Some(t))
+        }
+    }
+}
+
+impl From<String> for DefaultedUnknown<RichStrng> {
+    fn from(t: String) -> Self {
+        if t.is_empty() {
+            DefaultedUnknown(None)
+        } else {
+            DefaultedUnknown(Some(t.into()))
+        }
+    }
+}
+
+impl From<Strng> for DefaultedUnknown<RichStrng> {
+    fn from(t: Strng) -> Self {
+        if t.is_empty() {
+            DefaultedUnknown(None)
+        } else {
+            DefaultedUnknown(Some(t.into()))
+        }
+    }
+}
+
+impl From<Option<Strng>> for DefaultedUnknown<RichStrng> {
+    fn from(t: Option<Strng>) -> Self {
+        DefaultedUnknown(t.map(RichStrng::from))
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -18,6 +18,7 @@ use std::mem;
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
 use prometheus_client::registry::Registry;
 use tracing::error;
+use tracing::field::{display, DisplayValue};
 
 use crate::identity::Identity;
 
@@ -102,6 +103,12 @@ where
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
 // DefaultedUnknown is a wrapper around an Option that encodes as "unknown" when missing, rather than ""
 pub struct DefaultedUnknown<T>(Option<T>);
+
+impl DefaultedUnknown<RichStrng> {
+    pub fn display(&self) -> Option<DisplayValue<&str>> {
+        self.as_ref().map(|rs| display(rs.as_str()))
+    }
+}
 
 impl<T> DefaultedUnknown<T> {
     pub fn inner(self) -> Option<T> {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -620,7 +620,7 @@ mod tests {
         let w = mock_default_gateway_workload();
         let s = mock_default_gateway_service();
         let mut state = state::ProxyState::default();
-        state.workloads.insert(w);
+        state.workloads.insert(Arc::new(w));
         state.services.insert(s);
         let state = state::DemandProxyState::new(
             Arc::new(RwLock::new(state)),
@@ -630,9 +630,9 @@ mod tests {
         );
 
         let gateawy_id = Identity::Spiffe {
-            trust_domain: "cluster.local".to_string(),
-            namespace: "gatewayns".to_string(),
-            service_account: "default".to_string(),
+            trust_domain: "cluster.local".into(),
+            namespace: "gatewayns".into(),
+            service_account: "default".into(),
         };
         let from_gw_conn = Some(gateawy_id);
         let not_from_gw_conn = Some(Identity::default());
@@ -668,20 +668,20 @@ mod tests {
             network_gateway: gw,
             gateway_address: None,
             protocol: Default::default(),
-            uid: "".to_string(),
-            name: "app".to_string(),
-            namespace: "appns".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
-            network: "".to_string(),
-            workload_name: "app".to_string(),
-            workload_type: "deployment".to_string(),
-            canonical_name: "app".to_string(),
-            canonical_revision: "".to_string(),
-            hostname: "".to_string(),
-            node: "".to_string(),
+            uid: "".into(),
+            name: "app".into(),
+            namespace: "appns".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "default".into(),
+            network: "".into(),
+            workload_name: "app".into(),
+            workload_type: "deployment".into(),
+            canonical_name: "app".into(),
+            canonical_revision: "".into(),
+            hostname: "".into(),
+            node: "".into(),
             status: Default::default(),
-            cluster_id: "Kubernetes".to_string(),
+            cluster_id: "Kubernetes".into(),
 
             authorization_policies: Vec::new(),
             native_tunnel: false,
@@ -697,20 +697,20 @@ mod tests {
             network_gateway: None,
             gateway_address: None,
             protocol: Default::default(),
-            uid: "".to_string(),
-            name: "gateway".to_string(),
-            namespace: "gatewayns".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
-            network: "".to_string(),
-            workload_name: "gateway".to_string(),
-            workload_type: "deployment".to_string(),
-            canonical_name: "".to_string(),
-            canonical_revision: "".to_string(),
-            hostname: "".to_string(),
-            node: "".to_string(),
+            uid: "".into(),
+            name: "gateway".into(),
+            namespace: "gatewayns".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "default".into(),
+            network: "".into(),
+            workload_name: "gateway".into(),
+            workload_type: "deployment".into(),
+            canonical_name: "".into(),
+            canonical_revision: "".into(),
+            hostname: "".into(),
+            node: "".into(),
             status: Default::default(),
-            cluster_id: "Kubernetes".to_string(),
+            cluster_id: "Kubernetes".into(),
 
             authorization_policies: Vec::new(),
             native_tunnel: false,
@@ -722,14 +722,14 @@ mod tests {
     fn mock_default_gateway_service() -> Service {
         let vip1 = NetworkAddress {
             address: IpAddr::V4(Ipv4Addr::new(127, 0, 10, 1)),
-            network: "".to_string(),
+            network: "".into(),
         };
         let vips = vec![vip1];
         let mut ports = HashMap::new();
         ports.insert(8080, 80);
         let mut endpoints = HashMap::new();
         let addr = Some(NetworkAddress {
-            network: "".to_string(),
+            network: "".into(),
             address: IpAddr::V4(mock_default_gateway_ipaddr()),
         });
         endpoints.insert(
@@ -737,17 +737,17 @@ mod tests {
             Endpoint {
                 workload_uid: mock_default_gateway_workload().uid,
                 service: NamespacedHostname {
-                    namespace: "gatewayns".to_string(),
-                    hostname: "gateway".to_string(),
+                    namespace: "gatewayns".into(),
+                    hostname: "gateway".into(),
                 },
                 address: addr,
                 port: ports.clone(),
             },
         );
         Service {
-            name: "gateway".to_string(),
-            namespace: "gatewayns".to_string(),
-            hostname: "gateway".to_string(),
+            name: "gateway".into(),
+            namespace: "gatewayns".into(),
+            hostname: "gateway".into(),
             vips,
             ports,
             endpoints,
@@ -760,7 +760,7 @@ mod tests {
     fn mock_default_gateway_address() -> GatewayAddress {
         GatewayAddress {
             destination: Destination::Address(NetworkAddress {
-                network: "".to_string(),
+                network: "".into(),
                 address: IpAddr::V4(mock_default_gateway_ipaddr()),
             }),
             hbone_mtls_port: 15008,
@@ -771,8 +771,8 @@ mod tests {
     fn mock_default_gateway_hostname() -> GatewayAddress {
         GatewayAddress {
             destination: Destination::Hostname(state::workload::NamespacedHostname {
-                namespace: "gatewayns".to_string(),
-                hostname: "gateway".to_string(),
+                namespace: "gatewayns".into(),
+                hostname: "gateway".into(),
             }),
             hbone_mtls_port: 15008,
             hbone_single_tls_port: Some(15003),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -513,7 +513,7 @@ pub fn guess_inbound_service(
     // Note: the set of Services we look for is bounded, so we won't blindly trust bogus info.
     if let Some(found) = upstream_service
         .iter()
-        .find(|s| for_host_header.as_ref() == Some(&s.hostname))
+        .find(|s| for_host_header.as_deref() == Some(s.hostname.as_ref()))
         .map(|s| ServiceDescription::from(s.as_ref()))
     {
         return Some(found);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -519,7 +519,7 @@ pub fn guess_inbound_service(
         return Some(found);
     }
     let dport = conn.dst.port();
-    let netaddr = network_addr(&dest.network, conn.dst.ip());
+    let netaddr = network_addr(dest.network.clone(), conn.dst.ip());
     let euid = endpoint_uid(&dest.uid, Some(&netaddr));
     upstream_service
         .iter()

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -364,7 +364,7 @@ mod tests {
                         std::net::Ipv4Addr::new(192, 168, 0, 1).into(),
                         80,
                     ),
-                    dst_network: "".to_string(),
+                    dst_network: "".into(),
                     dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                         Ipv4Addr::new(192, 168, 0, 2),
                         8080,
@@ -398,7 +398,7 @@ mod tests {
                         std::net::Ipv4Addr::new(192, 168, 0, 3).into(),
                         80,
                     ),
-                    dst_network: "".to_string(),
+                    dst_network: "".into(),
                     dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                         Ipv4Addr::new(192, 168, 0, 2),
                         8080,
@@ -465,7 +465,7 @@ mod tests {
                         std::net::Ipv4Addr::new(192, 168, 0, 1).into(),
                         80,
                     ),
-                    dst_network: "".to_string(),
+                    dst_network: "".into(),
                     dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                         Ipv4Addr::new(192, 168, 0, 2),
                         8080,
@@ -485,7 +485,7 @@ mod tests {
                         std::net::Ipv4Addr::new(192, 168, 0, 3).into(),
                         80,
                     ),
-                    dst_network: "".to_string(),
+                    dst_network: "".into(),
                     dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                         Ipv4Addr::new(192, 168, 0, 2),
                         8080,
@@ -577,7 +577,7 @@ mod tests {
                         std::net::Ipv4Addr::new(192, 168, 0, 1).into(),
                         80,
                     ),
-                    dst_network: "".to_string(),
+                    dst_network: "".into(),
                     dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                         Ipv4Addr::new(192, 168, 0, 2),
                         8080,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -602,6 +602,7 @@ pub fn parse_forwarded_host<T>(req: &Request<T>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::Inbound;
+    use crate::strng;
 
     use std::{
         net::SocketAddr,
@@ -704,18 +705,18 @@ mod tests {
         ]
         .into_iter()
         .map(|(name, vip, ep_ip, waypoint)| {
-            let ep_uid = format!("cluster1//v1/Pod/default/{name}");
+            let ep_uid = strng::format!("cluster1//v1/Pod/default/{name}");
             let ep_addr = Some(NetworkAddress {
                 address: ep_ip.parse().unwrap(),
                 network: "".to_string(),
             });
             Service {
-                name: name.to_string(),
-                namespace: "default".to_string(),
-                hostname: format!("{name}.default.svc.cluster.local"),
+                name: name.into(),
+                namespace: "default".into(),
+                hostname: strng::format!("{name}.default.svc.cluster.local"),
                 vips: vec![NetworkAddress {
                     address: vip.parse().unwrap(),
-                    network: "".to_string(),
+                    network: "".into(),
                 }],
                 ports: std::collections::HashMap::new(),
                 endpoints: vec![(
@@ -723,8 +724,8 @@ mod tests {
                     Endpoint {
                         workload_uid: ep_uid,
                         service: NamespacedHostname {
-                            hostname: format!("{name}.default.svc.cluster.local"),
-                            namespace: "default".to_string(),
+                            hostname: strng::format!("{name}.default.svc.cluster.local"),
+                            namespace: "default".into(),
                         },
                         address: ep_addr,
                         port: std::collections::HashMap::new(),
@@ -732,7 +733,7 @@ mod tests {
                 )]
                 .into_iter()
                 .collect(),
-                subject_alt_names: vec![format!("{name}.default.svc.cluster.local")],
+                subject_alt_names: vec![strng::format!("{name}.default.svc.cluster.local")],
                 waypoint: waypoint.service_attached(),
                 load_balancer: None,
             }
@@ -754,10 +755,10 @@ mod tests {
             workload_ips: vec![ip.parse().unwrap()],
             waypoint: waypoint.workload_attached(),
             protocol: Protocol::HBONE,
-            uid: format!("cluster1//v1/Pod/default/{name}"),
-            name: format!("workload-{name}"),
-            namespace: "default".to_string(),
-            service_account: format!("service-account-{name}"),
+            uid: strng::format!("cluster1//v1/Pod/default/{name}"),
+            name: strng::format!("workload-{name}"),
+            namespace: "default".into(),
+            service_account: strng::format!("service-account-{name}"),
             application_tunnel: app_tunnel,
             ..test_helpers::test_default_workload()
         });
@@ -766,7 +767,7 @@ mod tests {
             state.services.insert(svc);
         }
         for wl in workloads {
-            state.workloads.insert(wl);
+            state.workloads.insert(Arc::new(wl));
         }
 
         Ok(DemandProxyState::new(

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -47,7 +47,7 @@ use crate::socket::to_canonical;
 use crate::state::service::Service;
 use crate::state::workload::address::Address;
 use crate::state::workload::application_tunnel::Protocol as AppProtocol;
-use crate::{assertions, proxy, socket, tls};
+use crate::{assertions, proxy, socket, strng, tls};
 
 use crate::state::workload::{self, NetworkAddress, Workload};
 use crate::state::DemandProxyState;
@@ -530,8 +530,8 @@ impl Inbound {
             return None;
         }
         tokio::join![
-            state.fetch_on_demand(connection_dst.to_string()),
-            state.fetch_on_demand(hbone_dst.to_string()),
+            state.fetch_on_demand(strng::new(connection_dst.to_string())),
+            state.fetch_on_demand(strng::new(hbone_dst.to_string())),
         ];
         lookup().flatten()
     }

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -116,7 +116,7 @@ impl Inbound {
                 let conn = Connection {
                     src_identity,
                     src,
-                    dst_network: network, // inbound request must be on our network
+                    dst_network: strng::new(&network), // inbound request must be on our network
                     dst,
                 };
                 debug!(%conn, "accepted connection");
@@ -670,7 +670,7 @@ mod tests {
         let conn = Connection {
             src_identity: None,
             src: format!("{CLIENT_POD_IP}:1234").parse().unwrap(),
-            dst_network: "".to_string(),
+            dst_network: "".into(),
             dst: format!("{connection_dst}:15008").parse().unwrap(),
         };
         let res = Inbound::find_inbound_upstream(

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -28,7 +28,7 @@ use crate::proxy::metrics::Reporter;
 use crate::proxy::Error;
 use crate::proxy::{metrics, util, ProxyInputs};
 use crate::state::workload::NetworkAddress;
-use crate::{assertions, rbac};
+use crate::{assertions, rbac, strng};
 use crate::{proxy, socket};
 
 pub(super) struct InboundPassthrough {
@@ -170,7 +170,7 @@ impl InboundPassthrough {
                 // inbound request must be on our network since this is passthrough
                 // rather than HBONE, which can be tunneled across networks through gateways.
                 // by definition, without the gateway our source must be on our network.
-                dst_network: pi.cfg.network.clone(),
+                dst_network: strng::new(&pi.cfg.network),
                 dst: dest_addr,
             },
             dest_workload_info: pi.proxy_workload_info.clone(),

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -148,7 +148,7 @@ impl InboundPassthrough {
             return;
         }
         let network_addr = NetworkAddress {
-            network: pi.cfg.network.clone(), // inbound request must be on our network
+            network: strng::new(&pi.cfg.network), // inbound request must be on our network
             address: dest_addr.ip(),
         };
         let Some((upstream, upstream_service)) =
@@ -182,7 +182,7 @@ impl InboundPassthrough {
                 // inbound request must be on our network since this is passthrough
                 // rather than HBONE, which can be tunneled across networks through gateways.
                 // by definition, without the gateway our source must be on our network.
-                network: pi.cfg.network.clone(),
+                network: pi.cfg.network.as_str().into(),
                 address: source_addr.ip(),
             };
             pi.state.fetch_workload(&network_addr_srcip).await

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -436,15 +436,15 @@ impl ConnectionResult {
             tracing::Level::DEBUG,
 
             src.addr = %src.0,
-            src.workload = src.1,
-            src.namespace = tl.source_workload_namespace.as_ref(),
+            src.workload = src.1.as_deref().map(display),
+            src.namespace = tl.source_workload_namespace.display(),
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             dst.addr = %dst.0,
-            dst.hbone_addr = hbone_target.map(tracing::field::display),
-            dst.service = tl.destination_service.as_ref(),
-            dst.workload = dst.1,
-            dst.namespace = tl.destination_workload_namespace.as_ref(),
+            dst.hbone_addr = hbone_target.map(display),
+            dst.service = tl.destination_service.as_deref().map(display),,
+            dst.workload = dst.1.as_deref().map(display),
+            dst.namespace = tl.destination_workload_namespace.display(),
             dst.identity = tl.destination_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             direction = if tl.reporter == Reporter::source {
@@ -515,20 +515,19 @@ impl ConnectionResult {
         let dur = format!("{}ms", self.start.elapsed().as_millis());
 
         // We use our own macro to allow setting the level dynamically
-        /*
         access_log!(
             res,
 
             src.addr = %self.src.0,
-            src.workload = %self.src.1,
-            src.namespace = %tl.source_workload_namespace,
+            src.workload = self.src.1.as_deref().map(display),
+            src.namespace = tl.source_workload_namespace.display(),
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             dst.addr = %self.dst.0,
-            dst.hbone_addr = self.hbone_target.map(tracing::field::display),
-            dst.service = tl.destination_service.as_ref(),
-            dst.workload = self.dst.1,
-            dst.namespace = tl.destination_workload_namespace.as_ref(),
+            dst.hbone_addr = self.hbone_target.map(display),
+            dst.service = tl.destination_service.display(),
+            dst.workload = self.dst.1.as_deref().map(display),
+            dst.namespace = tl.destination_workload_namespace.display(),
             dst.identity = tl.destination_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             direction = if tl.reporter == Reporter::source {
@@ -543,7 +542,5 @@ impl ConnectionResult {
             bytes_recv = if tl.reporter == Reporter::source {bytes.1} else {bytes.0},
             duration = dur,
         );
-        *
-         */
     }
 }

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -442,7 +442,7 @@ impl ConnectionResult {
 
             dst.addr = %dst.0,
             dst.hbone_addr = hbone_target.map(display),
-            dst.service = tl.destination_service.as_deref().map(display),,
+            dst.service = tl.destination_service.display(),
             dst.workload = dst.1.as_deref().map(display),
             dst.namespace = tl.destination_workload_namespace.display(),
             dst.identity = tl.destination_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -30,6 +30,7 @@ use crate::metrics::{DefaultedUnknown, DeferRecorder, Deferred, IncrementRecorde
 
 use crate::state::service::ServiceDescription;
 use crate::state::workload::Workload;
+use crate::strng::{RichStrng, Strng};
 
 pub struct Metrics {
     pub connection_opens: Family<CommonTrafficLabels, Counter>,
@@ -116,12 +117,12 @@ pub enum SecurityPolicy {
 
 #[derive(Clone, Debug, Default)]
 pub struct DerivedWorkload {
-    pub workload_name: Option<String>,
-    pub app: Option<String>,
-    pub revision: Option<String>,
-    pub namespace: Option<String>,
+    pub workload_name: Option<Strng>,
+    pub app: Option<Strng>,
+    pub revision: Option<Strng>,
+    pub namespace: Option<Strng>,
     pub identity: Option<Identity>,
-    pub cluster_id: Option<String>,
+    pub cluster_id: Option<Strng>,
 }
 
 #[derive(Clone)]
@@ -208,27 +209,27 @@ impl From<ConnectionOpen> for CommonTrafficLabels {
 pub struct CommonTrafficLabels {
     reporter: Reporter,
 
-    source_workload: DefaultedUnknown<String>,
-    source_canonical_service: DefaultedUnknown<String>,
-    source_canonical_revision: DefaultedUnknown<String>,
-    source_workload_namespace: DefaultedUnknown<String>,
+    source_workload: DefaultedUnknown<RichStrng>,
+    source_canonical_service: DefaultedUnknown<RichStrng>,
+    source_canonical_revision: DefaultedUnknown<RichStrng>,
+    source_workload_namespace: DefaultedUnknown<RichStrng>,
     source_principal: DefaultedUnknown<Identity>,
-    source_app: DefaultedUnknown<String>,
-    source_version: DefaultedUnknown<String>,
-    source_cluster: DefaultedUnknown<String>,
+    source_app: DefaultedUnknown<RichStrng>,
+    source_version: DefaultedUnknown<RichStrng>,
+    source_cluster: DefaultedUnknown<RichStrng>,
 
-    destination_service: DefaultedUnknown<String>,
-    destination_service_namespace: DefaultedUnknown<String>,
-    destination_service_name: DefaultedUnknown<String>,
+    destination_service: DefaultedUnknown<RichStrng>,
+    destination_service_namespace: DefaultedUnknown<RichStrng>,
+    destination_service_name: DefaultedUnknown<RichStrng>,
 
-    destination_workload: DefaultedUnknown<String>,
-    destination_canonical_service: DefaultedUnknown<String>,
-    destination_canonical_revision: DefaultedUnknown<String>,
-    destination_workload_namespace: DefaultedUnknown<String>,
+    destination_workload: DefaultedUnknown<RichStrng>,
+    destination_canonical_service: DefaultedUnknown<RichStrng>,
+    destination_canonical_revision: DefaultedUnknown<RichStrng>,
+    destination_workload_namespace: DefaultedUnknown<RichStrng>,
     destination_principal: DefaultedUnknown<Identity>,
-    destination_app: DefaultedUnknown<String>,
-    destination_version: DefaultedUnknown<String>,
-    destination_cluster: DefaultedUnknown<String>,
+    destination_app: DefaultedUnknown<RichStrng>,
+    destination_version: DefaultedUnknown<RichStrng>,
+    destination_cluster: DefaultedUnknown<RichStrng>,
 
     request_protocol: RequestProtocol,
     response_flags: ResponseFlags,
@@ -238,17 +239,17 @@ pub struct CommonTrafficLabels {
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct OnDemandDnsLabels {
     // on-demand DNS client information is just nice-to-have
-    source_workload: DefaultedUnknown<String>,
-    source_canonical_service: DefaultedUnknown<String>,
-    source_canonical_revision: DefaultedUnknown<String>,
-    source_workload_namespace: DefaultedUnknown<String>,
+    source_workload: DefaultedUnknown<RichStrng>,
+    source_canonical_service: DefaultedUnknown<RichStrng>,
+    source_canonical_revision: DefaultedUnknown<RichStrng>,
+    source_workload_namespace: DefaultedUnknown<RichStrng>,
     source_principal: DefaultedUnknown<Identity>,
-    source_app: DefaultedUnknown<String>,
-    source_version: DefaultedUnknown<String>,
-    source_cluster: DefaultedUnknown<String>,
+    source_app: DefaultedUnknown<RichStrng>,
+    source_version: DefaultedUnknown<RichStrng>,
+    source_cluster: DefaultedUnknown<RichStrng>,
 
     // on-demand DNS is resolved per hostname, so this is the most interesting part
-    hostname: DefaultedUnknown<String>,
+    hostname: DefaultedUnknown<RichStrng>,
 }
 
 impl OnDemandDnsLabels {
@@ -328,9 +329,9 @@ impl Metrics {
 /// ConnectionResult abstracts recording a metric and emitting an access log upon a connection completion
 pub struct ConnectionResult {
     // Src address and name
-    src: (SocketAddr, Option<String>),
+    src: (SocketAddr, Option<RichStrng>),
     // Dst address and name
-    dst: (SocketAddr, Option<String>),
+    dst: (SocketAddr, Option<RichStrng>),
     hbone_target: Option<SocketAddr>,
     start: Instant,
 
@@ -417,10 +418,10 @@ impl ConnectionResult {
         metrics: Arc<Metrics>,
     ) -> Self {
         // for src and dest, try to get pod name but fall back to "canonical service"
-        let mut src = (src, conn.source.as_ref().map(|wl| wl.name.clone()));
+        let mut src = (src, conn.source.as_ref().map(|wl| wl.name.clone().into()));
         let mut dst = (
             dst,
-            conn.destination.as_ref().map(|wl| wl.name.clone()), // TODO: canonical
+            conn.destination.as_ref().map(|wl| wl.name.clone().into()),
         );
         let tl = CommonTrafficLabels::from(conn);
         metrics.connection_opens.get_or_create(&tl).inc();
@@ -512,13 +513,15 @@ impl ConnectionResult {
             self.sent.load(Ordering::SeqCst),
         );
         let dur = format!("{}ms", self.start.elapsed().as_millis());
+
         // We use our own macro to allow setting the level dynamically
+        /*
         access_log!(
             res,
 
             src.addr = %self.src.0,
-            src.workload = self.src.1,
-            src.namespace = tl.source_workload_namespace.as_ref(),
+            src.workload = %self.src.1,
+            src.namespace = %tl.source_workload_namespace,
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(|id| id.to_string()),
 
             dst.addr = %self.dst.0,
@@ -540,5 +543,7 @@ impl ConnectionResult {
             bytes_recv = if tl.reporter == Reporter::source {bytes.1} else {bytes.0},
             duration = dur,
         );
+        *
+         */
     }
 }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -38,6 +38,7 @@ use crate::state::service::ServiceDescription;
 use crate::state::workload::gatewayaddress::Destination;
 use crate::state::workload::{address::Address, NetworkAddress, Protocol, Workload};
 use crate::{assertions, proxy, socket};
+use crate::strng::Strng;
 
 pub struct Outbound {
     pi: ProxyInputs,
@@ -313,7 +314,7 @@ impl OutboundConnection {
         let mut f = http_types::proxies::Forwarded::new();
         f.add_for(remote_addr.to_string());
         if let Some(svc) = &req.destination_service {
-            f.set_host(&svc.hostname);
+            f.set_host(svc.hostname.as_ref());
         }
 
         let request = http::Request::builder()
@@ -580,7 +581,7 @@ struct Request {
     gateway: SocketAddr,
     request_type: RequestType,
 
-    upstream_sans: Vec<String>,
+    upstream_sans: Vec<Strng>,
 }
 
 #[derive(PartialEq, Debug)]

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -314,7 +314,7 @@ impl OutboundConnection {
         let mut f = http_types::proxies::Forwarded::new();
         f.add_for(remote_addr.to_string());
         if let Some(svc) = &req.destination_service {
-            f.set_host(svc.hostname.as_ref());
+            f.set_host(svc.hostname.as_str());
         }
 
         let request = http::Request::builder()

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -37,8 +37,8 @@ use crate::proxy::h2_client::H2Stream;
 use crate::state::service::ServiceDescription;
 use crate::state::workload::gatewayaddress::Destination;
 use crate::state::workload::{address::Address, NetworkAddress, Protocol, Workload};
-use crate::{assertions, proxy, socket};
 use crate::strng::Strng;
+use crate::{assertions, proxy, socket};
 
 pub struct Outbound {
     pi: ProxyInputs,

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -27,6 +27,7 @@ use xds::istio::security::StringMatch as XdsStringMatch;
 use crate::identity::Identity;
 
 use crate::state::workload::{byte_to_ip, WorkloadError};
+use crate::strng::Strng;
 use crate::xds;
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -72,11 +73,15 @@ impl Display for Connection {
 }
 
 impl Authorization {
-    pub fn to_key(&self) -> String {
-        format!("{}/{}", self.namespace, self.name)
+    pub fn to_key(&self) -> Strng {
+        let mut res = String::with_capacity(1 + self.namespace.len() + self.name.len());
+        res.push_str(&self.namespace);
+        res.push('/');
+        res.push_str(&self.name);
+        res.into()
     }
 
-    #[instrument(level = "trace", skip_all, fields(policy=self.to_key()))]
+    #[instrument(level = "trace", skip_all, fields(policy=self.to_key().as_str()))]
     pub fn matches(&self, conn: &Connection) -> bool {
         let id = conn
             .src_identity

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -31,7 +31,8 @@ use crate::xds;
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct Authorization { // TODO move all of this
+pub struct Authorization {
+    // TODO move all of this
     pub name: String,
     pub namespace: String,
     pub scope: RbacScope,

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -31,7 +31,7 @@ use crate::xds;
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct Authorization {
+pub struct Authorization { // TODO move all of this
     pub name: String,
     pub namespace: String,
     pub scope: RbacScope,

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -444,9 +444,9 @@ mod tests {
     fn tls_conn() -> Connection {
         Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "namespace".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "namespace".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
@@ -457,9 +457,9 @@ mod tests {
     fn tls_conn_alt() -> Connection {
         Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td-alt".to_string(),
-                namespace: "ns-alt".to_string(),
-                service_account: "sa=alt".to_string(),
+                trust_domain: "td-alt".into(),
+                namespace: "ns-alt".into(),
+                service_account: "sa=alt".into(),
             }),
             src: "127.0.0.3:1234".parse().unwrap(),
             dst_network: "".to_string(),
@@ -505,9 +505,9 @@ mod tests {
         // Can match either namespace...
         assert!(pol.matches(&Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "a".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "a".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
@@ -515,9 +515,9 @@ mod tests {
         }));
         assert!(pol.matches(&Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "b".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "b".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
@@ -526,9 +526,9 @@ mod tests {
         // Policy is applied regardless of network
         assert!(pol.matches(&Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "b".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "b".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "remote".to_string(),
@@ -537,9 +537,9 @@ mod tests {
         // Wrong namespace
         assert!(!pol.matches(&Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "bad".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "bad".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
@@ -548,9 +548,9 @@ mod tests {
         // Wrong port
         assert!(!pol.matches(&Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "b".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "b".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
@@ -576,9 +576,9 @@ mod tests {
         // Can match either namespace...
         assert!(pol.matches(&Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "a".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "a".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
@@ -586,9 +586,9 @@ mod tests {
         }));
         assert!(pol.matches(&Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "b".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "b".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),
@@ -597,9 +597,9 @@ mod tests {
         // Wrong namespace
         assert!(!pol.matches(&Connection {
             src_identity: Some(Identity::Spiffe {
-                trust_domain: "td".to_string(),
-                namespace: "bad".to_string(),
-                service_account: "account".to_string(),
+                trust_domain: "td".into(),
+                namespace: "bad".into(),
+                service_account: "account".into(),
             }),
             src: "127.0.0.1:1234".parse().unwrap(),
             dst_network: "".to_string(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -396,7 +396,7 @@ impl DemandProxyState {
 
         // We can get policies from namespace, global, and workload...
         let ns = state.policies.get_by_namespace(&wl.namespace);
-        let global = state.policies.get_by_namespace(&crate::strng::new(""));
+        let global = state.policies.get_by_namespace(&crate::strng::literal!(""));
         let workload = wl.authorization_policies.iter();
 
         // Aggregate all of them based on type
@@ -426,10 +426,10 @@ impl DemandProxyState {
         // "If there are any DENY policies that match the request, deny the request."
         for pol in deny.iter() {
             if pol.matches(conn) {
-                debug!(policy = pol.to_key(), "deny policy match");
+                debug!(policy = pol.to_key().as_str(), "deny policy match");
                 return false;
             } else {
-                trace!(policy = pol.to_key(), "deny policy does not match");
+                trace!(policy = pol.to_key().as_str(), "deny policy does not match");
             }
         }
         // "If there are no ALLOW policies for the workload, allow the request."
@@ -440,10 +440,13 @@ impl DemandProxyState {
         // "If any of the ALLOW policies match the request, allow the request."
         for pol in allow.iter() {
             if pol.matches(conn) {
-                debug!(policy = pol.to_key(), "allow policy match");
+                debug!(policy = pol.to_key().as_str(), "allow policy match");
                 return true;
             } else {
-                trace!(policy = pol.to_key(), "allow policy does not match");
+                trace!(
+                    policy = pol.to_key().as_str(),
+                    "allow policy does not match"
+                );
             }
         }
         // "Deny the request."

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,6 +23,7 @@ use crate::state::workload::{
     address::Address, gatewayaddress::Destination, network_addr, NamespacedHostname,
     NetworkAddress, Protocol, WaypointError, Workload, WorkloadStore,
 };
+use crate::strng::Strng;
 use crate::tls;
 use crate::xds::istio::security::Authorization as XdsAuthorization;
 use crate::xds::istio::workload::Address as XdsAddress;
@@ -43,7 +44,6 @@ use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 use tracing::{debug, error, trace, warn};
-use crate::strng::Strng;
 
 pub mod policy;
 pub mod service;
@@ -761,7 +761,7 @@ impl DemandProxyState {
             debug!(%key, "sending demand request");
             Box::pin(
                 demand
-                    .demand(xds::ADDRESS_TYPE.into(), key.clone())
+                    .demand(xds::ADDRESS_TYPE, key.clone())
                     .then(|o| o.recv()),
             )
             .await;

--- a/src/state.rs
+++ b/src/state.rs
@@ -643,7 +643,7 @@ impl DemandProxyState {
     }
 
     // only support workload
-    pub async fn fetch_workload_by_uid(&self, uid: &str) -> Option<Workload> {
+    pub async fn fetch_workload_by_uid(&self, uid: &Strng) -> Option<Workload> {
         // Wait for it on-demand, *if* needed
         debug!(%uid, "fetch workload");
         if let Some(wl) = self.state.read().unwrap().workloads.find_uid(uid) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -533,7 +533,7 @@ impl DemandProxyState {
             TokioConnectionProvider::default(),
         );
 
-        let resp = resolver_result.lookup_ip(hostname.as_ref()).await;
+        let resp = resolver_result.lookup_ip(hostname.as_str()).await;
         if resp.is_err() {
             warn!(
                 "system dns async resolution: error response for workload {} is: {:?}",

--- a/src/state.rs
+++ b/src/state.rs
@@ -869,7 +869,7 @@ mod tests {
         let mut state = ProxyState::default();
         state
             .workloads
-            .insert(test_helpers::test_default_workload());
+            .insert(Arc::new(test_helpers::test_default_workload()));
         state.services.insert(test_helpers::mock_default_service());
 
         let mock_proxy_state = DemandProxyState::new(
@@ -895,8 +895,8 @@ mod tests {
 
         // Some from Hostname
         let dst = Destination::Hostname(NamespacedHostname {
-            namespace: "default".to_string(),
-            hostname: "defaulthost".to_string(),
+            namespace: "default".into(),
+            hostname: "defaulthost".into(),
         });
         test_helpers::assert_eventually(
             Duration::from_secs(5),
@@ -909,7 +909,7 @@ mod tests {
 
         // None from Address
         let dst = Destination::Address(NetworkAddress {
-            network: "".to_string(),
+            network: "".into(),
             address: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
         });
         test_helpers::assert_eventually(
@@ -921,8 +921,8 @@ mod tests {
 
         // None from Hostname
         let dst = Destination::Hostname(NamespacedHostname {
-            namespace: "default".to_string(),
-            hostname: "nothost".to_string(),
+            namespace: "default".into(),
+            hostname: "nothost".into(),
         });
         test_helpers::assert_eventually(
             Duration::from_secs(5),
@@ -936,14 +936,14 @@ mod tests {
     async fn assert_rbac_with_dest_workload_info() {
         let mut state = ProxyState::default();
         let wl = Workload {
-            name: "test".to_string(),
-            namespace: "default".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "defaultacct".to_string(),
+            name: "test".into(),
+            namespace: "default".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "defaultacct".into(),
             workload_ips: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2))],
             ..test_helpers::test_default_workload()
         };
-        state.workloads.insert(wl);
+        state.workloads.insert(Arc::new(wl));
 
         let mock_proxy_state = DemandProxyState::new(
             Arc::new(RwLock::new(state)),
@@ -953,10 +953,10 @@ mod tests {
         );
 
         let wi = WorkloadInfo {
-            name: "test".to_string(),
-            namespace: "default".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "defaultacct".to_string(),
+            name: "test".into(),
+            namespace: "default".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "defaultacct".into(),
         };
 
         let mut ctx = crate::state::ProxyRbacContext {
@@ -979,25 +979,25 @@ mod tests {
         // now make sure it fails when we change just one property of the workload info
         {
             let mut wi = wi.clone();
-            wi.name = "not-test".to_string();
+            wi.name = "not-test".into();
             ctx.dest_workload_info = Some(Arc::new(wi.clone()));
             assert!(!mock_proxy_state.assert_rbac(&ctx).await);
         }
         {
             let mut wi = wi.clone();
-            wi.namespace = "not-test".to_string();
+            wi.namespace = "not-test".into();
             ctx.dest_workload_info = Some(Arc::new(wi.clone()));
             assert!(!mock_proxy_state.assert_rbac(&ctx).await);
         }
         {
             let mut wi = wi.clone();
-            wi.service_account = "not-test".to_string();
+            wi.service_account = "not-test".into();
             ctx.dest_workload_info = Some(Arc::new(wi.clone()));
             assert!(!mock_proxy_state.assert_rbac(&ctx).await);
         }
         {
             let mut wi = wi.clone();
-            wi.trust_domain = "not-test".to_string();
+            wi.trust_domain = "not-test".into();
             ctx.dest_workload_info = Some(Arc::new(wi.clone()));
             assert!(!mock_proxy_state.assert_rbac(&ctx).await);
         }
@@ -1007,116 +1007,116 @@ mod tests {
     async fn test_load_balance() {
         let mut state = ProxyState::default();
         let wl_no_locality = Workload {
-            uid: "cluster1//v1/Pod/default/wl_no_locality".to_string(),
-            name: "wl_no_locality".to_string(),
-            namespace: "default".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
+            uid: "cluster1//v1/Pod/default/wl_no_locality".into(),
+            name: "wl_no_locality".into(),
+            namespace: "default".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "default".into(),
             workload_ips: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))],
             ..test_helpers::test_default_workload()
         };
         let wl_match = Workload {
-            uid: "cluster1//v1/Pod/default/wl_match".to_string(),
-            name: "wl_match".to_string(),
-            namespace: "default".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
+            uid: "cluster1//v1/Pod/default/wl_match".into(),
+            name: "wl_match".into(),
+            namespace: "default".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "default".into(),
             workload_ips: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2))],
-            network: "network".to_string(),
+            network: "network".into(),
             locality: Locality {
-                region: "reg".to_string(),
-                zone: "zone".to_string(),
-                subzone: "".to_string(),
+                region: "reg".into(),
+                zone: "zone".into(),
+                subzone: "".into(),
             },
             ..test_helpers::test_default_workload()
         };
         let wl_almost = Workload {
-            uid: "cluster1//v1/Pod/default/wl_almost".to_string(),
-            name: "wl_almost".to_string(),
-            namespace: "default".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
+            uid: "cluster1//v1/Pod/default/wl_almost".into(),
+            name: "wl_almost".into(),
+            namespace: "default".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "default".into(),
             workload_ips: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 0, 3))],
-            network: "network".to_string(),
+            network: "network".into(),
             locality: Locality {
-                region: "reg".to_string(),
-                zone: "not-zone".to_string(),
-                subzone: "".to_string(),
+                region: "reg".into(),
+                zone: "not-zone".into(),
+                subzone: "".into(),
             },
             ..test_helpers::test_default_workload()
         };
         let _ep_almost = Workload {
-            uid: "cluster1//v1/Pod/default/ep_almost".to_string(),
-            name: "wl_almost".to_string(),
-            namespace: "default".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
+            uid: "cluster1//v1/Pod/default/ep_almost".into(),
+            name: "wl_almost".into(),
+            namespace: "default".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "default".into(),
             workload_ips: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 0, 4))],
-            network: "network".to_string(),
+            network: "network".into(),
             locality: Locality {
-                region: "reg".to_string(),
-                zone: "other-not-zone".to_string(),
-                subzone: "".to_string(),
+                region: "reg".into(),
+                zone: "other-not-zone".into(),
+                subzone: "".into(),
             },
             ..test_helpers::test_default_workload()
         };
         let _ep_no_match = Workload {
-            uid: "cluster1//v1/Pod/default/ep_no_match".to_string(),
-            name: "wl_almost".to_string(),
-            namespace: "default".to_string(),
-            trust_domain: "cluster.local".to_string(),
-            service_account: "default".to_string(),
+            uid: "cluster1//v1/Pod/default/ep_no_match".into(),
+            name: "wl_almost".into(),
+            namespace: "default".into(),
+            trust_domain: "cluster.local".into(),
+            service_account: "default".into(),
             workload_ips: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 0, 5))],
-            network: "not-network".to_string(),
+            network: "not-network".into(),
             locality: Locality {
-                region: "not-reg".to_string(),
-                zone: "unmatched-zone".to_string(),
-                subzone: "".to_string(),
+                region: "not-reg".into(),
+                zone: "unmatched-zone".into(),
+                subzone: "".into(),
             },
             ..test_helpers::test_default_workload()
         };
         let endpoints = HashMap::from([
             (
-                "cluster1//v1/Pod/default/ep_almost".to_string(),
+                "cluster1//v1/Pod/default/ep_almost".into(),
                 Endpoint {
-                    workload_uid: "cluster1//v1/Pod/default/ep_almost".to_string(),
+                    workload_uid: "cluster1//v1/Pod/default/ep_almost".into(),
                     service: NamespacedHostname {
-                        namespace: TEST_SERVICE_NAMESPACE.to_string(),
-                        hostname: "example.com".to_string(),
+                        namespace: TEST_SERVICE_NAMESPACE.into(),
+                        hostname: "example.com".into(),
                     },
                     address: Some(NetworkAddress {
                         address: "192.168.0.4".parse().unwrap(),
-                        network: "".to_string(),
+                        network: "".into(),
                     }),
                     port: HashMap::from([(80u16, 80u16)]),
                 },
             ),
             (
-                "cluster1//v1/Pod/default/ep_no_match".to_string(),
+                "cluster1//v1/Pod/default/ep_no_match".into(),
                 Endpoint {
-                    workload_uid: "cluster1//v1/Pod/default/ep_almost".to_string(),
+                    workload_uid: "cluster1//v1/Pod/default/ep_almost".into(),
                     service: NamespacedHostname {
-                        namespace: TEST_SERVICE_NAMESPACE.to_string(),
-                        hostname: "example.com".to_string(),
+                        namespace: TEST_SERVICE_NAMESPACE.into(),
+                        hostname: "example.com".into(),
                     },
                     address: Some(NetworkAddress {
                         address: "192.168.0.5".parse().unwrap(),
-                        network: "".to_string(),
+                        network: "".into(),
                     }),
                     port: HashMap::from([(80u16, 80u16)]),
                 },
             ),
             (
-                "cluster1//v1/Pod/default/wl_match".to_string(),
+                "cluster1//v1/Pod/default/wl_match".into(),
                 Endpoint {
-                    workload_uid: "cluster1//v1/Pod/default/wl_match".to_string(),
+                    workload_uid: "cluster1//v1/Pod/default/wl_match".into(),
                     service: NamespacedHostname {
-                        namespace: TEST_SERVICE_NAMESPACE.to_string(),
-                        hostname: "example.com".to_string(),
+                        namespace: TEST_SERVICE_NAMESPACE.into(),
+                        hostname: "example.com".into(),
                     },
                     address: Some(NetworkAddress {
                         address: "192.168.0.2".parse().unwrap(),
-                        network: "".to_string(),
+                        network: "".into(),
                     }),
                     port: HashMap::from([(80u16, 80u16)]),
                 },
@@ -1146,9 +1146,9 @@ mod tests {
             }),
             ..test_helpers::mock_default_service()
         };
-        state.workloads.insert(wl_no_locality.clone());
-        state.workloads.insert(wl_match.clone());
-        state.workloads.insert(wl_almost.clone());
+        state.workloads.insert(Arc::new(wl_no_locality.clone()));
+        state.workloads.insert(Arc::new(wl_match.clone()));
+        state.workloads.insert(Arc::new(wl_almost.clone()));
         state.services.insert(strict_svc.clone());
         state.services.insert(failover_svc.clone());
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -624,7 +624,7 @@ impl DemandProxyState {
         if !self.supports_on_demand() {
             return None;
         }
-        self.fetch_on_demand(addr.to_string()).await;
+        self.fetch_on_demand(addr.to_string().into()).await;
         fetch(addr)
     }
 
@@ -638,7 +638,7 @@ impl DemandProxyState {
         if !self.supports_on_demand() {
             return None;
         }
-        self.fetch_on_demand(addr.to_string()).await;
+        self.fetch_on_demand(addr.to_string().into()).await;
         self.state.read().unwrap().workloads.find_address(addr)
     }
 
@@ -652,7 +652,7 @@ impl DemandProxyState {
         if !self.supports_on_demand() {
             return None;
         }
-        self.fetch_on_demand(uid.to_string()).await;
+        self.fetch_on_demand(uid.clone()).await;
         self.state.read().unwrap().workloads.find_uid(uid)
     }
 
@@ -731,7 +731,7 @@ impl DemandProxyState {
             return None;
         }
         // if both cache not found, start on demand fetch
-        self.fetch_on_demand(network_addr.to_string()).await;
+        self.fetch_on_demand(network_addr.to_string().into()).await;
         self.state.read().unwrap().find_address(network_addr)
     }
 
@@ -747,7 +747,7 @@ impl DemandProxyState {
             return None;
         }
         // if both cache not found, start on demand fetch
-        self.fetch_on_demand(hostname.to_string()).await;
+        self.fetch_on_demand(hostname.to_string().into()).await;
         self.state.read().unwrap().find_hostname(hostname)
     }
 
@@ -756,12 +756,12 @@ impl DemandProxyState {
     }
 
     /// fetch_on_demand looks up the provided key on-demand and waits for it to return
-    pub async fn fetch_on_demand(&self, key: String) {
+    pub async fn fetch_on_demand(&self, key: Strng) {
         if let Some(demand) = &self.demand {
             debug!(%key, "sending demand request");
             Box::pin(
                 demand
-                    .demand(xds::ADDRESS_TYPE.to_string(), key.clone())
+                    .demand(xds::ADDRESS_TYPE.into(), key.clone())
                     .then(|o| o.recv()),
             )
             .await;

--- a/src/state.rs
+++ b/src/state.rs
@@ -969,7 +969,7 @@ mod tests {
                     Ipv4Addr::new(192, 168, 0, 1),
                     1234,
                 )),
-                dst_network: "".to_string(),
+                dst_network: "".into(),
                 dst: std::net::SocketAddr::V4(SocketAddrV4::new(
                     Ipv4Addr::new(192, 168, 0, 2),
                     8080,

--- a/src/state/policy.rs
+++ b/src/state/policy.rs
@@ -81,7 +81,7 @@ impl PolicyStore {
             return;
         };
         if let Some(key) = match rbac.scope {
-            RbacScope::Global => Some("".into()),
+            RbacScope::Global => Some(strng::new("")),
             RbacScope::Namespace => Some(rbac.namespace.into()),
             RbacScope::WorkloadSelector => None,
         } {

--- a/src/state/policy.rs
+++ b/src/state/policy.rs
@@ -57,11 +57,11 @@ impl PolicyStore {
     }
 
     pub fn insert(&mut self, rbac: Authorization) {
-        let key: Strng = rbac.to_key().into();
+        let key: Strng = rbac.to_key();
         match rbac.scope {
             RbacScope::Global => {
                 self.by_namespace
-                    .entry("".into())
+                    .entry(strng::literal!(""))
                     .or_default()
                     .insert(key.clone());
             }
@@ -81,7 +81,7 @@ impl PolicyStore {
             return;
         };
         if let Some(key) = match rbac.scope {
-            RbacScope::Global => Some(strng::new("")),
+            RbacScope::Global => Some(strng::literal!("")),
             RbacScope::Namespace => Some(rbac.namespace.into()),
             RbacScope::WorkloadSelector => None,
         } {

--- a/src/state/policy.rs
+++ b/src/state/policy.rs
@@ -15,6 +15,7 @@
 use crate::rbac::{Authorization, RbacScope};
 use std::collections::{HashMap, HashSet};
 use tokio::sync::watch;
+use crate::strng;
 use crate::strng::Strng;
 
 /// A PolicyStore encapsulates all policy information about workloads in the mesh
@@ -66,7 +67,7 @@ impl PolicyStore {
             }
             RbacScope::Namespace => {
                 self.by_namespace
-                    .entry(rbac.namespace.into())
+                    .entry(strng::new(&rbac.namespace))
                     .or_default()
                     .insert(key.clone());
             }

--- a/src/state/policy.rs
+++ b/src/state/policy.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use crate::rbac::{Authorization, RbacScope};
-use std::collections::{HashMap, HashSet};
-use tokio::sync::watch;
 use crate::strng;
 use crate::strng::Strng;
+use std::collections::{HashMap, HashSet};
+use tokio::sync::watch;
 
 /// A PolicyStore encapsulates all policy information about workloads in the mesh
 #[derive(Default, Debug)]
@@ -49,7 +49,7 @@ impl PolicyStore {
 
     pub fn get_by_namespace(&self, namespace: &Strng) -> Vec<Strng> {
         self.by_namespace
-            .get(namespace.into())
+            .get(namespace)
             .into_iter()
             .flatten()
             .cloned()

--- a/src/state/policy.rs
+++ b/src/state/policy.rs
@@ -61,7 +61,7 @@ impl PolicyStore {
         match rbac.scope {
             RbacScope::Global => {
                 self.by_namespace
-                    .entry(strng::literal!(""))
+                    .entry(strng::EMPTY)
                     .or_default()
                     .insert(key.clone());
             }
@@ -81,8 +81,8 @@ impl PolicyStore {
             return;
         };
         if let Some(key) = match rbac.scope {
-            RbacScope::Global => Some(strng::literal!("")),
-            RbacScope::Namespace => Some(rbac.namespace.into()),
+            RbacScope::Global => Some(strng::EMPTY),
+            RbacScope::Namespace => Some(rbac.namespace),
             RbacScope::WorkloadSelector => None,
         } {
             if let Some(pl) = self.by_namespace.get_mut(&key) {

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -151,11 +151,12 @@ pub struct Endpoint {
 }
 
 pub fn endpoint_uid(workload_uid: &str, address: Option<&NetworkAddress>) -> Strng {
-    format!(
-        "{}:{}",
-        workload_uid,
-        address.map(|a| a.to_string()).unwrap_or_default()
-    ).into()
+    let addr = address.map(|a| a.to_string()).unwrap_or_default();
+    let mut res = String::with_capacity(1 +addr.len() + workload_uid.len());
+    res.push_str(workload_uid);
+    res.push(':');
+    res.push_str(&addr);
+    res.into()
 }
 
 impl TryFrom<&XdsService> for Service {

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -192,9 +192,9 @@ impl TryFrom<&XdsService> for Service {
             None
         };
         let svc = Service {
-            name: s.name.as_str().into(),
-            namespace: s.namespace.as_str().into(),
-            hostname: s.hostname.as_str().into(),
+            name: Strng::from(&s.name),
+            namespace: Strng::from(&s.namespace),
+            hostname: Strng::from(&s.hostname),
             vips: nw_addrs,
             ports: (&PortList {
                 ports: s.ports.clone(),
@@ -214,20 +214,20 @@ impl TryFrom<&XdsService> for Service {
 pub struct ServiceStore {
     /// Maintains a mapping of service key -> (endpoint UID -> workload endpoint)
     /// this is used to handle ordering issues if workloads are received before services.
-    pub staged_services: HashMap<NamespacedHostname, HashMap<Strng, Endpoint>>,
+    pub(super) staged_services: HashMap<NamespacedHostname, HashMap<Strng, Endpoint>>,
 
     /// Maintains a mapping of workload UID to service. This is used only to handle removal of
     /// service endpoints when a workload is removed.
-    pub workload_to_services: HashMap<Strng, HashSet<NamespacedHostname>>,
+    workload_to_services: HashMap<Strng, HashSet<NamespacedHostname>>,
 
     /// Allows for lookup of services by network address, the service's xds secondary key.
-    pub by_vip: HashMap<NetworkAddress, Arc<Service>>,
+    pub(super) by_vip: HashMap<NetworkAddress, Arc<Service>>,
 
     /// Allows for lookup of services by hostname, and then by namespace. XDS uses a combination
     /// of hostname and namespace as the primary key. In most cases, there will be a single
     /// service for a given hostname. However, `ServiceEntry` allows hostnames to be overridden
     /// on a per-namespace basis.
-    pub by_host: HashMap<Strng, Vec<Arc<Service>>>,
+    by_host: HashMap<Strng, Vec<Arc<Service>>>,
 }
 
 impl ServiceStore {

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -17,7 +17,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use tracing::trace;
+use tracing::{error, trace};
 
 use xds::istio::workload::Service as XdsService;
 
@@ -213,20 +213,20 @@ impl TryFrom<&XdsService> for Service {
 pub struct ServiceStore {
     /// Maintains a mapping of service key -> (endpoint UID -> workload endpoint)
     /// this is used to handle ordering issues if workloads are received before services.
-    pub(super) staged_services: HashMap<NamespacedHostname, HashMap<Strng, Endpoint>>,
+    pub  staged_services: HashMap<NamespacedHostname, HashMap<Strng, Endpoint>>,
 
     /// Maintains a mapping of workload UID to service. This is used only to handle removal of
     /// service endpoints when a workload is removed.
-    workload_to_services: HashMap<Strng, HashSet<NamespacedHostname>>,
+    pub workload_to_services: HashMap<Strng, HashSet<NamespacedHostname>>,
 
     /// Allows for lookup of services by network address, the service's xds secondary key.
-    pub(super) by_vip: HashMap<NetworkAddress, Arc<Service>>,
+    pub  by_vip: HashMap<NetworkAddress, Arc<Service>>,
 
     /// Allows for lookup of services by hostname, and then by namespace. XDS uses a combination
     /// of hostname and namespace as the primary key. In most cases, there will be a single
     /// service for a given hostname. However, `ServiceEntry` allows hostnames to be overridden
     /// on a per-namespace basis.
-    by_host: HashMap<Strng, Vec<Arc<Service>>>,
+    pub by_host: HashMap<Strng, Vec<Arc<Service>>>,
 }
 
 impl ServiceStore {

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -17,7 +17,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use tracing::{error, trace};
+use tracing::trace;
 
 use xds::istio::workload::Service as XdsService;
 
@@ -27,9 +27,9 @@ use crate::state::workload::{
     WorkloadError,
 };
 use crate::strng::Strng;
-use crate::{strng, xds};
 use crate::xds::istio::workload::load_balancing::Scope as XdsScope;
 use crate::xds::istio::workload::PortList;
+use crate::{strng, xds};
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -152,7 +152,7 @@ pub struct Endpoint {
 
 pub fn endpoint_uid(workload_uid: &str, address: Option<&NetworkAddress>) -> Strng {
     let addr = address.map(|a| a.to_string()).unwrap_or_default();
-    let mut res = String::with_capacity(1 +addr.len() + workload_uid.len());
+    let mut res = String::with_capacity(1 + addr.len() + workload_uid.len());
     res.push_str(workload_uid);
     res.push(':');
     res.push_str(&addr);
@@ -214,14 +214,14 @@ impl TryFrom<&XdsService> for Service {
 pub struct ServiceStore {
     /// Maintains a mapping of service key -> (endpoint UID -> workload endpoint)
     /// this is used to handle ordering issues if workloads are received before services.
-    pub  staged_services: HashMap<NamespacedHostname, HashMap<Strng, Endpoint>>,
+    pub staged_services: HashMap<NamespacedHostname, HashMap<Strng, Endpoint>>,
 
     /// Maintains a mapping of workload UID to service. This is used only to handle removal of
     /// service endpoints when a workload is removed.
     pub workload_to_services: HashMap<Strng, HashSet<NamespacedHostname>>,
 
     /// Allows for lookup of services by network address, the service's xds secondary key.
-    pub  by_vip: HashMap<NetworkAddress, Arc<Service>>,
+    pub by_vip: HashMap<NetworkAddress, Arc<Service>>,
 
     /// Allows for lookup of services by hostname, and then by namespace. XDS uses a combination
     /// of hostname and namespace as the primary key. In most cases, there will be a single

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -166,7 +166,7 @@ impl TryFrom<&XdsService> for Service {
         let mut nw_addrs = Vec::new();
         for addr in &s.addresses {
             let network_address = network_addr(
-                &addr.network,
+                strng::new(&addr.network),
                 byte_to_ip(&Bytes::copy_from_slice(&addr.address))?,
             );
             nw_addrs.push(network_address);

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -343,12 +343,9 @@ impl TryFrom<&XdsGatewayAddress> for GatewayAddress {
     }
 }
 
-impl TryFrom<&XdsWorkload> for Workload {
+impl TryFrom<XdsWorkload> for Workload {
     type Error = WorkloadError;
-    fn try_from(resource: &XdsWorkload) -> Result<Self, Self::Error> {
-        // TODO can we avoid the clone?
-        let resource: XdsWorkload = resource.to_owned();
-
+    fn try_from(resource: XdsWorkload) -> Result<Self, Self::Error> {
         let wp = match &resource.waypoint {
             Some(w) => Some(GatewayAddress::try_from(w)?),
             None => None,

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -585,11 +585,10 @@ pub struct WorkloadStore {
 }
 
 impl WorkloadStore {
-    pub fn insert(&mut self, w: Workload) {
+    pub fn insert(&mut self, w: Arc<Workload>) {
         // First, remove the entry entirely to make sure things are cleaned up properly.
         self.remove(&w.uid);
 
-        let w = Arc::new(w);
         for ip in &w.workload_ips {
             self.by_addr
                 .insert(network_addr(&w.network, *ip), w.clone());

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -578,13 +578,13 @@ pub fn network_addr(network: &str, vip: IpAddr) -> NetworkAddress {
 #[derive(Default, Debug)]
 pub struct WorkloadStore {
     /// byAddress maps workload network addresses to workloads
-    pub(super) by_addr: HashMap<NetworkAddress, Arc<Workload>>,
+    pub by_addr: HashMap<NetworkAddress, Arc<Workload>>,
     /// byUid maps workload UIDs to workloads
-    by_uid: HashMap<Strng, Arc<Workload>>,
+    pub by_uid: HashMap<Strng, Arc<Workload>>,
     /// byHostname maps workload hostname to workloads.
-    by_hostname: HashMap<Strng, Arc<Workload>>,
+    pub by_hostname: HashMap<Strng, Arc<Workload>>,
     // Identity->Set of UIDs
-    by_identity: HashMap<Identity, HashSet<Strng>>,
+    pub by_identity: HashMap<Identity, HashSet<Strng>>,
 }
 
 impl WorkloadStore {

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -343,7 +343,7 @@ impl TryFrom<&XdsGatewayAddress> for GatewayAddress {
     }
 }
 
-impl TryFrom<XdsWorkload> for Workload {
+impl TryFrom<XdsWorkload> for (Workload, HashMap<String, PortList>) {
     type Error = WorkloadError;
     fn try_from(resource: XdsWorkload) -> Result<Self, Self::Error> {
         let wp = match &resource.waypoint {
@@ -368,7 +368,7 @@ impl TryFrom<XdsWorkload> for Workload {
             .collect::<Result<Vec<_>, _>>()?;
 
         let workload_type = resource.workload_type().as_str_name().to_lowercase();
-        Ok(Workload {
+        Ok((Workload {
             workload_ips: addresses,
             waypoint: wp,
             network_gateway: network_gw,
@@ -424,7 +424,7 @@ impl TryFrom<XdsWorkload> for Workload {
                     result.into()
                 }
             },
-        })
+        }, resource.services))
     }
 }
 

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -1,9 +1,8 @@
 use std::fmt::Error;
 use std::ops::Deref;
-use std::rc::Rc;
-use std::sync::Arc;
+
 use arcstr::ArcStr;
-use prometheus_client::encoding::{EncodeLabelKey, LabelSetEncoder, LabelValueEncoder};
+use prometheus_client::encoding::LabelValueEncoder;
 
 pub type Strng = ArcStr;
 
@@ -33,7 +32,9 @@ impl Deref for RichStrng {
 }
 
 impl<T> From<T> for RichStrng
-    where T: Into<Strng>{
+where
+    T: Into<Strng>,
+{
     fn from(value: T) -> Self {
         RichStrng(value.into())
     }
@@ -42,27 +43,23 @@ impl<T> From<T> for RichStrng
 #[cfg(test)]
 mod test {
     use super::*;
-    fn as_ref_fn<A: AsRef<str>>(s: A) {
-
-    }
-    fn into_string_fn<A: Into<String>>(s: A) {
-
-    }
-    fn string_fn(s: String) {
-
-    }
-    fn str_fn(s: &str) {
-
-    }
+    fn as_ref_fn<A: AsRef<str>>(_s: A) {}
+    fn into_string_fn<A: Into<String>>(_s: A) {}
+    fn string_fn(_s: String) {}
+    fn str_fn(_s: &str) {}
 
     #[test]
     fn interning() {
+        // Mostly we just thinly wrap ArcString, so just validate our assumptions about the library
         let a = new("abc");
         let b = new("abc");
-        assert_eq!(std::mem::size_of::<Strng>(), 16);
+        assert_eq!(std::mem::size_of::<Strng>(), 8);
         assert_eq!(std::format!("{a}"), "abc");
         assert_eq!(super::format!("{a}"), "abc");
         assert_eq!(ArcStr::strong_count(&a), ArcStr::strong_count(&b));
+        assert_eq!(ArcStr::strong_count(&a), Some(1));
+        let c = a.clone();
+        assert_eq!(ArcStr::strong_count(&a), ArcStr::strong_count(&c));
         assert_eq!(ArcStr::strong_count(&a), Some(2));
         assert_eq!("abc", b.to_string());
 
@@ -70,6 +67,6 @@ mod test {
         as_ref_fn(new("abc"));
         into_string_fn(&*new("abc"));
         string_fn(a.to_string());
-        as_ref_fn(new("abc"));
+        str_fn(&new("abc"));
     }
 }

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -1,4 +1,6 @@
 use std::fmt::Error;
+use std::ops::Deref;
+use std::rc::Rc;
 use internment::ArcIntern;
 use prometheus_client::encoding::{EncodeLabelKey, LabelSetEncoder, LabelValueEncoder};
 
@@ -14,7 +16,15 @@ pub struct RichStrng(Strng);
 
 impl prometheus_client::encoding::EncodeLabelValue for RichStrng {
     fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), Error> {
-        prometheus_client::encoding::EncodeLabelValue::encode(self.0.as_ref(), encoder)
+        prometheus_client::encoding::EncodeLabelValue::encode(&self.0.as_ref(), encoder)
+    }
+}
+
+impl Deref for RichStrng {
+    type Target = Strng;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -11,6 +11,9 @@ pub fn new<A: AsRef<str>>(s: A) -> Strng {
     s.as_ref().into()
 }
 
+pub use arcstr::format;
+pub use arcstr::literal;
+
 /// RichStrng wraps Strng to let us implement arbitrary methods. How annoying.
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq)]
 pub struct RichStrng(Strng);
@@ -42,10 +45,13 @@ mod test {
     fn as_ref_fn<A: AsRef<str>>(s: A) {
 
     }
+    fn into_string_fn<A: Into<String>>(s: A) {
+
+    }
     fn string_fn(s: String) {
 
     }
-    fn str_fn(s: &s) {
+    fn str_fn(s: &str) {
 
     }
 
@@ -54,14 +60,16 @@ mod test {
         let a = new("abc");
         let b = new("abc");
         assert_eq!(std::mem::size_of::<Strng>(), 16);
-        assert_eq!(format!("{a}"), "abc");
-        assert_eq!(a.refcount(), b.refcount());
-        assert_eq!(a.refcount(), 2);
+        assert_eq!(std::format!("{a}"), "abc");
+        assert_eq!(super::format!("{a}"), "abc");
+        assert_eq!(ArcStr::strong_count(&a), ArcStr::strong_count(&b));
+        assert_eq!(ArcStr::strong_count(&a), Some(2));
         assert_eq!("abc", b.to_string());
 
         // Compile time assertion we can call function in various ways
         as_ref_fn(new("abc"));
+        into_string_fn(&*new("abc"));
         string_fn(a.to_string());
-        as_ref_fn(a.as_ref());
+        as_ref_fn(new("abc"));
     }
 }

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -1,22 +1,56 @@
+use std::fmt::Error;
 use internment::ArcIntern;
+use prometheus_client::encoding::{EncodeLabelKey, LabelSetEncoder, LabelValueEncoder};
 
 pub type Strng = ArcIntern<str>;
 
-pub fn intern<A: AsRef<str>>(s: A) -> ArcIntern<str> {
+pub fn new<A: AsRef<str>>(s: A) -> ArcIntern<str> {
     s.as_ref().into()
+}
+
+/// RichStrng wraps Strng to let us implement arbitrary methods. How annoying.
+#[derive(Clone, Hash, Default, Debug, PartialEq, Eq)]
+pub struct RichStrng(Strng);
+
+impl prometheus_client::encoding::EncodeLabelValue for RichStrng {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), Error> {
+        prometheus_client::encoding::EncodeLabelValue::encode(self.0.as_ref(), encoder)
+    }
+}
+
+impl<T> From<T> for RichStrng
+    where T: Into<Strng>{
+    fn from(value: T) -> Self {
+        RichStrng(value.into())
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    fn as_ref_fn<A: AsRef<str>>(s: A) {
+
+    }
+    fn string_fn(s: String) {
+
+    }
+    fn str_fn(s: &s) {
+
+    }
+
     #[test]
     fn interning() {
-        let a = intern("abc");
-        let b = intern("abc");
+        let a = new("abc");
+        let b = new("abc");
         assert_eq!(std::mem::size_of::<Strng>(), 16);
         assert_eq!(format!("{a}"), "abc");
         assert_eq!(a.refcount(), b.refcount());
         assert_eq!(a.refcount(), 2);
-        assert_eq!("abc", b.into_string());
+        assert_eq!("abc", b.to_string());
+
+        // Compile time assertion we can call function in various ways
+        as_ref_fn(new("abc"));
+        string_fn(a.to_string());
+        as_ref_fn(a.as_ref());
     }
 }

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -1,12 +1,13 @@
 use std::fmt::Error;
 use std::ops::Deref;
 use std::rc::Rc;
-use internment::ArcIntern;
+use std::sync::Arc;
+use arcstr::ArcStr;
 use prometheus_client::encoding::{EncodeLabelKey, LabelSetEncoder, LabelValueEncoder};
 
-pub type Strng = ArcIntern<str>;
+pub type Strng = ArcStr;
 
-pub fn new<A: AsRef<str>>(s: A) -> ArcIntern<str> {
+pub fn new<A: AsRef<str>>(s: A) -> Strng {
     s.as_ref().into()
 }
 

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -1,13 +1,33 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt::Error;
 use std::ops::Deref;
 
 use arcstr::ArcStr;
 use prometheus_client::encoding::LabelValueEncoder;
 
+/// 'Strng' provides a string type that has better properties for our use case:
+/// * Cheap cloning (ref counting)
+/// * Efficient storage (8 bytes vs 24 bytes)
+/// * Immutable
+/// This is mostly provided by a library, ArcStr, we just provide a very thin wrapper around it
+/// for some flexibility.
 pub type Strng = ArcStr;
 
 pub fn new<A: AsRef<str>>(s: A) -> Strng {
-    s.as_ref().into()
+    Strng::from(s.as_ref())
 }
 
 pub use arcstr::format;

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -1,0 +1,22 @@
+use internment::ArcIntern;
+
+pub type Strng = ArcIntern<str>;
+
+pub fn intern<A: AsRef<str>>(s: A) -> ArcIntern<str> {
+    s.as_ref().into()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn interning() {
+        let a = intern("abc");
+        let b = intern("abc");
+        assert_eq!(std::mem::size_of::<Strng>(), 16);
+        assert_eq!(format!("{a}"), "abc");
+        assert_eq!(a.refcount(), b.refcount());
+        assert_eq!(a.refcount(), 2);
+        assert_eq!("abc", b.into_string());
+    }
+}

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -26,6 +26,8 @@ use prometheus_client::encoding::LabelValueEncoder;
 /// for some flexibility.
 pub type Strng = ArcStr;
 
+pub const EMPTY: Strng = literal!("");
+
 pub fn new<A: AsRef<str>>(s: A) -> Strng {
     Strng::from(s.as_ref())
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -407,7 +407,9 @@ pub fn new_proxy_state(
             },
         };
         let handler = &updater as &dyn Handler<XdsAddress>;
-        handler.handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter())).unwrap();
+        handler
+            .handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter()))
+            .unwrap();
     }
     for s in xds_services {
         let res = XdsResource {
@@ -417,7 +419,9 @@ pub fn new_proxy_state(
             },
         };
         let handler = &updater as &dyn Handler<XdsAddress>;
-        handler.handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter())).unwrap();
+        handler
+            .handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter()))
+            .unwrap();
     }
     for a in xds_authorizations {
         let res = XdsResource {
@@ -425,7 +429,9 @@ pub fn new_proxy_state(
             resource: a.clone(),
         };
         let handler = &updater as &dyn Handler<XdsAuthorization>;
-        handler.handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter())).unwrap();
+        handler
+            .handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter()))
+            .unwrap();
     }
     DemandProxyState::new(
         state,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -158,9 +158,9 @@ pub fn mock_default_service() -> Service {
     ports.insert(8080, 80);
     let endpoints = HashMap::new();
     Service {
-        name: "".to_string(),
-        namespace: "default".to_string(),
-        hostname: "defaulthost".to_string(),
+        name: "".into(),
+        namespace: "default".into(),
+        hostname: "defaulthost".into(),
         vips,
         ports,
         endpoints,
@@ -177,20 +177,20 @@ pub fn test_default_workload() -> Workload {
         network_gateway: None,
         gateway_address: None,
         protocol: Default::default(),
-        uid: "".to_string(),
-        name: "".to_string(),
-        namespace: "".to_string(),
-        trust_domain: "cluster.local".to_string(),
-        service_account: "default".to_string(),
-        network: "".to_string(),
-        workload_name: "".to_string(),
-        workload_type: "deployment".to_string(),
-        canonical_name: "".to_string(),
-        canonical_revision: "".to_string(),
-        hostname: "".to_string(),
-        node: "".to_string(),
+        uid: "".into(),
+        name: "".into(),
+        namespace: "".into(),
+        trust_domain: "cluster.local".into(),
+        service_account: "default".into(),
+        network: "".into(),
+        workload_name: "".into(),
+        workload_type: "deployment".into(),
+        canonical_name: "".into(),
+        canonical_revision: "".into(),
+        hostname: "".into(),
+        node: "".into(),
         status: Default::default(),
-        cluster_id: "Kubernetes".to_string(),
+        cluster_id: "Kubernetes".into(),
 
         authorization_policies: Vec::new(),
         native_tunnel: false,
@@ -217,13 +217,13 @@ fn test_custom_workload(
     };
     let workload = Workload {
         workload_ips: wips,
-        hostname: host,
+        hostname: host.into(),
         protocol,
-        uid: format!("cluster1//v1/Pod/default/{}", name),
-        name: name.to_string(),
-        namespace: "default".to_string(),
-        service_account: "default".to_string(),
-        node: "local".to_string(),
+        uid: format!("cluster1//v1/Pod/default/{}", name).into(),
+        name: name.into(),
+        namespace: "default".into(),
+        service_account: "default".into(),
+        node: "local".into(),
         ..test_default_workload()
     };
     let mut services = HashMap::new();
@@ -250,27 +250,27 @@ fn test_custom_svc(
         }),
     };
     Ok(Service {
-        name: name.to_string(),
-        namespace: TEST_SERVICE_NAMESPACE.to_string(),
-        hostname: hostname.to_string(),
+        name: name.into(),
+        namespace: TEST_SERVICE_NAMESPACE.into(),
+        hostname: hostname.into(),
         vips: vec![NetworkAddress {
-            network: "".to_string(),
+            network: "".into(),
             address: vip.parse()?,
         }],
         ports: HashMap::from([(80u16, echo_port)]),
         endpoints: HashMap::from([(
-            format!("cluster1//v1/Pod/default/{}", workload_name),
+            format!("cluster1//v1/Pod/default/{}", workload_name).into(),
             Endpoint {
-                workload_uid: format!("cluster1//v1/Pod/default/{}", workload_name),
+                workload_uid: format!("cluster1//v1/Pod/default/{}", workload_name).into(),
                 service: NamespacedHostname {
-                    namespace: TEST_SERVICE_NAMESPACE.to_string(),
-                    hostname: hostname.to_string(),
+                    namespace: TEST_SERVICE_NAMESPACE.into(),
+                    hostname: hostname.into(),
                 },
                 address: addr,
                 port: HashMap::from([(80u16, echo_port)]),
             },
         )]),
-        subject_alt_names: vec!["spiffe://cluster.local/ns/default/sa/default".to_string()],
+        subject_alt_names: vec!["spiffe://cluster.local/ns/default/sa/default".into()],
         waypoint: None,
         load_balancer: None,
     })
@@ -337,14 +337,14 @@ pub fn local_xds_config(
             workload: Workload {
                 workload_ips: vec![TEST_WORKLOAD_WAYPOINT.parse()?],
                 protocol: HBONE,
-                uid: "cluster1//v1/Pod/default/local-waypoint".to_string(),
-                name: "local-waypoint".to_string(),
-                namespace: "default".to_string(),
-                service_account: "default".to_string(),
-                node: "local".to_string(),
+                uid: "cluster1//v1/Pod/default/local-waypoint".into(),
+                name: "local-waypoint".into(),
+                namespace: "default".into(),
+                service_account: "default".into(),
+                node: "local".into(),
                 waypoint: Some(GatewayAddress {
                     destination: gatewayaddress::Destination::Address(NetworkAddress {
-                        network: "".to_string(),
+                        network: "".into(),
                         address: waypoint_ip,
                     }),
                     hbone_mtls_port: 15008,
@@ -401,31 +401,31 @@ pub fn new_proxy_state(
 
     for w in xds_workloads {
         let res = XdsResource {
-            name: w.name.clone(),
+            name: w.name.as_str().into(),
             resource: XdsAddress {
                 r#type: Some(address::Type::Workload(w.clone())),
             },
         };
         let handler = &updater as &dyn Handler<XdsAddress>;
-        handler.handle(vec![XdsUpdate::Update(res)]).unwrap();
+        handler.handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter())).unwrap();
     }
     for s in xds_services {
         let res = XdsResource {
-            name: s.name.clone(),
+            name: s.name.as_str().into(),
             resource: XdsAddress {
                 r#type: Some(address::Type::Service(s.clone())),
             },
         };
         let handler = &updater as &dyn Handler<XdsAddress>;
-        handler.handle(vec![XdsUpdate::Update(res)]).unwrap();
+        handler.handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter())).unwrap();
     }
     for a in xds_authorizations {
         let res = XdsResource {
-            name: a.name.clone(),
+            name: a.name.as_str().into(),
             resource: a.clone(),
         };
         let handler = &updater as &dyn Handler<XdsAuthorization>;
-        handler.handle(vec![XdsUpdate::Update(res)]).unwrap();
+        handler.handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter())).unwrap();
     }
     DemandProxyState::new(
         state,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -31,6 +31,7 @@ use anyhow::anyhow;
 use bytes::{BufMut, Bytes};
 use hickory_resolver::config::*;
 
+use crate::strng;
 use http_body_util::{BodyExt, Full};
 use hyper::Response;
 use std::collections::HashMap;
@@ -151,7 +152,7 @@ pub fn localhost_error_message() -> String {
 pub fn mock_default_service() -> Service {
     let vip1 = NetworkAddress {
         address: IpAddr::V4(Ipv4Addr::new(127, 0, 10, 1)),
-        network: "".to_string(),
+        network: strng::EMPTY,
     };
     let vips = vec![vip1];
     let mut ports = HashMap::new();
@@ -245,7 +246,7 @@ fn test_custom_svc(
     let addr = match endpoint.is_empty() {
         true => None,
         false => Some(NetworkAddress {
-            network: "".to_string(),
+            network: strng::EMPTY,
             address: endpoint.parse()?,
         }),
     };
@@ -254,7 +255,7 @@ fn test_custom_svc(
         namespace: TEST_SERVICE_NAMESPACE.into(),
         hostname: hostname.into(),
         vips: vec![NetworkAddress {
-            network: "".into(),
+            network: strng::EMPTY,
             address: vip.parse()?,
         }],
         ports: HashMap::from([(80u16, echo_port)]),

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -406,7 +406,8 @@ impl<'a> TestWorkloadBuilder<'a> {
         self.w.workload.uid = format!(
             "cluster1//v1/Pod/{}/{}",
             self.w.workload.namespace, self.w.workload.name,
-        ).into();
+        )
+        .into();
         let uid = self.w.workload.uid.clone();
 
         // update the endpoints for the service.

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -285,7 +285,7 @@ impl<'a> TestServiceBuilder<'a> {
     pub fn waypoint(mut self, waypoint: IpAddr) -> Self {
         self.s.waypoint = Some(GatewayAddress {
             destination: gatewayaddress::Destination::Address(NetworkAddress {
-                network: "".to_string(),
+                network: strng::EMPTY,
                 address: waypoint,
             }),
             hbone_mtls_port: 15008,
@@ -353,7 +353,7 @@ impl<'a> TestWorkloadBuilder<'a> {
     pub fn waypoint(mut self, waypoint: IpAddr) -> Self {
         self.w.workload.waypoint = Some(GatewayAddress {
             destination: gatewayaddress::Destination::Address(NetworkAddress {
-                network: "".to_string(),
+                network: strng::EMPTY,
                 address: waypoint,
             }),
             hbone_mtls_port: 15008,
@@ -416,7 +416,7 @@ impl<'a> TestWorkloadBuilder<'a> {
 
             for wip in self.w.workload.workload_ips.iter() {
                 let ep_network_addr = NetworkAddress {
-                    network: "".to_string(),
+                    network: strng::EMPTY,
                     address: *wip,
                 };
 

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -206,9 +206,9 @@ impl HboneTestServer {
     pub async fn run(self) {
         let certs = tls::mock::generate_test_certs(
             &identity::Identity::Spiffe {
-                trust_domain: "cluster.local".to_string(),
-                namespace: "default".to_string(),
-                service_account: self.name,
+                trust_domain: "cluster.local".into(),
+                namespace: "default".into(),
+                service_account: self.name.into(),
             }
             .into(),
             Duration::from_secs(0),

--- a/src/tls/workload.rs
+++ b/src/tls/workload.rs
@@ -30,11 +30,11 @@ use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use crate::strng::Strng;
 use crate::tls;
 use tokio::net::TcpStream;
 use tokio_rustls::client;
 use tracing::{debug, trace};
-use crate::strng::Strng;
 
 #[derive(Clone, Debug)]
 pub struct InboundAcceptor<F: ServerCertProvider> {

--- a/src/tls/workload.rs
+++ b/src/tls/workload.rs
@@ -34,6 +34,7 @@ use crate::tls;
 use tokio::net::TcpStream;
 use tokio_rustls::client;
 use tracing::{debug, trace};
+use crate::strng::Strng;
 
 #[derive(Clone, Debug)]
 pub struct InboundAcceptor<F: ServerCertProvider> {
@@ -49,11 +50,11 @@ impl<F: ServerCertProvider> InboundAcceptor<F> {
 #[derive(Debug)]
 pub(super) struct TrustDomainVerifier {
     base: Arc<dyn ClientCertVerifier>,
-    trust_domain: Option<String>,
+    trust_domain: Option<Strng>,
 }
 
 impl TrustDomainVerifier {
-    pub fn new(base: Arc<dyn ClientCertVerifier>, trust_domain: Option<String>) -> Arc<Self> {
+    pub fn new(base: Arc<dyn ClientCertVerifier>, trust_domain: Option<Strng>) -> Arc<Self> {
         Arc::new(Self { base, trust_domain })
     }
 

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -34,7 +34,7 @@ use xds::istio::workload::Workload as XdsWorkload;
 
 use crate::cert_fetcher::{CertFetcher, NoCertFetcher};
 use crate::config::ConfigSource;
-use crate::rbac;
+use crate::{rbac, strng};
 use crate::rbac::Authorization;
 use crate::state::service::{endpoint_uid, Endpoint, Service};
 use crate::state::workload::{network_addr, HealthStatus, NamespacedHostname, Workload};
@@ -158,7 +158,7 @@ impl ProxyStateUpdateMutator {
 
     fn remove_internal(&self, state: &mut ProxyState, xds_name: &String, for_insert: bool) {
         // remove workload by UID; if xds_name is a service then this will no-op
-        if let Some(prev) = state.workloads.remove(xds_name) {
+        if let Some(prev) = state.workloads.remove(&strng::new(xds_name)) {
             // Also remove service endpoints for the workload.
             for wip in prev.workload_ips.iter() {
                 let prev_addr = &network_addr(&prev.network, *wip);

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -34,13 +34,13 @@ use xds::istio::workload::Workload as XdsWorkload;
 
 use crate::cert_fetcher::{CertFetcher, NoCertFetcher};
 use crate::config::ConfigSource;
-use crate::{rbac, strng};
 use crate::rbac::Authorization;
 use crate::state::service::{endpoint_uid, Endpoint, Service, ServiceStore};
 use crate::state::workload::{network_addr, HealthStatus, NamespacedHostname, Workload};
 use crate::state::ProxyState;
-use crate::{tls, xds};
 use crate::strng::Strng;
+use crate::{rbac, strng};
+use crate::{tls, xds};
 
 use self::service::discovery::v3::DeltaDiscoveryRequest;
 
@@ -258,7 +258,10 @@ impl ProxyStateUpdateMutator {
 }
 
 impl Handler<XdsWorkload> for ProxyStateUpdater {
-    fn handle(&self, updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsWorkload>>>) -> Result<(), Vec<RejectedConfig>> {
+    fn handle(
+        &self,
+        updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsWorkload>>>,
+    ) -> Result<(), Vec<RejectedConfig>> {
         // use deepsize::DeepSizeOf;
         let mut state = self.state.write().unwrap();
         let handle = |res: XdsUpdate<XdsWorkload>| {
@@ -276,7 +279,10 @@ impl Handler<XdsWorkload> for ProxyStateUpdater {
 }
 
 impl Handler<XdsAddress> for ProxyStateUpdater {
-    fn handle(&self, updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsAddress>>>) -> Result<(), Vec<RejectedConfig>> {
+    fn handle(
+        &self,
+        updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsAddress>>>,
+    ) -> Result<(), Vec<RejectedConfig>> {
         let mut state = self.state.write().unwrap();
         let handle = |res: XdsUpdate<XdsAddress>| {
             match res {
@@ -295,7 +301,7 @@ impl Handler<XdsAddress> for ProxyStateUpdater {
 fn insert_service_endpoints(
     workload: &Workload,
     services: &HashMap<String, PortList>,
-    services_state: &mut ServiceStore
+    services_state: &mut ServiceStore,
 ) -> anyhow::Result<()> {
     for (namespaced_host, ports) in services {
         // Parse the namespaced hostname for the service.
@@ -337,7 +343,10 @@ impl Handler<XdsAuthorization> for ProxyStateUpdater {
         true
     }
 
-    fn handle(&self, updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsAuthorization>>>) -> Result<(), Vec<RejectedConfig>> {
+    fn handle(
+        &self,
+        updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsAuthorization>>>,
+    ) -> Result<(), Vec<RejectedConfig>> {
         let mut state = self.state.write().unwrap();
         let handle = |res: XdsUpdate<XdsAuthorization>| {
             match res {
@@ -349,7 +358,7 @@ impl Handler<XdsAuthorization> for ProxyStateUpdater {
             Ok(())
         };
         let mut len_updates = 0;
-        let updates = updates.inspect(|_| len_updates+=1);
+        let updates = updates.inspect(|_| len_updates += 1);
         match handle_single_resource(updates, handle) {
             Ok(()) => {
                 state.policies.send();

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -288,19 +288,7 @@ impl Handler<XdsAddress> for ProxyStateUpdater {
             }
             Ok(())
         };
-        let res = handle_single_resource(updates, handle);
-        error!("deep size of s.workloads.by_identity: {}", state.workloads.by_identity.len());
-        error!("deep size of s.workloads.by_addr: {}", state.workloads.by_addr.len());
-        error!("deep size of s.workloads.by_hostname: {}", state.workloads.by_hostname.len());
-        error!("deep size of s.workloads.by_uid: {}", state.workloads.by_uid.len());
-
-        error!("deep size of s.state.services.staged_services: {}", state.services.staged_services.len());
-        error!("deep size of s.state.services.workload_to_services: {}", state.services.workload_to_services.len());
-        error!("deep size of s.state.services.by_vip: {}", state.services.by_vip.len());
-        error!("deep size of s.state.services.by_host: {}", state.services.by_host.len());
-        let size = internment::deep_size_of_arc_interned::<str>();
-        error!("intern size: {size}");
-        res
+        handle_single_resource(updates, handle)
     }
 }
 

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -253,7 +253,7 @@ impl ProxyStateUpdateMutator {
 
     pub fn remove_authorization(&self, state: &mut ProxyState, name: String) {
         info!("handling RBAC delete {}", name);
-        state.policies.remove(name);
+        state.policies.remove(name.into());
     }
 }
 
@@ -300,8 +300,8 @@ fn service_endpoints(
         // Parse the namespaced hostname for the service.
         let namespaced_host = match namespaced_host.split_once('/') {
             Some((namespace, hostname)) => NamespacedHostname {
-                namespace: namespace.to_string(),
-                hostname: hostname.to_string(),
+                namespace: namespace.into(),
+                hostname: hostname.into(),
             },
             None => {
                 return Err(anyhow::anyhow!(

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -126,9 +126,10 @@ impl ProxyStateUpdateMutator {
         // Clone services, so we can pass full ownership of the rest of XdsWorkload to build our Workload
         // object, which doesn't include Services.
         // In theory, I think we could avoid this if Workload::try_from returning the services.
-        let services = w.services.clone();
+        // let services = w.services.clone();
         // Convert the workload.
-        let workload = Arc::new(Workload::try_from(w)?);
+        let (workload, services): (Workload, HashMap<String, PortList>) = w.try_into()?;
+        let workload = Arc::new(workload);
 
         // First, remove the entry entirely to make sure things are cleaned up properly.
         self.remove_for_insert(state, &workload.uid);

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -256,9 +256,9 @@ impl ProxyStateUpdateMutator {
         Ok(())
     }
 
-    pub fn remove_authorization(&self, state: &mut ProxyState, name: String) {
+    pub fn remove_authorization(&self, state: &mut ProxyState, name: Strng) {
         info!("handling RBAC delete {}", name);
-        state.policies.remove(name.into());
+        state.policies.remove(name);
     }
 }
 

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -259,6 +259,7 @@ impl ProxyStateUpdateMutator {
 
 impl Handler<XdsWorkload> for ProxyStateUpdater {
     fn handle(&self, updates: Vec<XdsUpdate<XdsWorkload>>) -> Result<(), Vec<RejectedConfig>> {
+        // use deepsize::DeepSizeOf;
         let mut state = self.state.write().unwrap();
         let handle = |res: XdsUpdate<XdsWorkload>| {
             match res {
@@ -287,7 +288,19 @@ impl Handler<XdsAddress> for ProxyStateUpdater {
             }
             Ok(())
         };
-        handle_single_resource(updates, handle)
+        let res = handle_single_resource(updates, handle);
+        error!("deep size of s.workloads.by_identity: {}", state.workloads.by_identity.len());
+        error!("deep size of s.workloads.by_addr: {}", state.workloads.by_addr.len());
+        error!("deep size of s.workloads.by_hostname: {}", state.workloads.by_hostname.len());
+        error!("deep size of s.workloads.by_uid: {}", state.workloads.by_uid.len());
+
+        error!("deep size of s.state.services.staged_services: {}", state.services.staged_services.len());
+        error!("deep size of s.state.services.workload_to_services: {}", state.services.workload_to_services.len());
+        error!("deep size of s.state.services.by_vip: {}", state.services.by_vip.len());
+        error!("deep size of s.state.services.by_host: {}", state.services.by_host.len());
+        let size = internment::deep_size_of_arc_interned::<str>();
+        error!("intern size: {size}");
+        res
     }
 }
 

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -161,7 +161,7 @@ impl ProxyStateUpdateMutator {
         if let Some(prev) = state.workloads.remove(&strng::new(xds_name)) {
             // Also remove service endpoints for the workload.
             for wip in prev.workload_ips.iter() {
-                let prev_addr = &network_addr(&prev.network, *wip);
+                let prev_addr = &network_addr(prev.network.clone(), *wip);
                 state
                     .services
                     .remove_endpoint(&prev.uid, &endpoint_uid(&prev.uid, Some(prev_addr)));
@@ -322,7 +322,7 @@ fn insert_service_endpoints(
             services_state.insert_endpoint(Endpoint {
                 workload_uid: workload.uid.clone(),
                 service: namespaced_host.clone(),
-                address: Some(network_addr(&workload.network, *wip)),
+                address: Some(network_addr(workload.network.clone(), *wip)),
                 port: ports.into(),
             })
         }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -245,7 +245,7 @@ impl ProxyStateUpdateMutator {
     ) -> anyhow::Result<()> {
         info!("handling RBAC update {}", r.name);
 
-        let rbac = rbac::Authorization::try_from(&r)?;
+        let rbac = rbac::Authorization::try_from(r)?;
         trace!("insert policy {}", serde_json::to_string(&rbac)?);
         state.policies.insert(rbac);
         Ok(())

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -619,6 +619,7 @@ impl AdsClient {
             tls_grpc_channel,
             self.config.auth.clone(),
         )
+        .max_decoding_message_size(200 * 1024 * 1024)
         .delta_aggregated_resources(tonic::Request::new(outbound))
         .await;
 

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -833,7 +833,7 @@ mod tests {
         // this is a borrow, Ok not to clone
         let mut matched = false;
         let ip_network_addr = NetworkAddress {
-            network: "".to_string(),
+            network: strng::EMPTY,
             address: ip,
         };
         while start_time.elapsed().unwrap() < TEST_TIMEOUT && !matched {
@@ -935,7 +935,7 @@ mod tests {
                     // make sure our cache is warm by using our resources
                     state.read()
                     .find_address(&NetworkAddress {
-                        network: "".to_string(),
+                        network: strng::EMPTY,
                         address: std::net::Ipv4Addr::new(1, 2, 3, 4).into(),
                     })
                     .expect("address not in cache");
@@ -1107,7 +1107,7 @@ mod tests {
                 state
                     .read()
                     .find_address(&NetworkAddress {
-                        network: "".to_string(),
+                        network: strng::EMPTY,
                         address: std::net::Ipv4Addr::new(1, 0, 0, 1).into(),
                     })
                     .expect("demander return but resource not in cache");

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -943,7 +943,7 @@ mod tests {
                         dst: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),
                         src_identity: None,
                         src: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 80),
-                        dst_network: "".to_string(),
+                        dst_network: "".into(),
                     };
                     let rbac_ctx = crate::state::ProxyRbacContext {
                         conn: conn.clone(),

--- a/src/xds/types.rs
+++ b/src/xds/types.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::strng;
+use crate::strng::Strng;
+
 // We don't control the codegen, so disable any code warnings in the
 // proto modules.
 #[allow(warnings)]
@@ -38,5 +41,5 @@ pub mod istio {
     }
 }
 
-pub const ADDRESS_TYPE: &str = "type.googleapis.com/istio.workload.Address";
-pub const AUTHORIZATION_TYPE: &str = "type.googleapis.com/istio.security.Authorization";
+pub const ADDRESS_TYPE: Strng = strng::literal!("type.googleapis.com/istio.workload.Address");
+pub const AUTHORIZATION_TYPE: Strng = strng::literal!("type.googleapis.com/istio.security.Authorization");

--- a/src/xds/types.rs
+++ b/src/xds/types.rs
@@ -42,4 +42,5 @@ pub mod istio {
 }
 
 pub const ADDRESS_TYPE: Strng = strng::literal!("type.googleapis.com/istio.workload.Address");
-pub const AUTHORIZATION_TYPE: Strng = strng::literal!("type.googleapis.com/istio.security.Authorization");
+pub const AUTHORIZATION_TYPE: Strng =
+    strng::literal!("type.googleapis.com/istio.security.Authorization");

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -453,13 +453,13 @@ mod namespaced {
         let zt = manager.deploy_ztunnel(DEFAULT_NODE).await?;
         manager
             .add_policy(Authorization {
-                name: "deny_bypass".to_string(),
-                namespace: "default".to_string(),
+                name: "deny_bypass".into(),
+                namespace: "default".into(),
                 scope: ztunnel::rbac::RbacScope::Namespace,
                 action: ztunnel::rbac::RbacAction::Allow,
                 rules: vec![vec![vec![RbacMatch {
                     principals: vec![StringMatch::Exact(
-                        "spiffe://cluster.local/ns/default/sa/waypoint".to_string(),
+                        "spiffe://cluster.local/ns/default/sa/waypoint".into(),
                     )],
                     ..Default::default()
                 }]]],

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -671,9 +671,9 @@ mod namespaced {
     async fn trust_domain_mismatch_rejected() -> anyhow::Result<()> {
         let mut manager = setup_netns_test!(InPod);
         let id = identity::Identity::Spiffe {
-            trust_domain: "clusterset.local".to_string(), // change to mismatched trustdomain
-            service_account: "my-app".to_string(),
-            namespace: "default".to_string(),
+            trust_domain: "clusterset.local".into(), // change to mismatched trustdomain
+            service_account: "my-app".into(),
+            namespace: "default".into(),
         };
 
         let _ = manager.deploy_ztunnel(DEFAULT_NODE).await?;

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -43,7 +43,7 @@ mod namespaced {
     use ztunnel::test_helpers::app::ParsedMetrics;
     use ztunnel::test_helpers::app::TestApp;
     use ztunnel::test_helpers::helpers::initialize_telemetry;
-    use ztunnel::{identity, telemetry};
+    use ztunnel::{identity, strng, telemetry};
 
     use crate::namespaced::WorkloadMode::Captured;
     use ztunnel::test_helpers::linux::TestMode::{InPod, SharedNode};
@@ -222,7 +222,7 @@ mod namespaced {
         manager
             .service_builder("service")
             .addresses(vec![NetworkAddress {
-                network: "".to_string(),
+                network: strng::EMPTY,
                 address: TEST_VIP.parse::<IpAddr>()?,
             }])
             .ports(HashMap::from([(80u16, 80u16)]))
@@ -311,7 +311,7 @@ mod namespaced {
         manager
             .service_builder("service")
             .addresses(vec![NetworkAddress {
-                network: "".to_string(),
+                network: strng::EMPTY,
                 address: TEST_VIP.parse::<IpAddr>()?,
             }])
             .ports(HashMap::from([(80u16, 80u16)]))


### PR DESCRIPTION
Fixes https://github.com/istio/ztunnel/issues/988

This PR introduces a new string representation. See issue above for some more background.

I initially implemented this using `internment::ArcIntern<str>`. This showed improvements over master, but I compared to using ArcStr and found actually better memory utilization with ArcStr, and much less complexity and risk. Conveniently, due to the `strng` module abstracting things, the swap was pretty much trivial (just a few small changes due to different conversion helpers in the libraries). So if we do want to switch things in the future, it shouldn't be too bad.


This optimizes the XDS path (and, presumably, others -- but I only measured XDS much).

My test covered 30k pods with 2k services. I loaded this up and checked memory usage (total and peak).

Before: 1.8GB total, 700mb retained
After: 1.1GB total, 520mb retained

Roughly 100mb of improvement came from switching the string representation, and 80mb came from other optimizations. Not confident in that breakdown as I was going back and forth moving things over + optimizing. 

All optimizations here are guided by profiling. End profile (github
![2024-05-03_13-31-45](https://github.com/istio/ztunnel/assets/623453/af1c6628-486a-4c77-9442-ad7065e81a0d)

Not much low hanging fruit left, most of the memory is in our hashmaps.

Optimizations aside from string changes:
* Optimizing string concat in hotpaths
* Avoid buffering up a vector of all XDS updates; stream it
* Avoid buffering up a copy of all endpoints; just iterate it
* Avoid a clone on the XDS workload
