### PR TITLE
misc: remove Default identity from prod codepath

### DIFF
--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -46,23 +46,6 @@ pub enum Identity {
     },
 }
 
-// struct PrioritizedFetch {
-//     identity: Identity,
-//     priority: Priority
-// }
-//
-// impl Ord for PrioritizedFetch {
-//     fn cmp(&self, other: &Self) -> Ordering {
-//         self.cmp(other)
-//     }
-// }
-//
-// impl PartialOrd for PrioritizedFetch {
-//     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-//         Some(self.cmp(other))
-//     }
-// }
-
 impl EncodeLabelValue for Identity {
     fn encode(&self, writer: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
         writer.write_str(&self.to_string())
@@ -117,8 +100,7 @@ impl fmt::Display for Identity {
     }
 }
 
-// TODO we shouldn't have a "default identity" outside of tests
-// #[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 impl Default for Identity {
     fn default() -> Self {
         const TRUST_DOMAIN: &str = "cluster.local";

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -98,7 +98,7 @@ where
     }
 }
 
-#[derive(Default, Hash, PartialEq, Eq, Clone, Debug)]
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
 // DefaultedUnknown is a wrapper around an Option that encodes as "unknown" when missing, rather than ""
 pub struct DefaultedUnknown<T>(Option<T>);
 
@@ -108,6 +108,12 @@ impl<T> DefaultedUnknown<T> {
     }
     pub fn as_ref(&self) -> Option<&T> {
         self.0.as_ref()
+    }
+}
+
+impl<T> Default for DefaultedUnknown<T> {
+    fn default() -> Self {
+        Self(None)
     }
 }
 


### PR DESCRIPTION
We didn't use it anywhere which is good -- but it was a risk
