### PR TITLE
Fix regression in source IP spoofing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -205,7 +205,7 @@ pub struct Config {
 
     // If set, explicitly configure whether to use original source.
     // If unset (recommended), this is automatically detected based on permissions.
-    pub explicitly_configure_original_source: Option<bool>,
+    pub require_original_source: Option<bool>,
 
     // CLI args passed to ztunnel at runtime
     pub proxy_args: String,
@@ -436,7 +436,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             pc.concurrency.unwrap_or(DEFAULT_WORKER_THREADS).into(),
         )?,
 
-        explicitly_configure_original_source: parse(ENABLE_ORIG_SRC)?,
+        require_original_source: parse(ENABLE_ORIG_SRC)?,
         proxy_args: parse_args(),
         dns_resolver_cfg,
         dns_resolver_opts,

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,8 +203,9 @@ pub struct Config {
     /// Specify the number of worker threads the Tokio Runtime will use.
     pub num_worker_threads: usize,
 
-    // If true, then use original source proxying
-    pub enable_original_source: Option<bool>,
+    // If set, explicitly configure whether to use original source.
+    // If unset (recommended), this is automatically detected based on permissions.
+    pub explicitly_configure_original_source: Option<bool>,
 
     // CLI args passed to ztunnel at runtime
     pub proxy_args: String,
@@ -435,7 +436,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             pc.concurrency.unwrap_or(DEFAULT_WORKER_THREADS).into(),
         )?,
 
