### PR TITLE
mertics: derive identity from TLS handshake

### DIFF
--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -154,16 +154,24 @@ impl CommonTrafficLabels {
         self
     }
 
+    fn with_derived_source_identity(mut self, w: Option<&DerivedWorkload>) -> Self {
+        let Some(w) = w else { return self };
+        // This is the identity from the TLS handshake; this is the most trustworthy source so use it
+        self.source_principal = w.identity.clone().into();
+        self
+    }
+
     fn with_derived_source(mut self, w: Option<&DerivedWorkload>) -> Self {
         let Some(w) = w else { return self };
         self.source_workload = w.workload_name.clone().into();
         self.source_canonical_service = w.app.clone().into();
         self.source_canonical_revision = w.revision.clone().into();
         self.source_workload_namespace = w.namespace.clone().into();
-        self.source_principal = w.identity.clone().into();
         self.source_app = w.workload_name.clone().into();
         self.source_version = w.revision.clone().into();
         self.source_cluster = w.cluster_id.clone().into();
+        // Intentionally not set is source_principal which is set later, to have priority over 'source'
+        // derived_source is the actual identity we got from the TLS
         self
     }
 
@@ -200,6 +208,7 @@ impl From<ConnectionOpen> for CommonTrafficLabels {
                 // Intentionally before with_source; source is more reliable
                 .with_derived_source(c.derived_source.as_ref())
                 .with_source(c.source.as_deref())
+                .with_derived_source_identity(c.derived_source.as_ref())
                 .with_destination(c.destination.as_deref())
                 .with_destination_service(c.destination_service.as_ref())
         }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -29,7 +29,7 @@ use crate::config::ProxyMode;
 use crate::identity::Identity;
 
 use crate::proxy::metrics::Reporter;
-use crate::proxy::{metrics, pool, ConnectionOpen, ConnectionResult};
+use crate::proxy::{metrics, pool, ConnectionOpen, ConnectionResult, DerivedWorkload};
 use crate::proxy::{util, Error, ProxyInputs, TraceParent, BAGGAGE_HEADER, TRACEPARENT_HEADER};
 
 use crate::proxy::h2::H2Stream;
@@ -315,9 +315,18 @@ impl OutboundConnection {
     }
 
     fn conn_metrics_from_request(req: &Request) -> ConnectionOpen {
+        let derived_source = if req.protocol == Protocol::HBONE {
+            Some(DerivedWorkload {
+                // We are going to do mTLS, so report our identity
+                identity: Some(req.source.as_ref().identity()),
+                ..Default::default()
+            })
+        } else {
+            None
+        };
         ConnectionOpen {
             reporter: Reporter::source,
-            derived_source: None,
+            derived_source,
             source: Some(req.source.clone()),
             destination: req.actual_destination_workload.clone(),
             connection_security_policy: if req.protocol == Protocol::HBONE {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -446,8 +446,12 @@ pub mod testing {
         let matched = logs.iter().find(|log| {
             for (k, v) in &want {
                 let Some(have) = log.get(k) else {
-                    // Required key not found, continue
-                    return false;
+                    if !v.is_empty() {
+                        // Required key not found, continue
+                        return false;
+                    } else {
+                        continue;
+                    }
                 };
                 let have = match have {
                     Value::Number(n) => format!("{n}"),
@@ -455,7 +459,7 @@ pub mod testing {
                     _ => panic!("assert_contains currently only supports string/number values"),
                 };
                 // TODO fuzzy match
-                if *v != have {
+                if !v.is_empty() && *v != have {
                     // no match
                     return false;
                 }

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -991,6 +991,9 @@ mod namespaced {
                     "dst.identity",
                     "spiffe://cluster.local/ns/default/sa/server",
                 );
+            } else {
+                want.insert("src.identity", "");
+                want.insert("dst.identity", "");
             }
             telemetry::testing::assert_contains(want);
         }
@@ -1014,6 +1017,9 @@ mod namespaced {
                     "dst.identity",
                     "spiffe://cluster.local/ns/default/sa/server",
                 );
+            } else {
+                want.insert("src.identity", "");
+                want.insert("dst.identity", "");
             }
             telemetry::testing::assert_contains(want);
         }


### PR DESCRIPTION
Today we do an IP lookup. I think this should only fail when we are going through middle proxies or have `!inpod && !src_ip_spoofing` which is ~never.

For the middle proxy case we really should consider getting the other attributes from them as well (baggage) vs lookup the IP.. but at least TLS identity seems critical to get right + has a clear right answer on where to get the attribute from