### PR TITLE
Cleanup `illegal_ports` and ARC all of PI

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -154,7 +154,9 @@ pub struct Config {
     pub outbound_addr: SocketAddr,
     /// The socket address for the DNS proxy. Only applies if `dns_proxy` is true.
     pub dns_proxy_addr: SocketAddr,
-
+    /// Populated with the internal ports of all the proxy handlers defined above.
+    /// illegal_ports are internal ports that clients are not authorized to send to
+    pub illegal_ports: HashSet<u16>,
     /// The network of the node this ztunnel is running on.
     pub network: Strng,
     /// The name of the node this ztunnel is running as.
@@ -334,6 +336,22 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         None
     };
 
+    let inbound_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15008);
+    let inbound_plaintext_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15006);
+    let outbound_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15001);
+
+    let mut illegal_ports = HashSet::from([
+        // HBONE doesn't have redirection, so we cannot have loops, but this would allow multiple layers of HBONE.
+        // This might be desirable in the future, but for now just ban it.
+        inbound_addr.port(),
+        inbound_plaintext_addr.port(),
+        outbound_addr.port(),
+    ]);
+
+    if let Some(addr) = socks5_addr {
+        illegal_ports.insert(addr.port());
+    }
+
     validate_config(Config {
         proxy: parse_default(ENABLE_PROXY, true)?,
         dns_proxy: pc
@@ -373,10 +391,12 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         ),
 
         socks5_addr,
-        inbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15008),
-        inbound_plaintext_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15006),
-        outbound_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 15001),
+        inbound_addr,
+        inbound_plaintext_addr,
+        outbound_addr,
         dns_proxy_addr,
+
+        illegal_ports,
 
         network: parse(NETWORK)?.unwrap_or_default(),
         local_node: parse(NODE_NAME)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,6 +189,9 @@ pub struct Config {
 
     /// If true, then use builtin fake CA with self-signed certificates.
     pub fake_ca: bool,
+    // If true, then force config to use the linux-assigned listener address:port instead
+    // of the well-known config addr:port socketaddress. Used by `direct` tests.
+    pub fake_self_inbound: bool,
     #[serde(skip_serializing)]
     pub auth: identity::AuthSource,
     // How long ztunnel should wait for in-flight requesthandlers to finish processing
@@ -440,6 +443,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         inpod_uds: parse_default(INPOD_UDS, PathBuf::from("/var/run/ztunnel/ztunnel.sock"))?,
         inpod_port_reuse: parse_default(INPOD_PORT_REUSE, true)?,
         inpod_mark: parse_default(INPOD_MARK, DEFAULT_INPOD_MARK)?,
+        fake_self_inbound: false,
     })
 }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -188,31 +188,9 @@ impl Proxy {
             tokio::spawn(self.inbound.run().in_current_span()),
             tokio::spawn(self.outbound.run().in_current_span()),
         ];
-
-        // // TODO hbone_port is ALWAYS (by necessity) fixed in read-only config -
-        // // except in (some) contrived integ test cases (direct), where we bind to random non-well-known ports,
-        // // and cannot rely on a well-known port - which is why this exists, so we can ignore
-        // // the config object and sidechannel the non-fixed runtime-bound port.
-        // #[cfg(any(test, feature = "testing"))]
-        // {
-        //     let hbone_port = self.inbound.address().port();
-        //     tasks.push(tokio::spawn(
-        //         self.outbound.run(hbone_port).in_current_span(),
-        //     ));
-        //     tasks.push(tokio::spawn(self.inbound.run().in_current_span()));
-        //     if let Some(socks5) = self.socks5 {
-        //         tasks.push(tokio::spawn(socks5.run(hbone_port).in_current_span()));
-        //     };
-        // }
-
-        // #[cfg(not(any(test, feature = "testing")))]
-        // {
-            // tasks.push(tokio::spawn(self.inbound.run().in_current_span()));
-            // tasks.push(tokio::spawn(self.outbound.run().in_current_span()));
-            if let Some(socks5) = self.socks5 {
-                tasks.push(tokio::spawn(socks5.run().in_current_span()));
-            };
-        // }
+        if let Some(socks5) = self.socks5 {
+            tasks.push(tokio::spawn(socks5.run().in_current_span()));
+        };
 
         futures::future::join_all(tasks).await;
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
 use std::fmt::Debug;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -101,7 +100,6 @@ pub struct Proxy {
     outbound: Outbound,
     socks5: Option<Socks5>,
     policy_watcher: PolicyWatcher,
-    illegal_ports: Arc<HashSet<u16>>,
 }
 
 #[derive(Clone)]
