### PR TITLE
Better handling of proxying shutdown

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -242,6 +242,12 @@ pub enum Error {
     #[error("io error: {0}")]
     Io(#[from] io::Error),
 
+    #[error("destination disconnected before all data was written")]
+    BackendDisconnected,
+
+    #[error("client disconnected before all data was written")]
+    ClientDisconnected,
+
     #[error("connection failed: {0}")]
     ConnectionFailed(io::Error),
 


### PR DESCRIPTION
Before: if one end closes, we abruptly stop. We give confusing error
messages

After: if one end closes, we drain the other end then shutdown. Errors
are nicer.

The "Disconnected" case is as such: the client has sent us data, but the
server disconnected before we could send it (or the opposite).
This *can* actually happen in legitimate cases but its somewhat rare.
For instance, and HTTP server may send a response back immediately
without reading the request body and then close the connection.

fixes https://github.com/istio/ztunnel/issues/1065
