### PR TITLE
logging: ignore duplicate fields from direct `log` usage

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -164,6 +164,8 @@ impl field::Visit for Visitor<'_> {
 
     fn record_debug(&mut self, field: &field::Field, val: &dyn std::fmt::Debug) {
         self.res = match field.name() {
+            // Skip fields that are actually log metadata that have already been handled
+            name if name.starts_with("log.") => Ok(()),
             // For the message, write out the message and a tab to separate the future fields
             "message" => write!(self.writer, "{:?}\t", val),
             // For the rest, k=v.


### PR DESCRIPTION
This is copied from `tracing` directly

Otherwise we get stuff like `pprof::profiler stopping cpu profiler   log.target="pprof::profiler" log.module_path="pprof::profiler" log.file="/home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pprof-0.13.0/src/profiler.rs" log.line=439`