### PR TITLE
Fix cleaning up identities

### DIFF
--- a/src/cert_fetcher.rs
+++ b/src/cert_fetcher.rs
@@ -25,6 +25,7 @@ use tracing::{debug, error, info};
 pub trait CertFetcher: Send + Sync {
     fn prefetch_cert(&self, w: &Workload);
     fn clear_cert(&self, id: &Identity);
+    fn should_track_certificates_for_removal(&self, w: &Workload) -> bool;
 }
 
 /// A no-op implementation of [CertFetcher].
@@ -33,6 +34,9 @@ pub struct NoCertFetcher();
 impl CertFetcher for NoCertFetcher {
     fn prefetch_cert(&self, _: &Workload) {}
     fn clear_cert(&self, _: &Identity) {}
+    fn should_track_certificates_for_removal(&self, _w: &Workload) -> bool {
+        false
+    }
 }
 
 /// Constructs an appropriate [CertFetcher] for the proxy config.
@@ -113,5 +117,12 @@ impl CertFetcher for CertFetcherImpl {
         if let Err(e) = self.tx.try_send(Request::Forget(id.clone())) {
             info!("couldn't clear identity: {:?}", e)
         }
+    }
+
+    fn should_track_certificates_for_removal(&self, w: &Workload) -> bool {
+        // Only shared mode fetches other workloads's certs
+        self.proxy_mode == ProxyMode::Shared &&
+            // We only get certs for our own node
+            Some(w.node.as_str()) == self.local_node.as_deref()
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -620,7 +620,7 @@ mod tests {
         let w = mock_default_gateway_workload();
         let s = mock_default_gateway_service();
         let mut state = state::ProxyState::default();
-        state.workloads.insert(Arc::new(w));
+        state.workloads.insert(Arc::new(w), true);
         state.services.insert(s);
         let state = state::DemandProxyState::new(
             Arc::new(RwLock::new(state)),

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -768,7 +768,7 @@ mod tests {
             state.services.insert(svc);
         }
         for wl in workloads {
-            state.workloads.insert(Arc::new(wl));
+            state.workloads.insert(Arc::new(wl), true);
         }
 
         Ok(DemandProxyState::new(

--- a/src/state.rs
+++ b/src/state.rs
@@ -876,7 +876,7 @@ mod tests {
         let mut state = ProxyState::default();
         state
             .workloads
-            .insert(Arc::new(test_helpers::test_default_workload()));
+            .insert(Arc::new(test_helpers::test_default_workload()), true);
         state.services.insert(test_helpers::mock_default_service());
 
         let mock_proxy_state = DemandProxyState::new(
@@ -950,7 +950,7 @@ mod tests {
             workload_ips: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2))],
             ..test_helpers::test_default_workload()
         };
-        state.workloads.insert(Arc::new(wl));
+        state.workloads.insert(Arc::new(wl), true);
 
         let mock_proxy_state = DemandProxyState::new(
             Arc::new(RwLock::new(state)),
@@ -1153,9 +1153,11 @@ mod tests {
             }),
             ..test_helpers::mock_default_service()
         };
-        state.workloads.insert(Arc::new(wl_no_locality.clone()));
-        state.workloads.insert(Arc::new(wl_match.clone()));
-        state.workloads.insert(Arc::new(wl_almost.clone()));
+        state
+            .workloads
+            .insert(Arc::new(wl_no_locality.clone()), true);
+        state.workloads.insert(Arc::new(wl_match.clone()), true);
+        state.workloads.insert(Arc::new(wl_almost.clone()), true);
         state.services.insert(strict_svc.clone());
         state.services.insert(failover_svc.clone());
 

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -597,12 +597,12 @@ pub struct WorkloadStore {
     by_uid: HashMap<Strng, Arc<Workload>>,
     /// byHostname maps workload hostname to workloads.
     by_hostname: HashMap<Strng, Arc<Workload>>,
-    // Identity->Set of UIDs
+    // Identity->Set of UIDs. Only stores local nodes
     by_identity: HashMap<Identity, HashSet<Strng>>,
 }
 
 impl WorkloadStore {
-    pub fn insert(&mut self, w: Arc<Workload>) {
+    pub fn insert(&mut self, w: Arc<Workload>, track_identity: bool) {
         // First, remove the entry entirely to make sure things are cleaned up properly.
         self.remove(&w.uid);
 
@@ -614,6 +614,13 @@ impl WorkloadStore {
             self.by_hostname.insert(w.hostname.clone(), w.clone());
         }
         self.by_uid.insert(w.uid.clone(), w.clone());
+        // Only track local nodes to avoid overhead
+        if track_identity {
+            self.by_identity
+                .entry(w.identity())
+                .or_default()
+                .insert(w.uid.clone());
+        }
     }
 
     pub fn remove(&mut self, uid: &Strng) -> Option<Workload> {

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -199,6 +199,12 @@ impl WorkloadManager {
         Ok(())
     }
 
+    pub async fn delete_workload(&mut self, name: &str) -> anyhow::Result<()> {
+        self.workloads.retain(|w| w.workload.name != name);
+        self.refresh_config().await?;
+        Ok(())
+    }
+
     /// workload_builder allows creating a new workload. It will run in its own network namespace.
     pub fn workload_builder(&mut self, name: &str, node: &str) -> TestWorkloadBuilder {
         TestWorkloadBuilder::new(name, self)


### PR DESCRIPTION
This fixes a bug where identities were being dropped wrongly. Basically we didnt track the identity properly, so ANY pod removal caused all ztunnels to forget that identity. This wasnt detected because ztunnel will on-demand fetch certificates its missing.