### PR TITLE
send HBONE address in PROXY

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -159,6 +159,7 @@ fn initialize_environment(
             Mode::Write => Mode::Read,
             Mode::Read => Mode::Write,
             Mode::Forward(_) => todo!("not implemented for benchmark"),
+            Mode::ForwardProxyProtocol => todo!("not implemented for benchmark"),
         };
         // warmup: send 1 byte so we ensure we have the full connection setup.
         tcp::run_client(&mut hbone, 1, client_mode).await.unwrap();

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -25,7 +25,7 @@ use rand::Rng;
 
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::time::timeout;
-use tracing::{error, trace, warn, Instrument};
+use tracing::{debug, trace, warn, Instrument};
 
 use inbound::Inbound;
 pub use metrics::*;
@@ -334,11 +334,12 @@ pub async fn write_proxy_protocol<T>(
     src_id: Option<Identity>,
 ) -> io::Result<()>
 where
-    T: Into<ppp::v2::Addresses>,
+    T: Into<ppp::v2::Addresses> + std::fmt::Debug,
 {
     use ppp::v2::{Builder, Command, Protocol, Version};
     use tokio::io::AsyncWriteExt;
 
+    debug!("writing proxy protocol addresses: {:?}", addresses);
     let mut builder =
         Builder::with_addresses(Version::Two | Command::Proxy, Protocol::Stream, addresses);
 

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proxy::{error, Error};
+use crate::proxy::Error;
 
 use crate::state::DemandProxyState;
 use crate::state::ProxyRbacContext;
@@ -26,7 +26,7 @@ use std::net::SocketAddr;
 
 use std::sync::Arc;
 use std::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 struct ConnectionDrain {
     // TODO: this should almost certainly be changed to a type which has counted references exposed.

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -341,7 +341,7 @@ impl Inbound {
         let request_type = match inbound_protocol {
             AppProtocol::PROXY => Proxy(
                 req,
-                (rbac_ctx.conn.src, rbac_ctx.conn.dst),
+                (rbac_ctx.conn.src, hbone_addr),
                 rbac_ctx.conn.src_identity.clone(),
             ),
             _ => Hbone(req),


### PR DESCRIPTION
Not sure how this was working in https://gist.github.com/stevenctl/ec2ddae79734f8f9367400961ca9c48f and other tests. This change is tested e2e with envoy that actually has filter chain matches on IPs. 

Cherry-pick to 1.22 would be nice, but I understand it might be a bit late. 