### PR TITLE
Fully remove public internet dependency on DNS tests

### DIFF
--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -1410,13 +1410,11 @@ mod tests {
 
         let resp = send_request(&mut tcp_client, n("large.com."), RecordType::A).await;
         assert!(!resp.truncated(), "TCP should not truncate");
-        assert_eq!(244, resp.answers().len());
+        assert_eq!(256, resp.answers().len());
 
         let resp = send_request(&mut udp_client, n("large.com."), RecordType::A).await;
-        //resp.answers()[0].
-        //let resp = send_request(&mut tcp_client, n("large.com."), RecordType::A).await;
+        // UDP is truncated
         assert!(resp.truncated());
-        // Not sure we can rely on the truncation being exactly 75, but for now assert
         assert_eq!(75, resp.answers().len(), "expected UDP to be truncated");
     }
 
@@ -1448,7 +1446,7 @@ mod tests {
 
     fn new_large_response() -> Vec<IpAddr> {
         let mut out = Vec::new();
-        for i in 0..244 {
+        for i in 0..256 {
             out.push(ip(format!("240.0.0.{i}")));
         }
         out

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -86,15 +86,18 @@ impl Server {
         metrics: Arc<Metrics>,
         drain: Watch,
         socket_factory: &(dyn SocketFactory + Send + Sync),
+        allow_unknown_source: bool,
     ) -> Result<Self, Error> {
         // Create the DNS server, backed by ztunnel data structures.
-        let handler = dns::handler::Handler::new(Arc::new(Store::new(
+        let mut store = Store::new(
             domain,
             network.as_ref().to_string(),
             state,
             forwarder,
             metrics,
-        )));
+        );
+        store.allow_unknown_source = allow_unknown_source;
+        let handler = dns::handler::Handler::new(Arc::new(store));
         let mut server = ServerFuture::new(handler);
         info!(
             address=%addr,
@@ -165,6 +168,7 @@ struct Store {
     domain: Name,
     svc_domain: Name,
     metrics: Arc<Metrics>,
+    allow_unknown_source: bool,
 }
 
 impl Store {
@@ -185,6 +189,7 @@ impl Store {
             domain,
             svc_domain,
             metrics,
+            allow_unknown_source: false,
         }
     }
 
@@ -508,6 +513,10 @@ impl Resolver for Store {
                     source: None,
                 });
                 debug!("unknown source");
+                #[cfg(any(test, feature = "testing"))]
+                if self.allow_unknown_source {
+                    return self.forward(None, request).await;
+                }
                 return Err(LookupError::ResponseCode(ResponseCode::ServFail));
             }
             Some(client) => client,
@@ -774,7 +783,7 @@ mod tests {
     use crate::metrics;
     use crate::strng;
     use crate::test_helpers::dns::{
-        a, aaaa, cname, ip, ipv4, ipv6, n, new_message, new_tcp_client, new_udp_client,
+        a, aaaa, cname, ip, ipv4, ipv6, n, new_message, new_tcp_client, new_udp_client, run_dns,
         send_request, server_request,
     };
     use crate::test_helpers::helpers::initialize_telemetry;
@@ -894,6 +903,7 @@ mod tests {
                 state,
                 forwarder,
                 metrics: test_metrics(),
+                allow_unknown_source: false,
             };
 
             let namespaced_domain = n(format!("{}.svc.cluster.local", c.client_namespace));
@@ -1191,6 +1201,7 @@ mod tests {
             test_metrics(),
             drain,
             &factory,
+            false,
         )
         .await
         .unwrap();
@@ -1246,6 +1257,7 @@ mod tests {
             state,
             forwarder,
             metrics: test_metrics(),
+            allow_unknown_source: false,
         };
 
         let bad_client_ip = ip("5.5.5.5");
@@ -1263,8 +1275,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn system_forwarder() {
+    async fn forward_to_server() {
         initialize_telemetry();
+        // Other test use fake forwarder; here we forward to a real server (which we run locally)
 
         struct Case {
             name: &'static str,
@@ -1275,7 +1288,7 @@ mod tests {
         let cases = [
             Case {
                 name: "success: www.google.com",
-                host: "www.google.com.",
+                host: "test.example.com.",
                 expect_code: ResponseCode::NoError,
             },
             Case {
@@ -1288,7 +1301,14 @@ mod tests {
         // Create and start the server.
         let domain = "cluster.local".to_string();
         let state = state();
-        let forwarder = Arc::new(SystemForwarder::new().unwrap());
+        let forwarder = Arc::new(
+            run_dns(HashMap::from([(
+                n("test.example.com."),
+                vec![ip("1.1.1.1")],
+            )]))
+            .await
+            .unwrap(),
+        );
         let (_signal, drain) = drain::channel();
         let factory = crate::proxy::DefaultSocketFactory;
         let server = Server::new(
@@ -1300,6 +1320,7 @@ mod tests {
             test_metrics(),
             drain,
             &factory,
+            false,
         )
         .await
         .unwrap();
@@ -1342,6 +1363,7 @@ mod tests {
             domain: n("cluster.local"),
             svc_domain: n("svc.cluster.local."),
             metrics: test_metrics(),
+            allow_unknown_source: false,
         };
 
         let ip4n6_client_ip = ip("::ffff:202:202");
@@ -1353,27 +1375,50 @@ mod tests {
             }
         }
     }
-    // #[tokio::test]
-    // async fn large_response() {
-    //     // Create and start the proxy with an an empty state. The forwarder is configured to
-    //     // return a large response.
-    //     let addr = new_socket_addr().await;
-    //     let state = new_proxy_state(&[local_workload()], &[], &[]).state;
-    //     let forwarder = Arc::new(FakeForwarder {
-    //         search_domains: vec![],
-    //         ips: HashMap::from([(n("large.com."), new_large_response())]),
-    //     });
-    //     let proxy = DnsProxy::new(addr, NW1, state, forwarder).await.unwrap();
-    //     tokio::spawn(proxy.run());
-    //
-    //     let mut tcp_client = new_tcp_client(addr).await;
-    //
-    //     let resp = send_with_max_size(&mut tcp_client, n("large.com."), RecordType::A, 20).await;
-    //     //resp.answers()[0].
-    //     //let resp = send_request(&mut tcp_client, n("large.com."), RecordType::A).await;
-    //     //assert!(resp.truncated());
-    //     println!("{:?}", resp);
-    // }
+    #[tokio::test]
+    async fn large_response() {
+        initialize_telemetry();
+        // Create and start the proxy with an an empty state. The forwarder is configured to
+        // return a large response.
+        let state = new_proxy_state(&[], &[], &[]);
+        let forwarder = Arc::new(FakeForwarder {
+            search_domains: vec![],
+            ips: HashMap::from([(n("large.com."), new_large_response())]),
+        });
+        let domain = "cluster.local".to_string();
+        let (_signal, drain) = drain::channel();
+        let factory = crate::proxy::DefaultSocketFactory;
+        let server = Server::new(
+            domain,
+            SocketAddr::from(([127, 0, 0, 1], 0)),
+            NW1,
+            state,
+            forwarder,
+            test_metrics(),
+            drain,
+            &factory,
+            true,
+        )
+        .await
+        .unwrap();
+        let tcp_addr = server.tcp_address();
+        let udp_addr = server.udp_address();
+        tokio::spawn(server.run());
+
+        let mut tcp_client = new_tcp_client(tcp_addr).await;
+        let mut udp_client = new_udp_client(udp_addr).await;
+
+        let resp = send_request(&mut tcp_client, n("large.com."), RecordType::A).await;
+        assert!(!resp.truncated(), "TCP should not truncate");
+        assert_eq!(244, resp.answers().len());
+
+        let resp = send_request(&mut udp_client, n("large.com."), RecordType::A).await;
+        //resp.answers()[0].
+        //let resp = send_request(&mut tcp_client, n("large.com."), RecordType::A).await;
+        assert!(resp.truncated());
+        // Not sure we can rely on the truncation being exactly 75, but for now assert
+        assert_eq!(75, resp.answers().len(), "expected UDP to be truncated");
+    }
 
     /// Sort the IP records so that we can directly compare them to the expected. The resulting
     /// list will contain CNAME first, followed by A, and then by AAAA. Within each record type,
@@ -1401,13 +1446,13 @@ mod tests {
         });
     }
 
-    // fn new_large_response() -> Vec<Record> {
-    //     let mut out = Vec::new();
-    //     for i in 0..64 {
-    //         out.push(a(n("aaaaaaaaaaaa.aaaaaa."), ipv4(format!("240.0.0.{i}"))));
-    //     }
-    //     out
-    // }
+    fn new_large_response() -> Vec<IpAddr> {
+        let mut out = Vec::new();
+        for i in 0..244 {
+            out.push(ip(format!("240.0.0.{i}")));
+        }
+        out
+    }
 
     fn req(host: Name, client_ip: IpAddr, query_type: RecordType) -> Request {
         let socket_addr = match client_ip {

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -117,6 +117,7 @@ impl ProxyFactory {
                     self.dns_metrics.clone().unwrap(),
                     drain,
                     socket_factory.as_ref(),
+                    false,
                 )
                 .await?,
             );

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -517,8 +517,10 @@ pub mod testing {
         let mock_writer = MockWriter::new(global_buf());
         let (non_blocking, _guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
             .lossy(false)
-            .buffered_lines_limit(10)
+            .buffered_lines_limit(1)
             .finish(std::io::stdout());
+        // Ensure we do not close until the program ends
+        Box::leak(Box::new(_guard));
         let layer: fmt::Layer<_, _, _, _> = fmt::layer()
             .event_format(IstioJsonFormat())
             .fmt_fields(IstioJsonFormat())

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -213,7 +213,7 @@ fn test_custom_workload(
     hostname_only: bool,
 ) -> anyhow::Result<LocalWorkload> {
     let host = match hostname_only {
-        true => format!("example.{}.internal.", ip_str),
+        true => format!("{}.reflect.internal.", ip_str),
         false => "".to_string(),
     };
     let wips = match hostname_only {

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -31,6 +31,7 @@ use itertools::Itertools;
 use prometheus_parse::Scrape;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpSocket, TcpStream};
+use tracing::info;
 
 use crate::app::Bound;
 use crate::identity::SecretManager;
@@ -74,6 +75,10 @@ where
 {
     initialize_telemetry();
     let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
+    info!(
+        "running with config: {}",
+        serde_yaml::to_string(&cfg).unwrap()
+    );
     let app = app::build_with_cert(Arc::new(cfg), cert_manager.clone())
         .await
         .unwrap();

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -216,7 +216,7 @@ pub struct TestDnsServer {
 }
 
 impl TestDnsServer {
-    /// resolver_config gets a config that can be used passed to Ztunnel to make this the resolver
+    /// resolver_config gets a config that can be passed to Ztunnel to make this the resolver
     pub fn resolver_config(&self) -> ResolverConfig {
         internal_resolver_config(self.tcp, self.udp)
     }
@@ -251,7 +251,6 @@ pub async fn run_dns(responses: HashMap<Name, Vec<IpAddr>>) -> anyhow::Result<Te
     let (signal, drain) = drain::channel();
     let factory = crate::proxy::DefaultSocketFactory {};
 
-    //HashMap::from([(n("www.bing.com."), vec![ip("1.1.1.1")])]),}
     let state = new_proxy_state(&[], &[], &[]);
     let forwarder = Arc::new(FakeForwarder {
         // Use the standard search domains for Kubernetes.

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::dns::forwarder::Forwarder;
+use crate::dns::resolver::{Answer, Resolver};
+use crate::dns::Metrics;
+use crate::proxy::Error;
+use crate::state::workload::Workload;
+use crate::test_helpers::new_proxy_state;
+use crate::{dns, metrics};
 use futures_util::ready;
 use futures_util::stream::{Stream, StreamExt};
 use hickory_client::client::{AsyncClient, ClientHandle};
 use hickory_client::error::ClientError;
 use hickory_proto::error::{ProtoError, ProtoErrorKind};
 use hickory_proto::iocompat::AsyncIoTokioAsStd;
-use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query};
+use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query, ResponseCode};
 use hickory_proto::rr::rdata::{A, AAAA, CNAME};
 use hickory_proto::rr::{DNSClass, Name, RData, Record, RecordType};
 use hickory_proto::serialize::binary::BinDecodable;
@@ -27,11 +32,15 @@ use hickory_proto::tcp::TcpClientStream;
 use hickory_proto::udp::UdpClientStream;
 use hickory_proto::xfer::{DnsRequest, DnsRequestOptions, DnsResponse};
 use hickory_proto::DnsHandle;
-use hickory_server::authority::MessageRequest;
+use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
+use hickory_server::authority::{LookupError, MessageRequest};
 use hickory_server::server::{Protocol, Request};
+use prometheus_client::registry::Registry;
+use std::collections::HashMap;
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::net::{TcpStream, UdpSocket};
 
@@ -55,14 +64,6 @@ pub fn aaaa(name: Name, addr: Ipv6Addr) -> Record {
 /// Creates a CNAME record for the given canonical name.
 pub fn cname(name: Name, canonical_name: Name) -> Record {
     Record::from_rdata(name, TTL, RData::CNAME(CNAME(canonical_name)))
-}
-
-#[cfg(any(unix, target_os = "windows"))]
-/// Creates a [Forwarder] that uses the system configuration (e.g. /etc/resolv.conf).
-pub fn system_forwarder() -> Forwarder {
-    use hickory_resolver::system_conf::read_system_conf;
-    let (cfg, opts) = read_system_conf().unwrap();
-    Forwarder::new(cfg, opts).unwrap()
 }
 
 /// Creates a new DNS client that establishes a TCP connection to the nameserver at the given
@@ -205,4 +206,165 @@ pub fn ipv4<S: AsRef<str>>(addr: S) -> Ipv4Addr {
 /// Helper for parsing a [Ipv6Addr] string.
 pub fn ipv6<S: AsRef<str>>(addr: S) -> Ipv6Addr {
     addr.as_ref().parse().unwrap()
+}
+
+pub struct TestDnsServer {
+    tcp: SocketAddr,
+    udp: SocketAddr,
+    resolver: Arc<dyn Resolver>,
+    _drain: drain::Signal,
+}
+
+impl TestDnsServer {
+    /// resolver_config gets a config that can be used passed to Ztunnel to make this the resolver
+    pub fn resolver_config(&self) -> ResolverConfig {
+        internal_resolver_config(self.tcp, self.udp)
+    }
+}
+
+fn internal_resolver_config(tcp: SocketAddr, udp: SocketAddr) -> ResolverConfig {
+    let mut rc = ResolverConfig::new();
+    rc.add_name_server(NameServerConfig {
+        socket_addr: udp,
+        protocol: hickory_resolver::config::Protocol::Udp,
+        tls_dns_name: None,
+        trust_negative_responses: false,
+        bind_addr: None,
+    });
+    rc.add_name_server(NameServerConfig {
+        socket_addr: tcp,
+        protocol: hickory_resolver::config::Protocol::Tcp,
+        tls_dns_name: None,
+        trust_negative_responses: false,
+        bind_addr: None,
+    });
+    rc
+}
+
+// run_dns sets up a test DNS server. We happen to have a DNS server implementation, so we abuse that here.
+pub async fn run_dns(responses: HashMap<Name, Vec<IpAddr>>) -> anyhow::Result<TestDnsServer> {
+    let test_metrics = {
+        let mut registry = Registry::default();
+        let istio_registry = metrics::sub_registry(&mut registry);
+        Arc::new(Metrics::new(istio_registry))
+    };
+    let (signal, drain) = drain::channel();
+    let factory = crate::proxy::DefaultSocketFactory {};
+
+    //HashMap::from([(n("www.bing.com."), vec![ip("1.1.1.1")])]),}
+    let state = new_proxy_state(&[], &[], &[]);
+    let forwarder = Arc::new(FakeForwarder {
+        // Use the standard search domains for Kubernetes.
+        search_domains: vec![
+            n("ns1.svc.cluster.local"),
+            n("svc.cluster.local"),
+            n("cluster.local"),
+        ],
+        ips: responses,
+    });
+    let srv = crate::dns::Server::new(
+        "example.com".to_string(),
+        "127.0.0.1:0".parse()?,
+        "",
+        state,
+        forwarder,
+        test_metrics,
+        drain,
+        &factory,
+        true,
+    )
+    .await?;
+
+    let tcp = srv.tcp_address();
+    let udp = srv.udp_address();
+    tokio::spawn(srv.run());
+    let cfg = internal_resolver_config(tcp, udp);
+    let opts = ResolverOpts::default();
+    let resolver = Arc::new(
+        dns::forwarder::Forwarder::new(cfg, opts).map_err(|e| Error::Generic(Box::new(e)))?,
+    );
+    Ok(TestDnsServer {
+        tcp,
+        udp,
+        resolver,
+        _drain: signal,
+    })
+}
+
+// Implement a Forwarder that sends a request to our server. This is used for testing the DNS server itself.
+// This is somewhat recursive. `Server --this Forwarder--> Server --FakeForwarder--> Mock`
+#[async_trait::async_trait]
+impl crate::dns::Forwarder for TestDnsServer {
+    fn search_domains(&self, _: &Workload) -> Vec<Name> {
+        vec![
+            n("ns1.svc.cluster.local"),
+            n("svc.cluster.local"),
+            n("cluster.local"),
+        ]
+    }
+
+    async fn forward(
+        &self,
+        _: Option<&Workload>,
+        request: &Request,
+    ) -> Result<Answer, LookupError> {
+        self.resolver.lookup(request).await
+    }
+}
+#[async_trait::async_trait]
+impl Resolver for TestDnsServer {
+    async fn lookup(&self, request: &Request) -> Result<Answer, LookupError> {
+        self.resolver.lookup(request).await
+    }
+}
+
+struct FakeForwarder {
+    search_domains: Vec<Name>,
+    ips: HashMap<Name, Vec<IpAddr>>,
+}
+
+#[async_trait::async_trait]
+impl crate::dns::Forwarder for FakeForwarder {
+    fn search_domains(&self, _: &Workload) -> Vec<Name> {
+        self.search_domains.clone()
+    }
+
+    async fn forward(
+        &self,
+        _: Option<&Workload>,
+        request: &Request,
+    ) -> Result<Answer, LookupError> {
+        let name: Name = request.query().name().into();
+        let utf = name.to_string();
+        if let Some(ip) = utf.strip_suffix(".reflect.internal.") {
+            // Magic to allow `ip.reflect.internal` to always return ip (like nip.io)
+            return Ok(Answer::new(
+                vec![a(request.query().name().into(), ip.parse().unwrap())],
+                false,
+            ));
+        }
+        let Some(ips) = self.ips.get(&name) else {
+            // Not found.
+            return Err(LookupError::ResponseCode(ResponseCode::NXDomain));
+        };
+
+        let mut out = Vec::new();
+        let rtype = request.query().query_type();
+        for ip in ips {
+            match ip {
+                IpAddr::V4(ip) => {
+                    if rtype == RecordType::A {
+                        out.push(a(request.query().name().into(), *ip));
+                    }
+                }
+                IpAddr::V6(ip) => {
+                    if rtype == RecordType::AAAA {
+                        out.push(aaaa(request.query().name().into(), *ip));
+                    }
+                }
+            }
+        }
+
+        return Ok(Answer::new(out, false));
+    }
 }


### PR DESCRIPTION
Make a common fake DNS server. Replace all instances of using the system
DNS resolver from tests and instead use it.

Really we already had a fake one, so mostly just moved it to a common
place and made it a bit more flexible.
