### PR TITLE
admin: serialize ALL workloads and services

### DIFF
--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -592,9 +592,9 @@ pub fn network_addr(network: Strng, vip: IpAddr) -> NetworkAddress {
 #[derive(Default, Debug)]
 pub struct WorkloadStore {
     /// byAddress maps workload network addresses to workloads
-    pub(super) by_addr: HashMap<NetworkAddress, Arc<Workload>>,
+    by_addr: HashMap<NetworkAddress, Arc<Workload>>,
     /// byUid maps workload UIDs to workloads
-    by_uid: HashMap<Strng, Arc<Workload>>,
+    pub(super) by_uid: HashMap<Strng, Arc<Workload>>,
     /// byHostname maps workload hostname to workloads.
     by_hostname: HashMap<Strng, Arc<Workload>>,
     // Identity->Set of UIDs. Only stores local nodes


### PR DESCRIPTION
Today we miss some services and workloads because not all of them have
VIPs or IPs. This makes sure we get all of them.

The service change is a breaking change since it was K->V and now its
K->[]V. The k isn't used by istioctl or generally useful (its in the V
anyways).

To handle this, and for consistency and future proofing, I changed all
workload, service, and policy to just be a []V instead. This will
require `istioctl x zc` changes, but they are simple.
