### PR TITLE
combine `proxymode = shared` and `inpod_mode = true`

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -54,7 +54,7 @@ INPOD_UDS=/tmp/ztunnel cargo run --example inpodserver -- pod1
 run ztunnel (as root) with:
 
 ```shell
-RUST_LOG=debug INPOD_ENABLED=true INPOD_UDS=/tmp/ztunnel FAKE_CA="true" XDS_ADDRESS="" LOCAL_XDS_PATH=./examples/localhost.yaml cargo run --features testing
+RUST_LOG=debug PROXY_MODE=shared INPOD_UDS=/tmp/ztunnel FAKE_CA="true" XDS_ADDRESS="" LOCAL_XDS_PATH=./examples/localhost.yaml cargo run --features testing
 ```
 
 (note: to run ztunnel as root, consider using `export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="sudo -E"` so cargo `sudo` the binary)
@@ -162,7 +162,7 @@ xargs env <<EOF
 INPOD_UDS=/tmp/worker1-ztunnel/ztunnel.sock
 CLUSTER_ID=Kubernetes
 RUST_LOG=debug
-INPOD_ENABLED="true"
+PROXY_MODE="shared"
 ISTIO_META_DNS_CAPTURE="true"
 ISTIO_META_DNS_PROXY_ADDR="127.0.0.1:15053"
 SERVICE_ACCOUNT=ztunnel

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -136,7 +136,7 @@ fn initialize_environment(
     SyncSender<usize>,
     Receiver<Result<(), io::Error>>,
 )> {
-    let mut manager = setup_netns_test!(TestMode::InPod);
+    let mut manager = setup_netns_test!(TestMode::Shared);
     let (server, mut manager) = run_async_blocking(async move {
         if ztunnel_mode != WorkloadMode::Direct {
             // we need a client ztunnel

--- a/src/app.rs
+++ b/src/app.rs
@@ -134,8 +134,8 @@ pub async fn build_with_cert(
     )
     .map_err(|e| anyhow::anyhow!("failed to start proxy factory {:?}", e))?;
 
-    if config.inpod_enabled {
-        tracing::info!("in-pod mode enabled");
+    if config.proxy_mode == config::ProxyMode::Shared {
+        tracing::info!("shared proxy mode - in-pod mode enabled");
         let run_future = init_inpod_proxy_mgr(
             &mut registry,
             &mut admin_server,

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,6 @@ const KUBERNETES_SERVICE_HOST: &str = "KUBERNETES_SERVICE_HOST";
 const NETWORK: &str = "NETWORK";
 const NODE_NAME: &str = "NODE_NAME";
 const PROXY_MODE: &str = "PROXY_MODE";
-const INPOD_ENABLED: &str = "INPOD_ENABLED";
 const INPOD_MARK: &str = "INPOD_MARK";
 const INPOD_UDS: &str = "INPOD_UDS";
 const INPOD_PORT_REUSE: &str = "INPOD_PORT_REUSE";
@@ -224,7 +223,6 @@ pub struct Config {
     // System dns resolver opts used for on-demand ztunnel dns resolution
     pub dns_resolver_opts: ResolverOpts,
 
-    pub inpod_enabled: bool,
     pub inpod_uds: PathBuf,
     pub inpod_port_reuse: bool,
     pub inpod_mark: u32,
@@ -490,7 +488,6 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         proxy_args: parse_args(),
         dns_resolver_cfg,
         dns_resolver_opts,
-        inpod_enabled: parse_default(INPOD_ENABLED, false)?,
         inpod_uds: parse_default(INPOD_UDS, PathBuf::from("/var/run/ztunnel/ztunnel.sock"))?,
         inpod_port_reuse: parse_default(INPOD_PORT_REUSE, true)?,
         inpod_mark: parse_default(INPOD_MARK, DEFAULT_INPOD_MARK)?,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -40,9 +40,9 @@ use crate::state::workload::address::Address;
 use crate::state::workload::application_tunnel::Protocol as AppProtocol;
 use crate::{assertions, copy, proxy, socket, strng, tls};
 
+use crate::config::ProxyMode;
 use crate::drain::run_with_drain;
 use crate::proxy::h2;
-use crate::config::ProxyMode;
 use crate::state::workload::{self, NetworkAddress, Workload};
 use crate::state::DemandProxyState;
 use crate::strng::Strng;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -42,6 +42,7 @@ use crate::{assertions, copy, proxy, socket, strng, tls};
 
 use crate::drain::run_with_drain;
 use crate::proxy::h2;
+use crate::config::ProxyMode;
 use crate::state::workload::{self, NetworkAddress, Workload};
 use crate::state::DemandProxyState;
 use crate::strng::Strng;
@@ -187,7 +188,7 @@ impl Inbound {
                     return req.send_error(build_response(StatusCode::BAD_REQUEST));
                 }
             };
-        let illegal_call = if pi.cfg.inpod_enabled {
+        let illegal_call = if pi.cfg.proxy_mode == ProxyMode::Shared {
             // User sent a request to pod:15006. This would forward to pod:15006 infinitely
             // Use hbone_addr instead of upstream_addr to allow for sandwich mode, which intentionally
             // sends to 15008.

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -131,7 +131,8 @@ impl InboundPassthrough {
             // User sent a request to pod:15006. This would forward to pod:15006 infinitely
             // OR
             // User sent a request to the ztunnel directly. This isn't allowed
-            pi.cfg.illegal_ports.contains(&dest_addr.port()) || Some(dest_addr.ip()) == pi.cfg.local_ip
+            pi.cfg.illegal_ports.contains(&dest_addr.port())
+                || Some(dest_addr.ip()) == pi.cfg.local_ip
         } else {
             false
         };

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -127,12 +127,12 @@ impl InboundPassthrough {
         let dest_addr = socket::orig_dst_addr_or_default(&inbound_stream);
         // Check if it is an illegal call to ourself, which could trampoline to illegal addresses or
         // lead to infinite loops
-        let illegal_call = if pi.cfg.inpod_enabled {
+        let illegal_call = if pi.cfg.proxy_mode == ProxyMode::Shared {
             // User sent a request to pod:15006. This would forward to pod:15006 infinitely
             pi.cfg.illegal_ports.contains(&dest_addr.port())
         } else {
             // User sent a request to the ztunnel directly. This isn't allowed
-            pi.cfg.proxy_mode == ProxyMode::Shared && Some(dest_addr.ip()) == pi.cfg.local_ip
+            Some(dest_addr.ip()) == pi.cfg.local_ip
         };
         if illegal_call {
             metrics::log_early_deny(

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -129,10 +129,11 @@ impl InboundPassthrough {
         // lead to infinite loops
         let illegal_call = if pi.cfg.proxy_mode == ProxyMode::Shared {
             // User sent a request to pod:15006. This would forward to pod:15006 infinitely
-            pi.cfg.illegal_ports.contains(&dest_addr.port())
-        } else {
+            // OR
             // User sent a request to the ztunnel directly. This isn't allowed
-            Some(dest_addr.ip()) == pi.cfg.local_ip
+            pi.cfg.illegal_ports.contains(&dest_addr.port()) || Some(dest_addr.ip()) == pi.cfg.local_ip
+        } else {
+            false
         };
         if illegal_call {
             metrics::log_early_deny(

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -165,7 +165,8 @@ impl OutboundConnection {
 
         // Block calls to ztunnel directly, unless we are in "in-pod".
         // For in-pod, this isn't an issue and is useful: this allows things like prometheus scraping ztunnel.
-        if self.pi.cfg.proxy_mode == ProxyMode::Shared
+        // TODO is this actually wrong for ProxyMode::Dedicated? Seems like a valid case
+        if self.pi.cfg.proxy_mode != ProxyMode::Shared
             && Some(dest_addr.ip()) == self.pi.cfg.local_ip
         {
             metrics::log_early_deny(source_addr, dest_addr, Reporter::source, Error::SelfCall);

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -60,13 +60,13 @@ impl Socks5 {
             "listener established",
         );
 
-        let inpod = pi.cfg.inpod_enabled;
+        let mode = pi.cfg.proxy_mode;
         Ok(Socks5 {
             pi,
             listener,
             drain,
             // Do not need to spoof with inpod mode for outbound
-            enable_orig_src: transparent && !inpod,
+            enable_orig_src: transparent && mode != config::ProxyMode::Shared,
         })
     }
 

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -31,6 +31,7 @@ use tokio::net::TcpStream;
 use tokio::sync::watch;
 use tracing::{debug, error, info, info_span, Instrument};
 
+use crate::config;
 use crate::drain::run_with_drain;
 use crate::drain::DrainWatcher;
 use crate::proxy::outbound::OutboundConnection;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -122,6 +122,7 @@ pub fn test_config_with_port_xds_addr_and_root_cert(
         outbound_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         dns_proxy_addr: config::Address::Localhost(false, 0),
+        proxy_mode: config::ProxyMode::Dedicated,
         illegal_ports: HashSet::new(), // for "direct" tests, since the ports are latebound, we can't test illegal ports
         fake_self_inbound: true, // for "direct" tests, since the ports are latebound, we have to do this. Yes, this is test concerns leaking into prod code
         ..config::parse_config().unwrap()

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -149,7 +149,7 @@ impl WorkloadManager {
         let cloned_ns = ns.clone();
         ns.run_ready(move |ready| async move {
             if proxy_mode != ProxyMode::Shared {
-                // not needed in inpod mode. In in pod mode we run `ztunnel-redirect-inpod.sh`
+                // not needed in "inpod" (shared proxy) mode. In shared mode we run `ztunnel-redirect-inpod.sh`
                 // inside the pod's netns
                 helpers::run_command(&format!("scripts/ztunnel-redirect.sh {ip}"))?;
             }

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -483,7 +483,7 @@ mod namespaced {
 
     #[tokio::test]
     async fn test_ztunnel_shutdown() -> anyhow::Result<()> {
-        let mut manager = setup_netns_test!(InPod);
+        let mut manager = setup_netns_test!(Shared);
         let local = manager.deploy_ztunnel(DEFAULT_NODE).await?;
         let server = manager
             .workload_builder("server", DEFAULT_NODE)
@@ -529,7 +529,7 @@ mod namespaced {
 
     #[tokio::test]
     async fn test_server_shutdown() -> anyhow::Result<()> {
-        let mut manager = setup_netns_test!(InPod);
+        let mut manager = setup_netns_test!(Shared);
         manager.deploy_ztunnel(DEFAULT_NODE).await?;
         let server = manager
             .workload_builder("server", DEFAULT_NODE)


### PR DESCRIPTION
We currently have `ProxyMode::Dedicated | Shared` and `InpodEnabled: true|false` and I can't think of any scenarios where those are not basically indicating the same thing.

We also sort of don't use `ProxyMode` at all, and I think we should - the tenancy model is more important to express than how we do the tenancy model (currently we have only one multitenant model anyway, so why make it optional?).