@@ -109,7 +107,6 @@ pub(super) struct ProxyInputs {
     cfg: Arc<config::Config>,
     cert_manager: Arc<SecretManager>,
     connection_manager: ConnectionManager,
-    hbone_port: u16,
     pub state: DemandProxyState,
     metrics: Arc<Metrics>,
     socket_factory: Arc<dyn SocketFactory + Send + Sync>,
@@ -126,17 +123,16 @@ impl ProxyInputs {
         metrics: Arc<Metrics>,
         socket_factory: Arc<dyn SocketFactory + Send + Sync>,
         proxy_workload_info: Option<WorkloadInfo>,
-    ) -> Self {
-        Self {
+    ) -> Arc<Self> {
+        Arc::new(Self {
             cfg,
             state,
             cert_manager,
             metrics,
             connection_manager,
-            hbone_port: 0,
             socket_factory,
             proxy_workload_info: proxy_workload_info.map(Arc::new),
-        }
+        })
     }
 }
 
@@ -151,40 +147,30 @@ impl Proxy {
         let metrics = Arc::new(metrics);
         let socket_factory = Arc::new(DefaultSocketFactory);
 
-        let pi = ProxyInputs {
+        let pi = ProxyInputs::new(
             cfg,
-            state,
             cert_manager,
-            connection_manager: ConnectionManager::default(),
+            ConnectionManager::default(),
+            state,
             metrics,
-            hbone_port: 0,
             socket_factory,
-            proxy_workload_info: None,
-        };
+            None,
+        );
         Self::from_inputs(pi, drain).await
     }
