### PR TITLE
[1.22] deps: use released `h2` (#1069)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,14 +1052,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.4.4"
-source = "git+https://github.com/hyperium/h2?rev=be129832df989bf28940da3618827e190ae64ef2#be129832df989bf28940da3618827e190ae64ef2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http 1.1.0",
  "indexmap 2.2.6",
  "slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ backoff = "0.4.0"
 pin-project-lite = "0.2"
 pingora-pool = "0.1.0"
 flurry = "0.5.0"
-h2 = "0.4"
+h2 = "0.4.5"
 http = "1.1"
 split-iter = "0.1"
 arcstr = { version = "1.1", features = ["serde"] }
@@ -142,7 +142,3 @@ test-case = "3.3"
 oid-registry = "0.7"
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
 ctor = "0.2"
-
-[patch.crates-io]
-# TODO h2 0.4.5 (https://github.com/istio/ztunnel/issues/1000)
-h2 = { git = "https://github.com/hyperium/h2", rev = "be129832df989bf28940da3618827e190ae64ef2" }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -183,6 +183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,15 +819,15 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http 1.1.0",
  "indexmap 2.2.3",
  "slab",


### PR DESCRIPTION
Fixes #1070