### PR TITLE
Refactor build_requests

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -365,7 +365,7 @@ pub fn metrics(c: &mut Criterion) {
         b.iter(|| {
             let co = proxy::ConnectionOpen {
                 reporter: Default::default(),
-                source: Some(test_helpers::test_default_workload()),
+                source: Some(Arc::new(test_helpers::test_default_workload())),
                 derived_source: None,
                 destination: None,
                 destination_service: None,

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -194,7 +194,7 @@ impl Store {
     }
 
     /// Find the workload for the client address.
-    fn find_client(&self, client_addr: SocketAddr) -> Option<Workload> {
+    fn find_client(&self, client_addr: SocketAddr) -> Option<Arc<Workload>> {
         let state = self.state.read();
         state.workloads.find_address(&NetworkAddress {
             network: self.network.clone(),

--- a/src/inpod/test_helpers.rs
+++ b/src/inpod/test_helpers.rs
@@ -69,7 +69,7 @@ impl Default for Fixture {
         let state = Arc::new(RwLock::new(ProxyState::default()));
         let cert_manager: Arc<crate::identity::SecretManager> =
             crate::identity::mock::new_secret_manager(std::time::Duration::from_secs(10));
-        let metrics = crate::proxy::Metrics::new(&mut registry);
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         let (drain_tx, drain_rx) = drain::channel();
 
         let dstate = DemandProxyState::new(
@@ -77,6 +77,7 @@ impl Default for Fixture {
             None,
             ResolverConfig::default(),
             ResolverOpts::default(),
+            metrics.clone(),
         );
 
         let ipc = InPodConfig::new(&cfg).unwrap();
@@ -84,7 +85,7 @@ impl Default for Fixture {
             Arc::new(cfg),
             dstate,
             cert_manager,
-            Some(metrics),
+            metrics,
             None,
             drain_rx.clone(),
         )

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -581,12 +581,12 @@ where
     };
 
     match state.fetch_destination(&gateway_address.destination).await {
-        Some(Address::Workload(wl)) => return predicate(&wl),
+        Some(Address::Workload(wl)) => return predicate(wl.as_ref()),
         Some(Address::Service(svc)) => {
             for (_ep_uid, ep) in svc.endpoints.iter() {
                 // fetch workloads by workload UID since we may not have an IP for an endpoint (e.g., endpoint is just a hostname)
                 let wl = state.fetch_workload_by_uid(&ep.workload_uid).await;
-                if wl.as_ref().is_some_and(&predicate) {
+                if wl.as_ref().is_some_and(|wl| predicate(wl.as_ref())) {
                     return true;
                 }
             }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -613,6 +613,7 @@ mod tests {
             workload::gatewayaddress::Destination,
         },
     };
+    use prometheus_client::registry::Registry;
     use std::{collections::HashMap, net::Ipv4Addr, sync::RwLock};
 
     #[tokio::test]
@@ -622,11 +623,14 @@ mod tests {
         let mut state = state::ProxyState::default();
         state.workloads.insert(Arc::new(w), true);
         state.services.insert(s);
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         let state = state::DemandProxyState::new(
             Arc::new(RwLock::new(state)),
             None,
             ResolverConfig::default(),
             ResolverOpts::default(),
+            metrics,
         );
 
         let gateawy_id = Identity::Spiffe {

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -324,6 +324,7 @@ impl PolicyWatcher {
 mod tests {
     use drain::Watch;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+    use prometheus_client::registry::Registry;
     use std::net::{Ipv4Addr, SocketAddrV4};
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
@@ -548,11 +549,14 @@ mod tests {
     async fn test_policy_watcher_lifecycle() {
         // preamble: setup an environment
         let state = Arc::new(RwLock::new(ProxyState::default()));
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         let dstate = DemandProxyState::new(
             state.clone(),
             None,
             ResolverConfig::default(),
             ResolverOpts::default(),
+            metrics,
         );
         let connection_manager = ConnectionManager::default();
         let (tx, stop) = drain::channel();

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -232,7 +232,7 @@ impl Inbound {
                     address: source_ip,
                 };
                 // Find source info. We can lookup by XDS or from connection attributes
-                pi.state.fetch_workload_arc(&src_network_addr).await
+                pi.state.fetch_workload(&src_network_addr).await
             }
         };
 
@@ -378,7 +378,7 @@ impl Inbound {
             let hbone_target = state.find_address(hbone_dst);
 
             // We can only sandwich a Workload waypoint
-            let conn_wl = state.workloads.find_address_arc(connection_dst);
+            let conn_wl = state.workloads.find_address(connection_dst);
 
             // on-demand fetch then retry
             let (Some(hbone_target), Some(conn_wl)) = (hbone_target, conn_wl) else {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -520,6 +520,7 @@ mod tests {
     };
 
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+    use prometheus_client::registry::Registry;
     use test_case::test_case;
 
     const CLIENT_POD_IP: &str = "10.0.0.1";
@@ -665,11 +666,14 @@ mod tests {
             state.workloads.insert(Arc::new(wl), true);
         }
 
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         Ok(DemandProxyState::new(
             Arc::new(RwLock::new(state)),
             None,
             ResolverConfig::default(),
             ResolverOpts::default(),
+            metrics,
         ))
     }
 

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -84,8 +84,7 @@ impl InboundPassthrough {
                         }
                         .in_current_span();
 
-                        // This is pretty large right now. Fortunately with pooling this is less problematic than outbound.
-                        assertions::size_between_ref(2400, 5000, &serve_client);
+                        assertions::size_between_ref(1500, 2500, &serve_client);
                         tokio::spawn(serve_client);
                     }
                     Err(e) => {

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -173,7 +173,7 @@ impl InboundPassthrough {
                 network: pi.cfg.network.as_str().into(),
                 address: source_addr.ip(),
             };
-            pi.state.fetch_workload(&network_addr_srcip).await
+            pi.state.fetch_workload_arc(&network_addr_srcip).await
         };
         let derived_source = metrics::DerivedWorkload {
             identity: rbac_ctx.conn.src_identity.clone(),

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -173,7 +173,7 @@ impl InboundPassthrough {
                 network: pi.cfg.network.as_str().into(),
                 address: source_addr.ip(),
             };
-            pi.state.fetch_workload_arc(&network_addr_srcip).await
+            pi.state.fetch_workload(&network_addr_srcip).await
         };
         let derived_source = metrics::DerivedWorkload {
             identity: rbac_ctx.conn.src_identity.clone(),

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -32,6 +32,7 @@ use crate::state::service::ServiceDescription;
 use crate::state::workload::Workload;
 use crate::strng::{RichStrng, Strng};
 
+#[derive(Debug)]
 pub struct Metrics {
     pub connection_opens: Family<CommonTrafficLabels, Counter>,
     pub connection_close: Family<CommonTrafficLabels, Counter>,

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -128,9 +128,9 @@ pub struct DerivedWorkload {
 #[derive(Clone)]
 pub struct ConnectionOpen {
     pub reporter: Reporter,
-    pub source: Option<Workload>,
+    pub source: Option<Arc<Workload>>,
     pub derived_source: Option<DerivedWorkload>,
-    pub destination: Option<Workload>,
+    pub destination: Option<Arc<Workload>>,
     pub destination_service: Option<ServiceDescription>,
     pub connection_security_policy: SecurityPolicy,
 }
@@ -198,8 +198,8 @@ impl From<ConnectionOpen> for CommonTrafficLabels {
             ..CommonTrafficLabels::new()
                 // Intentionally before with_source; source is more reliable
                 .with_derived_source(c.derived_source.as_ref())
-                .with_source(c.source.as_ref())
-                .with_destination(c.destination.as_ref())
+                .with_source(c.source.as_deref())
+                .with_destination(c.destination.as_deref())
                 .with_destination_service(c.destination_service.as_ref())
         }
     }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -247,7 +247,7 @@ impl OutboundConnection {
             metrics,
         ));
 
-        let res = match req {
+        let res = match req.protocol {
             Protocol::HBONE => {
                 self.proxy_to_hbone(source_stream, source_addr, req, &result_tracker)
                     .await
@@ -264,7 +264,7 @@ impl OutboundConnection {
         &mut self,
         stream: TcpStream,
         remote_addr: SocketAddr,
-        req: Box<OutboundRequest::HBONE>,
+        req: Box<Request>,
         connection_stats: &ConnectionResult,
     ) -> Result<(), Error> {
         let upgraded = Box::pin(self.send_hbone_request(remote_addr, req)).await?;
@@ -353,7 +353,7 @@ impl OutboundConnection {
         &self,
         downstream: IpAddr,
         target: SocketAddr,
-    ) -> Result<Box<OutboundRequest>, Error> {
+    ) -> Result<Box<Request>, Error> {
         // First find the source workload of this traffic. If we don't know where the request is from
         // we will reject it.
         let source_workload = {
@@ -556,7 +556,6 @@ fn baggage(r: &OutboundRequest::HBONE, cluster: String) -> String {
 enum OutboundRequest {
     TCP {
         source: Arc<Workload>,
-        destination_workload: Option<Arc<Workload>>,
         destination: SocketAddr,
         destination_service: Option<ServiceDescription>,
     },
@@ -581,15 +580,6 @@ enum OutboundRequest {
         // The identity we will assert for the next hop; this may not be the same as actual_destination_workload
         // in the case of proxies along the path.
         upstream_sans: Vec<Identity>,
-    }
-}
-
-impl OutboundRequest {
-    pub fn actual_destination(&self) -> SocketAddr {
-        match self {
-            OutboundRequest::TCP { destination, .. } => *destination,
-            OutboundRequest::HBONE { actual_destination, .. } => *actual_destination
-        }
     }
 }
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -174,7 +174,6 @@ impl OutboundConnection {
         stream: TcpStream,
         remote_addr: SocketAddr,
         orig_dst_addr: SocketAddr,
-        block_passthrough: bool,
         out_drain: Option<Watch>,
     ) {
         match out_drain {
@@ -183,11 +182,11 @@ impl OutboundConnection {
                         _ = drain.signaled() => {
                             info!("drain signaled");
                         }
-                        res = self.proxy_to(stream, remote_addr, orig_dst_addr, block_passthrough) => res
+                        res = self.proxy_to(stream, remote_addr, orig_dst_addr) => res
                 }
             }
             None => {
-                self.proxy_to(stream, remote_addr, orig_dst_addr, block_passthrough)
+                self.proxy_to(stream, remote_addr, orig_dst_addr)
                     .await;
             }
         }
@@ -198,7 +197,6 @@ impl OutboundConnection {
         mut source_stream: TcpStream,
         source_addr: SocketAddr,
         dest_addr: SocketAddr,
-        block_passthrough: bool,
     ) {
         let start = Instant::now();
 
@@ -218,42 +216,31 @@ impl OutboundConnection {
                 return;
             }
         };
-        if block_passthrough && req.actual_destination_workload.is_none() {
-            // This is mostly used by socks5. For typical outbound calls, we need to allow calls to arbitrary
-            // domains. But for socks5
-            metrics::log_early_deny(
-                source_addr,
-                dest_addr,
-                Reporter::source,
-                Error::UnknownDestination(dest_addr.ip()),
-            );
-            return;
-        }
         // TODO: should we use the original address or the actual address? Both seems nice!
         let _conn_guard = self.pi.connection_manager.track_outbound(
             source_addr,
             dest_addr,
-            req.actual_destination,
+            req.actual_destination(),
         );
 
         let metrics = self.pi.metrics.clone();
-        let hbone_target = req.hbone_target_destination;
         let result_tracker = Box::new(ConnectionResult::new(
             source_addr,
-            req.actual_destination,
-            hbone_target,
+            req.actual_destination(),
+            req.hbone_target(),
             start,
             Self::conn_metrics_from_request(&req),
             metrics,
         ));
 
+
         let res = match req {
-            Protocol::HBONE => {
+            req@OutboundRequest::HBONE{ .. } => {
                 self.proxy_to_hbone(source_stream, source_addr, req, &result_tracker)
                     .await
             }
-            Protocol::TCP => {
-                self.proxy_to_tcp(&mut source_stream, &req, &result_tracker)
+            req@OutboundRequest::TCP{ .. } => {
+                self.proxy_to_tcp(&mut source_stream, req, &result_tracker)
                     .await
             }
         };
@@ -264,7 +251,7 @@ impl OutboundConnection {
         &mut self,
         stream: TcpStream,
         remote_addr: SocketAddr,
-        req: Box<OutboundRequest::HBONE>,
+        req: OutboundRequest::HBONE,
         connection_stats: &ConnectionResult,
     ) -> Result<(), Error> {
         let upgraded = Box::pin(self.send_hbone_request(remote_addr, req)).await?;
@@ -274,7 +261,7 @@ impl OutboundConnection {
     async fn send_hbone_request(
         &mut self,
         remote_addr: SocketAddr,
-        req: Box<OutboundRequest::HBONE>,
+        req: OutboundRequest::HBONE,
     ) -> Result<H2Stream, Error> {
         let mut f = http_types::proxies::Forwarded::new();
         f.add_for(remote_addr.to_string());
@@ -314,7 +301,7 @@ impl OutboundConnection {
     async fn proxy_to_tcp(
         &mut self,
         stream: &mut TcpStream,
-        req: &Request,
+        req: Box<OutboundRequest::TCP>,
         connection_stats: &ConnectionResult,
     ) -> Result<(), Error> {
         // Create a TCP connection to upstream
@@ -325,7 +312,7 @@ impl OutboundConnection {
         };
         let mut outbound = super::freebind_connect(
             local,
-            req.actual_destination,
+            req.destination,
             self.pi.socket_factory.as_ref(),
         )
         .await?;
@@ -334,18 +321,18 @@ impl OutboundConnection {
         copy::copy_bidirectional(stream, &mut outbound, connection_stats).await
     }
 
-    fn conn_metrics_from_request(req: &Request) -> ConnectionOpen {
+    fn conn_metrics_from_request(req: &OutboundRequest) -> ConnectionOpen {
         ConnectionOpen {
             reporter: Reporter::source,
             derived_source: None,
-            source: Some(req.source.clone()),
-            destination: req.actual_destination_workload.clone(),
-            connection_security_policy: if req.protocol == Protocol::HBONE {
+            source: Some(req.source()),
+            destination: req.actual_destination_workload(),
+            connection_security_policy: if req.protocol() == Protocol::HBONE {
                 metrics::SecurityPolicy::mutual_tls
             } else {
                 metrics::SecurityPolicy::unknown
             },
-            destination_service: req.intended_destination_service.clone(),
+            destination_service: req.intended_destination_service(),
         }
     }
 
@@ -353,7 +340,7 @@ impl OutboundConnection {
         &self,
         downstream: IpAddr,
         target: SocketAddr,
-    ) -> Result<Box<OutboundRequest>, Error> {
+    ) -> Result<OutboundRequest, Error> {
         // First find the source workload of this traffic. If we don't know where the request is from
         // we will reject it.
         let source_workload = {
@@ -418,7 +405,7 @@ impl OutboundConnection {
                 let upstream_sans = waypoint_us.workload_and_services_san();
                 let waypoint_socket_address =
                     SocketAddr::new(waypoint_us.selected_workload_ip, waypoint_us.port);
-                return Ok(Box::new(Request {
+                return Ok(Request {
                     protocol: Protocol::HBONE,
                     source: source_workload,
                     hbone_target_destination: Some(target),
@@ -426,7 +413,7 @@ impl OutboundConnection {
                     intended_destination_service: Some(ServiceDescription::from(&*target_service)),
                     actual_destination: waypoint_socket_address,
                     upstream_sans,
-                }));
+                });
             }
             // this was service addressed but we did not find a waypoint
             true
@@ -450,7 +437,7 @@ impl OutboundConnection {
             Some(us) => us,
             None => {
                 // For case no upstream found, passthrough it
-                return Ok(Box::new(Request {
+                return Ok(Request {
                     protocol: Protocol::TCP,
                     source: source_workload,
                     hbone_target_destination: None,
@@ -458,7 +445,7 @@ impl OutboundConnection {
                     intended_destination_service: None,
                     actual_destination: target,
                     upstream_sans: vec![],
-                }));
+                });
             }
         };
 
@@ -484,7 +471,7 @@ impl OutboundConnection {
             if let Some(waypoint) = waypoint {
                 let actual_destination = waypoint.workload_socket_addr();
                 let upstream_sans = waypoint.workload_and_services_san();
-                return Ok(Box::new(Request {
+                return Ok(Request {
                     // Always use HBONE here
                     protocol: Protocol::HBONE,
                     source: source_workload,
@@ -494,7 +481,7 @@ impl OutboundConnection {
                     intended_destination_service: us.destination_service.clone(),
                     actual_destination,
                     upstream_sans,
-                }));
+                });
             }
             // Workload doesn't have a waypoint; send directly
         }
@@ -511,7 +498,7 @@ impl OutboundConnection {
 
         // For case no waypoint for both side and direct to remote node proxy
         let id = us.workload.identity();
-        Ok(Box::new(Request {
+        Ok(Request {
             protocol: us.workload.protocol,
             source: source_workload,
             hbone_target_destination,
@@ -519,7 +506,7 @@ impl OutboundConnection {
             intended_destination_service: us.destination_service.clone(),
             actual_destination: gw_addr,
             upstream_sans: workload_and_services_san(us.service_sans, id),
-        }))
+        })
     }
 }
 
@@ -589,6 +576,36 @@ impl OutboundRequest {
         match self {
             OutboundRequest::TCP { destination, .. } => *destination,
             OutboundRequest::HBONE { actual_destination, .. } => *actual_destination
+        }
+    }
+    pub fn source(&self) -> Arc<Workload> {
+        match self {
+            OutboundRequest::TCP { source, .. } => source.clone(),
+            OutboundRequest::HBONE { source, .. } => source.clone()
+        }
+    }
+    pub fn actual_destination_workload(&self) -> Option<Arc<Workload>> {
+        match self {
+            OutboundRequest::TCP { destination_workload, .. } => destination_workload.clone(),
+            OutboundRequest::HBONE { actual_destination_workload, .. } => actual_destination_workload.clone()
+        }
+    }
+    pub fn intended_destination_service(&self) -> Option<ServiceDescription> {
+        match self {
+            OutboundRequest::TCP { destination_service, .. } => destination_service.clone(),
+            OutboundRequest::HBONE { intended_destination_service, .. } => intended_destination_service.clone()
+        }
+    }
+    pub fn protocol(&self) -> Protocol {
+        match self {
+            OutboundRequest::TCP { .. } => Protocol::TCP,
+            OutboundRequest::HBONE { , .. } => Protocol::HBONE
+        }
+    }
+    pub fn hbone_target(&self) -> Option<SocketAddr> {
+        match self {
+            OutboundRequest::HBONE { hbone_target_destination, .. } => Some(*hbone_target_destination),
+            _ => None,
         }
     }
 }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -34,9 +34,8 @@ use crate::proxy::{util, Error, ProxyInputs, TraceParent, BAGGAGE_HEADER, TRACEP
 
 use crate::proxy::h2::H2Stream;
 use crate::state::service::ServiceDescription;
-use crate::state::workload::gatewayaddress::Destination;
 use crate::state::workload::{address::Address, NetworkAddress, Protocol, Workload};
-use crate::{assertions, copy, proxy, socket, strng};
+use crate::{assertions, copy, proxy, socket};
 
 pub struct Outbound {
     pi: Arc<ProxyInputs>,
@@ -346,10 +345,10 @@ impl OutboundConnection {
         // If this is to-service traffic check for a service waypoint
         // Capture result of whether this is svc addressed
         let svc_addressed = if let Some(Address::Service(target_service)) = state
-            .fetch_destination(&Destination::Address(NetworkAddress {
-                network: strng::new(&self.pi.cfg.network),
+            .fetch_address(&NetworkAddress {
+                network: self.pi.cfg.network.clone(),
                 address: target.ip(),
-            }))
+            })
             .await
         {
             // if we have a waypoint for this svc, use it; otherwise route traffic normally

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::net::{IpAddr, SocketAddr};
-use std::str::FromStr;
 use std::sync::Arc;
 
 use std::time::Instant;
@@ -24,7 +23,7 @@ use hyper::header::FORWARDED;
 
 use tokio::net::TcpStream;
 
-use tracing::{debug, error, info, info_span, trace, trace_span, warn, Instrument};
+use tracing::{debug, error, info, info_span, trace, trace_span, Instrument};
 
 use crate::config::ProxyMode;
 use crate::identity::Identity;
@@ -37,7 +36,6 @@ use crate::proxy::h2::H2Stream;
 use crate::state::service::ServiceDescription;
 use crate::state::workload::gatewayaddress::Destination;
 use crate::state::workload::{address::Address, NetworkAddress, Protocol, Workload};
-use crate::strng::Strng;
 use crate::{assertions, copy, proxy, socket, strng};
 
 pub struct Outbound {

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -23,7 +23,7 @@ use hyper::header::FORWARDED;
 
 use tokio::net::TcpStream;
 
-use tracing::{debug, error, info, info_span, trace, trace_span, Instrument};
+use tracing::{debug, error, info, info_span, trace_span, Instrument};
 
 use crate::config::ProxyMode;
 use crate::identity::Identity;
@@ -358,7 +358,7 @@ impl OutboundConnection {
             {
                 let upstream_sans = waypoint.workload_and_services_san();
                 let actual_destination = waypoint.workload_socket_addr();
-                trace!("built request to service waypoint proxy");
+                debug!("built request to service waypoint proxy");
                 return Ok(Request {
                     protocol: Protocol::HBONE,
                     source: source_workload,
@@ -380,7 +380,7 @@ impl OutboundConnection {
             .fetch_upstream(source_workload.network.clone(), &source_workload, target)
             .await?
         else {
-            trace!("built request as passthrough; no upstream found");
+            debug!("built request as passthrough; no upstream found");
             return Ok(Request {
                 protocol: Protocol::TCP,
                 source: source_workload,
@@ -411,7 +411,7 @@ impl OutboundConnection {
             if let Some(waypoint) = waypoint {
                 let actual_destination = waypoint.workload_socket_addr();
                 let upstream_sans = waypoint.workload_and_services_san();
-                trace!("built request to workload waypoint proxy");
+                debug!("built request to workload waypoint proxy");
                 return Ok(Request {
                     // Always use HBONE here
                     protocol: Protocol::HBONE,
@@ -439,7 +439,7 @@ impl OutboundConnection {
 
         // For case no waypoint for both side and direct to remote node proxy
         let upstream_sans = us.workload_and_services_san();
-        trace!("built request to workload");
+        debug!("built request to workload");
         Ok(Request {
             protocol: us.workload.protocol,
             source: source_workload,

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -218,7 +218,7 @@ async fn handle(
             true => Some(out_drain),
             false => None,
         };
-        oc.proxy_to_cancellable(stream, remote_addr, host, true, drain)
+        oc.proxy_to_cancellable(stream, remote_addr, host, drain)
             .await;
     });
     Ok(())

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -218,7 +218,7 @@ async fn handle(
             true => Some(out_drain),
             false => None,
         };
-        oc.proxy_to_cancellable(stream, remote_addr, host, drain)
+        oc.proxy_to_cancellable(stream, remote_addr, host, true, drain)
             .await;
     });
     Ok(())

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -32,7 +32,7 @@ pub struct ProxyFactory {
     config: Arc<config::Config>,
     state: DemandProxyState,
     cert_manager: Arc<SecretManager>,
-    proxy_metrics: Option<Arc<Metrics>>,
+    proxy_metrics: Arc<Metrics>,
     dns_metrics: Option<Arc<dns::Metrics>>,
     drain: Watch,
 }
@@ -42,19 +42,10 @@ impl ProxyFactory {
         config: Arc<config::Config>,
         state: DemandProxyState,
         cert_manager: Arc<SecretManager>,
-        proxy_metrics: Option<Metrics>,
+        proxy_metrics: Arc<Metrics>,
         dns_metrics: Option<dns::Metrics>,
         drain: Watch,
     ) -> std::io::Result<Self> {
-        let proxy_metrics = match proxy_metrics {
-            Some(metrics) => Some(Arc::new(metrics)),
-            None => {
-                if config.proxy {
-                    error!("proxy configured but no metrics provided")
-                }
-                None
-            }
-        };
         let dns_metrics = match dns_metrics {
             Some(metrics) => Some(Arc::new(metrics)),
             None => {
@@ -97,7 +88,7 @@ impl ProxyFactory {
                 self.cert_manager.clone(),
                 cm.clone(),
                 self.state.clone(),
-                self.proxy_metrics.clone().unwrap(),
+                self.proxy_metrics.clone(),
                 socket_factory.clone(),
                 proxy_workload_info,
             );

--- a/src/state.rs
+++ b/src/state.rs
@@ -772,7 +772,7 @@ impl DemandProxyState {
 
     /// Looks for the given address to find either a workload or service by IP. If not found
     /// locally, attempts to fetch on-demand.
-    async fn fetch_address(&self, network_addr: &NetworkAddress) -> Option<Address> {
+    pub async fn fetch_address(&self, network_addr: &NetworkAddress) -> Option<Address> {
         // Wait for it on-demand, *if* needed
         debug!(%network_addr.address, "fetch address");
         if let Some(address) = self.state.read().unwrap().find_address(network_addr) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -751,7 +751,7 @@ impl DemandProxyState {
                 metrics,
             )
             .await?
-            .ok_or_else(|| Error::UnknownWaypoint(wl.name.to_string()))?;
+            .ok_or_else(|| Err(Error::UnknownWaypoint(wl.name.to_string())))?;
         Ok(Some(waypoint))
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -21,7 +21,7 @@ use crate::state::service::{Endpoint, LoadBalancerMode, LoadBalancerScopes, Serv
 use crate::state::service::{Service, ServiceDescription};
 use crate::state::workload::{
     address::Address, gatewayaddress::Destination, network_addr, NamespacedHostname,
-    NetworkAddress, WaypointError, Workload, WorkloadStore,
+    NetworkAddress, Workload, WorkloadStore,
 };
 use crate::strng::Strng;
 use crate::tls;
@@ -751,7 +751,7 @@ impl DemandProxyState {
                 metrics,
             )
             .await?
-            .ok_or_else(|| Err(Error::UnknownWaypoint(wl.name.to_string())))?;
+            .ok_or_else(|| Error::UnknownWaypoint(wl.name.to_string()))?;
         Ok(Some(waypoint))
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -751,7 +751,7 @@ impl DemandProxyState {
                 metrics,
             )
             .await?
-            .ok_or_else(|| Err(Error::UnknownWaypoint(wl.name.to_string())))?;
+            .ok_or_else(|| Error::UnknownWaypoint(wl.name.to_string()))?;
         Ok(Some(waypoint))
     }
 

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -701,6 +701,7 @@ mod tests {
     use crate::{cert_fetcher, test_helpers};
     use bytes::Bytes;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+    use prometheus_client::registry::Registry;
     use std::collections::HashSet;
     use std::default::Default;
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -789,11 +790,15 @@ mod tests {
     fn workload_information() {
         initialize_telemetry();
         let state = Arc::new(RwLock::new(ProxyState::default()));
+
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         let demand = DemandProxyState::new(
             state.clone(),
             None,
             ResolverConfig::default(),
             ResolverOpts::default(),
+            metrics,
         );
         let updater = ProxyStateUpdateMutator::new_no_fetch();
 
@@ -1148,11 +1153,14 @@ mod tests {
     fn staged_services_cleanup() {
         initialize_telemetry();
         let state = Arc::new(RwLock::new(ProxyState::default()));
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         let demand = DemandProxyState::new(
             state.clone(),
             None,
             ResolverConfig::default(),
             ResolverOpts::default(),
+            metrics,
         );
         let updater = ProxyStateUpdateMutator::new_no_fetch();
         assert_eq!((state.read().unwrap().workloads.by_addr.len()), 0);
@@ -1263,11 +1271,15 @@ mod tests {
                 .join("localhost.yaml"),
         );
         let state = Arc::new(RwLock::new(ProxyState::default()));
+
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         let demand = DemandProxyState::new(
             state.clone(),
             None,
             ResolverConfig::default(),
             ResolverOpts::default(),
+            metrics,
         );
         let local_client = LocalClient {
             cfg,

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -648,13 +648,8 @@ impl WorkloadStore {
         }
     }
 
-    /// Finds the workload by address.
-    pub fn find_address(&self, addr: &NetworkAddress) -> Option<Workload> {
-        self.by_addr.get(addr).map(|wl| wl.deref().clone())
-    }
-
-    /// Finds the workload by address, as an arc. TODO: make find_address and other functions directly return an Arc too
-    pub fn find_address_arc(&self, addr: &NetworkAddress) -> Option<Arc<Workload>> {
+    /// Finds the workload by address, as an arc.
+    pub fn find_address(&self, addr: &NetworkAddress) -> Option<Arc<Workload>> {
         self.by_addr.get(addr).cloned()
     }
 
@@ -841,12 +836,12 @@ mod tests {
         assert_eq!(state.read().unwrap().workloads.by_uid.len(), 1);
         assert_eq!(
             state.read().unwrap().workloads.find_address(&nw_addr1),
-            Some(Workload {
+            Some(Arc::new(Workload {
                 uid: uid1.as_str().into(),
                 workload_ips: vec![nw_addr1.address],
                 name: "some name".into(),
                 ..test_helpers::test_default_workload()
-            })
+            }))
         );
         assert_eq!(state.read().unwrap().services.num_vips(), 0);
         assert_eq!(state.read().unwrap().services.num_services(), 0);
@@ -855,23 +850,23 @@ mod tests {
         updater.remove(&mut state.write().unwrap(), &"/invalid".into());
         assert_eq!(
             state.read().unwrap().workloads.find_address(&nw_addr1),
-            Some(Workload {
+            Some(Arc::new(Workload {
                 uid: uid1.as_str().into(),
                 workload_ips: vec![nw_addr1.address],
                 name: "some name".into(),
                 ..test_helpers::test_default_workload()
-            })
+            }))
         );
 
         updater.remove(&mut state.write().unwrap(), &uid2.as_str().into());
         assert_eq!(
             state.read().unwrap().workloads.find_address(&nw_addr1),
-            Some(Workload {
+            Some(Arc::new(Workload {
                 uid: uid1.as_str().into(),
                 workload_ips: vec![nw_addr1.address],
                 name: "some name".into(),
                 ..test_helpers::test_default_workload()
-            })
+            }))
         );
 
         updater.remove(&mut state.write().unwrap(), &uid1.as_str().into());

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -34,6 +34,7 @@ use hickory_resolver::config::*;
 use crate::strng;
 use http_body_util::{BodyExt, Full};
 use hyper::Response;
+use prometheus_client::registry::Registry;
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
 use std::fmt::Debug;
@@ -463,11 +464,14 @@ pub fn new_proxy_state(
             .handle(Box::new(&mut vec![XdsUpdate::Update(res)].into_iter()))
             .unwrap();
     }
+    let mut registry = Registry::default();
+    let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
     DemandProxyState::new(
         state,
         None,
         ResolverConfig::default(),
         ResolverOpts::default(),
+        metrics,
     )
 }
 

--- a/src/test_helpers/xds.rs
+++ b/src/test_helpers/xds.rs
@@ -109,12 +109,14 @@ impl AdsServer {
         );
         cfg.xds_on_demand = xds_on_demand;
 
+        let proxy_metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         let state: Arc<RwLock<ProxyState>> = Arc::new(RwLock::new(ProxyState::default()));
         let dstate = DemandProxyState::new(
             state.clone(),
             None,
             ResolverConfig::default(),
             ResolverOpts::default(),
+            proxy_metrics,
         );
         let store_updater = ProxyStateUpdater::new_no_fetch(state);
         let tls_client_fetcher = Box::new(tls::ControlPlaneAuthentication::RootCert(

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -849,7 +849,7 @@ mod tests {
         while start_time.elapsed().unwrap() < TEST_TIMEOUT && !matched {
             sleep(POLL_RATE).await;
             let wl = source.fetch_workload(&ip_network_addr).await;
-            matched = wl == converted; // Option<Workload> is Ok to compare without needing to unwrap
+            matched = wl.as_deref() == converted.as_ref(); // Option<Workload> is Ok to compare without needing to unwrap
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/istio/ztunnel/issues/846
Fixes https://github.com/istio/ztunnel/issues/1009

This does a general cleanup of a lot of accumulated cruft. Lots of minor changes, but main ones:
* Use Arc in more places
* Rework `Request`  and `pstream` type: rename fields to make it clear what are attributes of original workload/waypoint/network gatways. No more "gateway_address", especially not the mutable aspect
* Collapse the fetch upstream, pick_workload_destination, compute various identity sets/SocketAddrs. Now one function does it all for us.
* `State` has metrics now so we don't need to pass it in most functions