-    pub(super) async fn from_inputs(mut pi: ProxyInputs, drain: Watch) -> Result<Self, Error> {
-        // illegal_ports are internal ports that clients are not authorized to send to
-        let mut illegal_ports: HashSet<u16> = HashSet::new();
+    pub(super) async fn from_inputs(pi: Arc<ProxyInputs>, drain: Watch) -> Result<Self, Error> {
         // We setup all the listeners first so we can capture any errors that should block startup
         let inbound = Inbound::new(pi.clone(), drain.clone()).await?;
-        pi.hbone_port = inbound.address().port();
-        //  HBONE doesn't have redirection, so we cannot have loops, but this would allow multiple layers of HBONE.
-        // This might be desirable in the future, but for now just ban it.
-        illegal_ports.insert(inbound.address().port());
-
         let inbound_passthrough = InboundPassthrough::new(pi.clone(), drain.clone()).await?;
-        illegal_ports.insert(inbound_passthrough.address().port());
         let outbound = Outbound::new(pi.clone(), drain.clone()).await?;
-        illegal_ports.insert(outbound.address().port());
         let socks5 = if pi.cfg.socks5_addr.is_some() {
             let socks5 = Socks5::new(pi.clone(), drain.clone()).await?;
-            illegal_ports.insert(socks5.address().port());
             Some(socks5)
         } else {
             None
         };
-        let policy_watcher = PolicyWatcher::new(pi.state, drain, pi.connection_manager);
+        let policy_watcher =
+            PolicyWatcher::new(pi.state.clone(), drain, pi.connection_manager.clone());
 
         Ok(Proxy {
             inbound,
@@ -192,22 +178,13 @@ impl Proxy {
             outbound,
             socks5,
             policy_watcher,
-            illegal_ports: Arc::new(illegal_ports),
         })
     }
 
     pub async fn run(self) {
         let mut tasks = vec![
-            tokio::spawn(
-                self.inbound_passthrough
-                    .run(self.illegal_ports.clone())
-                    .in_current_span(),
-            ),
-            tokio::spawn(
-                self.inbound
-                    .run(self.illegal_ports.clone())
-                    .in_current_span(),
-            ),
+            tokio::spawn(self.inbound_passthrough.run().in_current_span()),
+            tokio::spawn(self.inbound.run().in_current_span()),
             tokio::spawn(self.outbound.run().in_current_span()),
             tokio::spawn(self.policy_watcher.run().in_current_span()),
         ];

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -184,12 +184,30 @@ impl Proxy {
     pub async fn run(self) {
         let mut tasks = vec![
             tokio::spawn(self.inbound_passthrough.run().in_current_span()),
-            tokio::spawn(self.inbound.run().in_current_span()),
-            tokio::spawn(self.outbound.run().in_current_span()),
             tokio::spawn(self.policy_watcher.run().in_current_span()),
         ];
-        if let Some(socks5) = self.socks5 {
-            tasks.push(tokio::spawn(socks5.run().in_current_span()));
+
+        // TODO hbone_port is ALWAYS (by necessity) fixed in read-only config -
+        // except in (some) contrived integ test cases (direct), where we bind to random non-well-known ports,
+        // and cannot rely on a well-known port - which is why this exists, so we can ignore
+        // the config object and sidechannel the non-fixed runtime-bound port.
+        #[cfg(any(test, feature = "testing"))]
+        {
+            let hbone_port = self.inbound.address().port();
+            tasks.push(tokio::spawn(self.outbound.run(hbone_port).in_current_span()));
+            tasks.push(tokio::spawn(self.inbound.run().in_current_span()));
+            if let Some(socks5) = self.socks5 {
+                tasks.push(tokio::spawn(socks5.run(hbone_port).in_current_span()));
+            };
+        }
+
+        #[cfg(not(any(test, feature = "testing")))]
+        {
+            tasks.push(tokio::spawn(self.inbound.run().in_current_span()));
+            tasks.push(tokio::spawn(self.outbound.run().in_current_span()));
+            if let Some(socks5) = self.socks5 {
+                tasks.push(tokio::spawn(socks5.run().in_current_span()));
+            };
         }
 
         futures::future::join_all(tasks).await;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -194,7 +194,9 @@ impl Proxy {
         #[cfg(any(test, feature = "testing"))]
         {
             let hbone_port = self.inbound.address().port();
-            tasks.push(tokio::spawn(self.outbound.run(hbone_port).in_current_span()));
+            tasks.push(tokio::spawn(
+                self.outbound.run(hbone_port).in_current_span(),
+            ));
             tasks.push(tokio::spawn(self.inbound.run().in_current_span()));
             if let Some(socks5) = self.socks5 {
                 tasks.push(tokio::spawn(socks5.run(hbone_port).in_current_span()));

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
@@ -28,7 +28,7 @@ use tokio::net::TcpStream;
 
 use tracing::{debug, info, instrument, trace_span, Instrument};
 
-use super::connection_manager::ConnectionManager;
+
 use super::Error;
 use crate::baggage::parse_baggage_header;
 use crate::identity::{Identity, SecretManager};

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -120,12 +120,7 @@ impl Inbound {
                 debug!(%conn, "accepted connection");
                 let cfg = pi.cfg.clone();
                 let request_handler = move |req| {
-                    Self::serve_connect(
-                        pi.clone(),
-                        conn.clone(),
-                        self.enable_orig_src,
-                        req,
-                    )
+                    Self::serve_connect(pi.clone(), conn.clone(), self.enable_orig_src, req)
                 };
                 let serve = Box::pin(h2::server::serve_connection(
                     cfg,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
@@ -27,7 +26,6 @@ use http::{Method, Response, StatusCode};
 use tokio::net::TcpStream;
 
 use tracing::{debug, info, instrument, trace_span, Instrument};
-
 
 use super::Error;
 use crate::baggage::parse_baggage_header;
@@ -64,11 +62,7 @@ impl Inbound {
             .map_err(|e| Error::Bind(pi.cfg.inbound_addr, e))?;
         let transparent = super::maybe_set_transparent(&pi, &listener)?;
         // Override with our explicitly configured setting
-        let enable_orig_src = if pi.cfg.enable_original_source.is_none() {
-            transparent
-        } else {
-            pi.cfg.enable_original_source.unwrap()
-        };
+        let enable_orig_src = pi.cfg.enable_original_source.unwrap_or(transparent);
 
         info!(
             address=%listener.local_addr(),

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -50,11 +49,7 @@ impl InboundPassthrough {
 
         let transparent = super::maybe_set_transparent(&pi, &listener)?;
         // Override with our explicitly configured setting
-        let enable_orig_src = if pi.cfg.enable_original_source.is_none() {
-            transparent
-        } else {
-            pi.cfg.enable_original_source.unwrap()
-        };
+        let enable_orig_src = pi.cfg.enable_original_source.unwrap_or(transparent);
 
         info!(
             address=%listener.local_addr(),

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -23,7 +23,7 @@ use tokio::net::TcpStream;
 use tracing::{error, info, trace, Instrument};
 
 use crate::config::ProxyMode;
-use crate::proxy::connection_manager::ConnectionManager;
+
 use crate::proxy::metrics::Reporter;
 use crate::proxy::Error;
 use crate::proxy::{metrics, util, ProxyInputs};

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -33,13 +33,14 @@ use crate::{proxy, socket};
 
 pub(super) struct InboundPassthrough {
     listener: socket::Listener,
-    pi: ProxyInputs,
+    pi: Arc<ProxyInputs>,
     drain: Watch,
+    enable_orig_src: bool,
 }
 
 impl InboundPassthrough {
     pub(super) async fn new(
-        mut pi: ProxyInputs,
+        pi: Arc<ProxyInputs>,
         drain: Watch,
     ) -> Result<InboundPassthrough, Error> {
         let listener = pi
@@ -49,11 +50,11 @@ impl InboundPassthrough {
 
         let transparent = super::maybe_set_transparent(&pi, &listener)?;
         // Override with our explicitly configured setting
-        if pi.cfg.enable_original_source.is_none() {
-            let mut cfg = (*pi.cfg).clone();
-            cfg.enable_original_source = Some(transparent);
-            pi.cfg = Arc::new(cfg);
-        }
+        let enable_orig_src = if pi.cfg.enable_original_source.is_none() {
+            transparent
+        } else {
+            pi.cfg.enable_original_source.unwrap()
+        };
 
         info!(
             address=%listener.local_addr(),
@@ -65,22 +66,16 @@ impl InboundPassthrough {
             listener,
             pi,
             drain,
+            enable_orig_src,
         })
     }
 
-    pub(super) fn address(&self) -> SocketAddr {
-        self.listener.local_addr()
-    }
-
-    pub(super) async fn run(self, illegal_ports: Arc<HashSet<u16>>) {
+    pub(super) async fn run(self) {
         let accept = async move {
             loop {
                 // Asynchronously wait for an inbound socket.
                 let socket = self.listener.accept().await;
                 let pi = self.pi.clone();
-                let illegal_ports = illegal_ports.clone();
-
-                let connection_manager = self.pi.connection_manager.clone();
                 match socket {
                     Ok((stream, remote)) => {
                         let serve_client = async move {
@@ -88,15 +83,14 @@ impl InboundPassthrough {
                                 pi, // pi cloned above; OK to move
                                 socket::to_canonical(remote),
                                 stream,
-                                illegal_ports,
-                                connection_manager,
+                                self.enable_orig_src,
                             )
                             .await
                         }
                         .in_current_span();
 
                         // This is pretty large right now. Fortunately with pooling this is less problematic than outbound.
-                        assertions::size_between_ref(3000, 5000, &serve_client);
+                        assertions::size_between_ref(2400, 5000, &serve_client);
                         tokio::spawn(serve_client);
                     }
                     Err(e) => {
@@ -121,11 +115,10 @@ impl InboundPassthrough {
     }
 
     async fn proxy_inbound_plaintext(
-        pi: ProxyInputs,
+        pi: Arc<ProxyInputs>,
         source_addr: SocketAddr,
         mut inbound_stream: TcpStream,
-        illegal_ports: Arc<HashSet<u16>>,
-        connection_manager: ConnectionManager,
+        enable_orig_src: bool,
     ) {
         let start = Instant::now();
         let dest_addr = socket::orig_dst_addr_or_default(&inbound_stream);
@@ -133,7 +126,7 @@ impl InboundPassthrough {
         // lead to infinite loops
         let illegal_call = if pi.cfg.inpod_enabled {
             // User sent a request to pod:15006. This would forward to pod:15006 infinitely
-            illegal_ports.contains(&dest_addr.port())
+            pi.cfg.illegal_ports.contains(&dest_addr.port())
         } else {
             // User sent a request to the ztunnel directly. This isn't allowed
             pi.cfg.proxy_mode == ProxyMode::Shared && Some(dest_addr.ip()) == pi.cfg.local_ip
@@ -205,10 +198,11 @@ impl InboundPassthrough {
                 connection_security_policy: metrics::SecurityPolicy::unknown,
                 destination_service: ds,
             },
-            pi.metrics,
+            pi.metrics.clone(),
         ));
 
-        let conn_guard = match connection_manager
+        let conn_guard = match pi
+            .connection_manager
             .assert_rbac(&pi.state, &rbac_ctx, None)
             .await
         {
@@ -221,7 +215,7 @@ impl InboundPassthrough {
             }
         };
 
-        let orig_src = if pi.cfg.enable_original_source.unwrap_or_default() {
+        let orig_src = if enable_orig_src {
             Some(source_addr.ip())
         } else {
             None

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -76,11 +76,6 @@ impl Outbound {
     }
 
     pub(super) async fn run(self) {
-        let hbone_port = self.pi.cfg.inbound_addr.port();
-        self.inner_run(hbone_port).await
-    }
-
-    async fn inner_run(self, hbone_port: u16) {
         // Since we are spawning autonomous tasks to handle outbound connections for a single workload,
         // we can have situations where the workload is deleted, but a task is still "stuck"
         // waiting for a server response stream on a HTTP/2 connection or whatnot.
@@ -105,7 +100,7 @@ impl Outbound {
                             id: TraceParent::new(),
                             pool: pool.clone(),
                             enable_orig_src: self.enable_orig_src,
-                            hbone_port,
+                            hbone_port: self.pi.cfg.inbound_addr.port(),
                         };
                         stream.set_nodelay(true).unwrap();
                         let span = info_span!("outbound", id=%oc.id);

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -169,7 +169,6 @@ pub(super) struct OutboundConnection {
     pub(super) pool: proxy::pool::WorkloadHBONEPool,
     pub(super) enable_orig_src: bool,
     pub(super) hbone_port: u16,
-
 }
 
 impl OutboundConnection {

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -55,11 +55,7 @@ impl Outbound {
             .map_err(|e| Error::Bind(pi.cfg.outbound_addr, e))?;
         let transparent = super::maybe_set_transparent(&pi, &listener)?;
         // Override with our explicitly configured setting
-        let enable_orig_src = if pi.cfg.enable_original_source.is_none() {
-            transparent
-        } else {
-            pi.cfg.enable_original_source.unwrap()
-        };
+        let enable_orig_src = pi.cfg.enable_original_source.unwrap_or(transparent);
 
         info!(
             address=%listener.local_addr(),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -49,7 +49,7 @@ pub struct Outbound {
 
 impl Outbound {
     pub(super) async fn new(pi: Arc<ProxyInputs>, drain: Watch) -> Result<Outbound, Error> {
-        let listener: TcpListener = pi
+        let listener = pi
             .socket_factory
             .tcp_bind(pi.cfg.outbound_addr)
             .map_err(|e| Error::Bind(pi.cfg.outbound_addr, e))?;
@@ -79,15 +79,6 @@ impl Outbound {
         self.listener.local_addr()
     }
 
-    // TODO hbone_port is ALWAYS (by necessity) fixed in read-only config -
-    // except in (some) contrived integ test cases (direct), where we bind to random non-well-known ports,
-    // and cannot rely on a well-known port - which is why this exists.
-    #[cfg(any(test, feature = "testing"))]
-    pub(super) async fn run(self, hbone_port: u16) {
-        self.inner_run(hbone_port).await
-    }
-
-    #[cfg(not(any(test, feature = "testing")))]
     pub(super) async fn run(self) {
         let hbone_port = self.pi.cfg.inbound_addr.port();
         self.inner_run(hbone_port).await

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -59,11 +59,6 @@ impl Socks5 {
     }
 
     pub async fn run(self) {
-        let hbone_port = self.pi.cfg.inbound_addr.port();
-        self.inner_run(hbone_port).await
-    }
-
-    async fn inner_run(self, hbone_port: u16) {
         let inner_drain = self.drain.clone();
         let inpod = self.pi.cfg.inpod_enabled;
         let accept = async move {
@@ -86,7 +81,7 @@ impl Socks5 {
                             id: TraceParent::new(),
                             pool,
                             enable_orig_src: self.pi.cfg.enable_original_source.unwrap_or_default(),
-                            hbone_port,
+                            hbone_port: self.pi.cfg.inbound_addr.port(),
                         };
                         tokio::spawn(async move {
                             if let Err(err) = handle(oc, stream, stream_drain, inpod).await {

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -58,15 +58,6 @@ impl Socks5 {
         self.listener.local_addr()
     }
 
-    // TODO hbone_port is ALWAYS (by necessity) fixed in read-only config -
-    // except in (some) contrived integ test cases (direct), where we bind to random non-well-known ports,
-    // and cannot rely on a well-known port - which is why this exists.
-    #[cfg(any(test, feature = "testing"))]
-    pub async fn run(self, hbone_port: u16) {
-        self.inner_run(hbone_port).await
-    }
-
-    #[cfg(not(any(test, feature = "testing")))]
     pub async fn run(self) {
         let hbone_port = self.pi.cfg.inbound_addr.port();
         self.inner_run(hbone_port).await

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -58,7 +58,21 @@ impl Socks5 {
         self.listener.local_addr()
     }
 
+    // TODO hbone_port is ALWAYS (by necessity) fixed in read-only config -
+    // except in (some) contrived integ test cases (direct), where we bind to random non-well-known ports,
+    // and cannot rely on a well-known port - which is why this exists.
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn run(self, hbone_port: u16) {
+        self.inner_run(hbone_port).await
+    }
+
+    #[cfg(not(any(test, feature = "testing")))]
     pub async fn run(self) {
+        let hbone_port = self.pi.cfg.inbound_addr.port();
+        self.inner_run(hbone_port).await
+    }
+
+    async fn inner_run(self, hbone_port: u16) {
         let inner_drain = self.drain.clone();
         let inpod = self.pi.cfg.inpod_enabled;
         let accept = async move {
@@ -81,6 +95,7 @@ impl Socks5 {
                             id: TraceParent::new(),
                             pool,
                             enable_orig_src: self.pi.cfg.enable_original_source.unwrap_or_default(),
+                            hbone_port,
                         };
                         tokio::spawn(async move {
                             if let Err(err) = handle(oc, stream, stream_drain, inpod).await {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -31,7 +31,7 @@ use anyhow::anyhow;
 use bytes::{BufMut, Bytes};
 use hickory_resolver::config::*;
 
-use std::sync::atomic::{Ordering, AtomicU16};
+use std::sync::atomic::{AtomicU16, Ordering};
 
 use crate::strng;
 use http_body_util::{BodyExt, Full};

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -34,7 +34,7 @@ use hickory_resolver::config::*;
 use crate::strng;
 use http_body_util::{BodyExt, Full};
 use hyper::Response;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::default::Default;
 use std::fmt::Debug;
 use std::future::Future;
@@ -109,6 +109,7 @@ pub fn test_config_with_port_xds_addr_and_root_cert(
         outbound_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         dns_proxy_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        illegal_ports: HashSet::new(), // for "direct" tests, since the ports are latebound, we can't test illegal ports
         ..config::parse_config().unwrap()
     };
     // Do not let tests use system defaults!


### PR DESCRIPTION
This is mostly just pushing some minor local cleanups.

- `Arc` all of ProxyInputs. We can probably de-arc some of the bits inside so they aren't double-arc'd eventually, but handlers shouldn't be able to get mut-ref to anything in PI - if they need to, it doesn't belong in PI.

- Put `illegal_ports` in config - it is effectively config anyway - all the values are sourced from config, and everywhere we use `illegal_ports` we already have config.


General goal is to make sure handlers keep a clean distinction between runtime-mutable state (their inner state/explicit mutable args) and state that should _not_ be runtime-mutable (static config, proxyinputs)

We have tests that (ab)use this lack of immutability which this also twiddles a bit, mostly just enough to prevent us from writing more tests like that.