### PR TITLE
logs: faster and more correct JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3246,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3809,6 +3830,8 @@ dependencies = [
  "tower",
  "tower-hyper-http-body-compat",
  "tracing",
+ "tracing-appender",
+ "tracing-core",
  "tracing-log",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,8 @@ h2 = "0.4"
 http = "1.1"
 split-iter = "0.1"
 arcstr = { version = "1.1", features = ["serde"] }
+tracing-core = "0.1.32"
+tracing-appender = "0.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -456,6 +456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,6 +2790,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,6 +3360,8 @@ dependencies = [
  "tower",
  "tower-hyper-http-body-compat",
  "tracing",
+ "tracing-appender",
+ "tracing-core",
  "tracing-log",
  "tracing-subscriber",
  "url",

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 fn main() -> anyhow::Result<()> {
-    telemetry::setup_logging();
+    let _log_flush = telemetry::setup_logging();
     let config = Arc::new(config::parse_config()?);
 
     // For now we don't need a complex CLI, so rather than pull in dependencies just use basic argv[1]

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -107,7 +107,7 @@ impl Outbound {
                         stream.set_nodelay(true).unwrap();
                         let span = info_span!("outbound", id=%oc.id);
                         let serve_outbound_connection = (async move {
-                            debug!(dur=?start_outbound_instant.elapsed(), id=%oc.id, "outbound spawn START");
+                            debug!(dur=?start_outbound_instant.elapsed(), "outbound spawn START");
                             // Since this task is spawned, make sure we are guaranteed to terminate
                             tokio::select! {
                                 _ = outbound_drain.signaled() => {
@@ -115,8 +115,9 @@ impl Outbound {
                                 }
                                 _ = oc.proxy(stream) => {}
                             }
-                            debug!(dur=?start_outbound_instant.elapsed(), id=%oc.id, "outbound spawn DONE");
-                        }).instrument(span);
+                            debug!(dur=?start_outbound_instant.elapsed(), "outbound spawn DONE");
+                        })
+                        .instrument(span);
 
                         assertions::size_between_ref(1000, 1750, &serve_outbound_connection);
                         tokio::spawn(serve_outbound_connection);

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -182,7 +182,7 @@ mod namespaced {
         let hbone_addr = format!("{server_ip}:8080");
         let dst_addr = format!("{waypoint_ip}:15008");
         let want = HashMap::from([
-            ("target", "access"),
+            ("scope", "access"),
             ("src.workload", "client"),
             ("dst.workload", "waypoint"),
             ("dst.namespace", "default"),
@@ -246,7 +246,7 @@ mod namespaced {
         let hbone_addr = format!("{TEST_VIP}:80");
         let dst_addr = format!("{waypoint_ip}:15008");
         let want = HashMap::from([
-            ("target", "access"),
+            ("scope", "access"),
             ("src.workload", "client"),
             ("dst.workload", "waypoint"),
             ("dst.hbone_addr", &hbone_addr),
@@ -550,7 +550,7 @@ mod namespaced {
             .join()
             .unwrap()?;
         telemetry::testing::assert_contains(HashMap::from([
-            ("target", "access"),
+            ("scope", "access"),
             ("error", "connection closed due to policy rejection"),
         ]));
         Ok(())
@@ -611,7 +611,7 @@ mod namespaced {
             .join()
             .unwrap()?;
         let e = format!("ip mismatch: {} != {}", srv.ip(), clt.ip());
-        telemetry::testing::assert_contains(HashMap::from([("target", "access"), ("error", &e)]));
+        telemetry::testing::assert_contains(HashMap::from([("scope", "access"), ("error", &e)]));
         Ok(())
     }
 
@@ -958,7 +958,7 @@ mod namespaced {
         if let Some(ref zt) = server_ztunnel {
             let _remote_metrics = verify_metrics(zt, &metrics, &destination_labels()).await;
             let mut want = HashMap::from([
-                ("target", "access"),
+                ("scope", "access"),
                 ("src.workload", "client"),
                 ("dst.workload", "server"),
                 ("bytes_sent", "22"),
@@ -981,7 +981,7 @@ mod namespaced {
         if let Some(zt) = client_ztunnel {
             let _remote_metrics = verify_metrics(&zt, &metrics, &source_labels()).await;
             let mut want = HashMap::from([
-                ("target", "access"),
+                ("scope", "access"),
                 ("src.workload", "client"),
                 ("dst.workload", "server"),
                 ("bytes_sent", "11"),


### PR DESCRIPTION
This PR builds a custom formatter for JSON logs. We already have a custom formatter for plaintext logs.

Benefits:
* Fast. With the same workload, this allocates 100mb while the old one was allocating 260mb, and has a ~20% improvement on throughput of requests.
* Correct. The old one had bugs that impacted us a lot (https://github.com/tokio-rs/tracing/issues/2973) and didn't follow the same format as the rest of Istio. 
* Consistent. Same format used in the rest of istion

Before:
```json
{
  "bytes_recv": 22,
  "bytes_sent": 11,
  "direction": "outbound",
  "dst.addr": "10.0.3.3:8080",
  "dst.namespace": "default",
  "dst.workload": "server",
  "duration": "1ms",
  "level": "INFO",
  "message": "connection complete",
  "span": {
    "id": "22a77cebe3297cdc0b93bc10f12c4100",
    "name": "outbound"
  },
  "spans": [
    {
      "name": "proxy",
      "uid": "cluster1//v1/Pod/default/client"
    },
    {
      "id": "22a77cebe3297cdc0b93bc10f12c4100",
      "name": "outbound"
    }
  ],
  "src.addr": "10.0.2.4:60364",
  "src.namespace": "default",
  "src.workload": "client",
  "target": "access",
  "timestamp": "2024-05-17T18:59:01.742549Z"
}
```

After:
```json
{
  "bytes_recv": 22,
  "bytes_sent": 11,
  "direction": "outbound",
  "dst.addr": "10.0.3.3:8080",
  "dst.namespace": "default",
  "dst.workload": "server",
  "duration": "0ms",
  "level": "info",
  "message": "connection complete",
  "scope": "access",
  "src.addr": "10.0.2.4:52968",
  "src.namespace": "default",
  "src.workload": "client",
  "time": "2024-05-17T18:59:37.481338Z"
}
```

(An obvious concern looking at above is: we lost data; we didn't, that data was supposed to not be logged. When we actually _do_ wanted nested spans logged they still are)