-        enable_original_source: parse(ENABLE_ORIG_SRC)?,
+        explicitly_configure_original_source: parse(ENABLE_ORIG_SRC)?,
         proxy_args: parse_args(),
         dns_resolver_cfg,
         dns_resolver_opts,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -418,7 +418,7 @@ pub(super) fn maybe_set_transparent(
     pi: &ProxyInputs,
     listener: &socket::Listener,
 ) -> Result<bool, Error> {
-    Ok(match pi.cfg.explicitly_configure_original_source {
+    Ok(match pi.cfg.require_original_source {
         Some(true) => {
             // Explicitly enabled. Return error if we cannot set it.
             listener.set_transparent()?;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -418,7 +418,7 @@ pub(super) fn maybe_set_transparent(
     pi: &ProxyInputs,
     listener: &socket::Listener,
 ) -> Result<bool, Error> {
-    Ok(match pi.cfg.enable_original_source {
+    Ok(match pi.cfg.explicitly_configure_original_source {
         Some(true) => {
             // Explicitly enabled. Return error if we cannot set it.
             listener.set_transparent()?;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -60,17 +60,12 @@ impl Inbound {
             .socket_factory
             .tcp_bind(pi.cfg.inbound_addr)
             .map_err(|e| Error::Bind(pi.cfg.inbound_addr, e))?;
-        let transparent = super::maybe_set_transparent(&pi, &listener)?;
-        // Override with our explicitly configured setting
-        let enable_orig_src = pi
-            .cfg
-            .explicitly_configure_original_source
-            .unwrap_or(transparent);
+        let enable_orig_src = super::maybe_set_transparent(&pi, &listener)?;
 
         info!(
             address=%listener.local_addr(),
             component="inbound",
-            transparent,
+            transparent=enable_orig_src,
             "listener established",
         );
         Ok(Inbound {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -62,7 +62,10 @@ impl Inbound {
             .map_err(|e| Error::Bind(pi.cfg.inbound_addr, e))?;
         let transparent = super::maybe_set_transparent(&pi, &listener)?;
         // Override with our explicitly configured setting
-        let enable_orig_src = pi.cfg.enable_original_source.unwrap_or(transparent);
+        let enable_orig_src = pi
+            .cfg
+            .explicitly_configure_original_source
+            .unwrap_or(transparent);
 
         info!(
             address=%listener.local_addr(),

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -49,7 +49,10 @@ impl InboundPassthrough {
 
         let transparent = super::maybe_set_transparent(&pi, &listener)?;
         // Override with our explicitly configured setting
-        let enable_orig_src = pi.cfg.enable_original_source.unwrap_or(transparent);
+        let enable_orig_src = pi
+            .cfg
+            .explicitly_configure_original_source
+            .unwrap_or(transparent);
 
         info!(
             address=%listener.local_addr(),

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -47,17 +47,12 @@ impl InboundPassthrough {
             .tcp_bind(pi.cfg.inbound_plaintext_addr)
             .map_err(|e| Error::Bind(pi.cfg.inbound_plaintext_addr, e))?;
 
-        let transparent = super::maybe_set_transparent(&pi, &listener)?;
-        // Override with our explicitly configured setting
-        let enable_orig_src = pi
-            .cfg
-            .explicitly_configure_original_source
-            .unwrap_or(transparent);
+        let enable_orig_src = super::maybe_set_transparent(&pi, &listener)?;
 
         info!(
             address=%listener.local_addr(),
             component="inbound plaintext",
-            transparent,
+            transparent=enable_orig_src,
             "listener established",
         );
         Ok(InboundPassthrough {

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -53,17 +53,12 @@ impl Outbound {
             .socket_factory
             .tcp_bind(pi.cfg.outbound_addr)
             .map_err(|e| Error::Bind(pi.cfg.outbound_addr, e))?;
-        let transparent = super::maybe_set_transparent(&pi, &listener)?;
-        // Override with our explicitly configured setting
-        let enable_orig_src = pi
-            .cfg
-            .explicitly_configure_original_source
-            .unwrap_or(transparent);
+        let enable_orig_src = super::maybe_set_transparent(&pi, &listener)?;
 
         info!(
             address=%listener.local_addr(),
             component="outbound",
-            transparent,
+            transparent=enable_orig_src,
             "listener established",
         );
         Ok(Outbound {
@@ -671,7 +666,7 @@ mod tests {
                 sock_fact,
                 cert_mgr.clone(),
             ),
-            enable_orig_src: cfg.explicitly_configure_original_source.unwrap_or_default(),
+            enable_orig_src: cfg.require_original_source.unwrap_or_default(),
             hbone_port: cfg.inbound_addr.port(),
         };
 

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -32,6 +32,7 @@ pub(super) struct Socks5 {
     pi: Arc<ProxyInputs>,
     listener: socket::Listener,
     drain: Watch,
+    enable_orig_src: bool,
 }
 
 impl Socks5 {
@@ -41,9 +42,15 @@ impl Socks5 {
             .tcp_bind(pi.cfg.socks5_addr.unwrap())
             .map_err(|e| Error::Bind(pi.cfg.socks5_addr.unwrap(), e))?;
 
+        let transparent = super::maybe_set_transparent(&pi, &listener)?;
+        let enable_orig_src = pi
+            .cfg
+            .explicitly_configure_original_source
+            .unwrap_or(transparent);
         info!(
             address=%listener.local_addr(),
             component="socks5",
+            transparent,
             "listener established",
         );
 
@@ -51,6 +58,7 @@ impl Socks5 {
             pi,
             listener,
             drain,
+            enable_orig_src,
         })
     }
 
@@ -70,6 +78,7 @@ impl Socks5 {
                 // but ProxyInfo is overloaded and only `outbound` should ever use the pool.
                 let pool = crate::proxy::pool::WorkloadHBONEPool::new(
                     self.pi.cfg.clone(),
+                    self.enable_orig_src,
                     self.pi.socket_factory.clone(),
                     self.pi.cert_manager.clone(),
                 );
@@ -80,7 +89,7 @@ impl Socks5 {
                             pi: self.pi.clone(),
                             id: TraceParent::new(),
                             pool,
-                            enable_orig_src: self.pi.cfg.enable_original_source.unwrap_or_default(),
+                            enable_orig_src: self.enable_orig_src,
                             hbone_port: self.pi.cfg.inbound_addr.port(),
                         };
                         tokio::spawn(async move {

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -42,15 +42,12 @@ impl Socks5 {
             .tcp_bind(pi.cfg.socks5_addr.unwrap())
             .map_err(|e| Error::Bind(pi.cfg.socks5_addr.unwrap(), e))?;
 
-        let transparent = super::maybe_set_transparent(&pi, &listener)?;
-        let enable_orig_src = pi
-            .cfg
-            .explicitly_configure_original_source
-            .unwrap_or(transparent);
+        let enable_orig_src = super::maybe_set_transparent(&pi, &listener)?;
+
         info!(
             address=%listener.local_addr(),
             component="socks5",
-            transparent,
+            transparent=enable_orig_src,
             "listener established",
         );
 


### PR DESCRIPTION
We were using the `cfg` in pool since #1040. `cfg` is not whether its used, but rather the intent of the user -- we may enable or disable at runtime.

This renames the field to make it clear it should not be used like this, and fixes the issue. This went through CI due to
https://github.com/istio/ztunnel/issues/1084.