### PR TITLE
adopt linting rules for rustc 1.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,3 +146,7 @@ ctor = "0.2"
 [patch.crates-io]
 # TODO h2 0.4.5 (https://github.com/istio/ztunnel/issues/1000)
 h2 = { git = "https://github.com/hyperium/h2", rev = "be129832df989bf28940da3618827e190ae64ef2" }
+
+[lints.clippy]
+# This rule makes code more confusing
+assigning_clones = "allow"

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -669,7 +669,7 @@ impl WorkloadStore {
     }
 
     pub fn has_identity(&self, identity: &Identity) -> bool {
-        self.by_identity.get(identity).is_some()
+        self.by_identity.contains_key(identity)
     }
 }
 


### PR DESCRIPTION
Well, turn one off.. I think its a bad rule and upstream may revert it
