### PR TITLE
Don't use trust_domain in zds

### DIFF
--- a/proto/zds.proto
+++ b/proto/zds.proto
@@ -16,10 +16,11 @@ message ZdsHello {
 }
 
 message WorkloadInfo {
+  reserved "trust_domain"; // Deprecated
+  reserved 4;
   string name = 1;
   string namespace = 2;
   string service_account = 3;
-  string trust_domain = 4;
 }
 
 // Add a workload to the ztunnel. this will be accompanied by ancillary data contianing

--- a/src/inpod/admin.rs
+++ b/src/inpod/admin.rs
@@ -169,14 +169,13 @@ mod test {
             &Some(crate::state::WorkloadInfo {
                 name: "name".to_string(),
                 namespace: "ns".to_string(),
-                trust_domain: "td".to_string(),
                 service_account: "sa".to_string(),
             }),
             None,
         );
         assert_eq!(
             data(),
-            r#"{"uid1":{"info":{"name":"name","namespace":"ns","serviceAccount":"sa","trustDomain":"td"},"state":"Up"}}"#
+            r#"{"uid1":{"info":{"name":"name","namespace":"ns","serviceAccount":"sa"},"state":"Up"}}"#
         );
         handler.proxy_down(&uid1);
         assert_eq!(data(), "{}");

--- a/src/inpod/protocol.rs
+++ b/src/inpod/protocol.rs
@@ -288,7 +288,6 @@ mod tests {
             name: "test".to_string(),
             namespace: "default".to_string(),
             service_account: "defaultsvc".to_string(),
-            trust_domain: "cluster.local".to_string(),
         };
         let uid = uid(0);
         let data = prep_request(zds::workload_request::Payload::Add(

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -121,7 +121,6 @@ impl WorkloadProxyManagerState {
                     name: w.name,
                     namespace: w.namespace,
                     service_account: w.service_account,
-                    trust_domain: w.trust_domain,
                 });
                 self.add_workload(&poddata.workload_uid, info, netns)
                     .await

--- a/src/state.rs
+++ b/src/state.rs
@@ -87,7 +87,6 @@ impl fmt::Display for Upstream {
 pub struct WorkloadInfo {
     pub name: String,
     pub namespace: String,
-    pub trust_domain: String,
     pub service_account: String,
 }
 
@@ -95,23 +94,17 @@ impl fmt::Display for WorkloadInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}.{}.{} ({})",
-            self.service_account, self.namespace, self.trust_domain, self.name
+            "{}.{} ({})",
+            self.service_account, self.namespace, self.name
         )
     }
 }
 
 impl WorkloadInfo {
-    pub fn new(
-        name: String,
-        namespace: String,
-        trust_domain: String,
-        service_account: String,
-    ) -> Self {
+    pub fn new(name: String, namespace: String, service_account: String) -> Self {
         Self {
             name,
             namespace,
-            trust_domain,
             service_account,
         }
     }
@@ -119,7 +112,6 @@ impl WorkloadInfo {
     pub fn matches(&self, w: &Workload) -> bool {
         self.name == w.name
             && self.namespace == w.namespace
-            && self.trust_domain == w.trust_domain
             && self.service_account == w.service_account
     }
 }
@@ -1099,7 +1091,6 @@ mod tests {
         let wi = WorkloadInfo {
             name: "test".into(),
             namespace: "default".into(),
-            trust_domain: "cluster.local".into(),
             service_account: "defaultacct".into(),
         };
 
@@ -1136,12 +1127,6 @@ mod tests {
         {
             let mut wi = wi.clone();
             wi.service_account = "not-test".into();
-            ctx.dest_workload_info = Some(Arc::new(wi.clone()));
-            assert!(!mock_proxy_state.assert_rbac(&ctx).await);
-        }
-        {
-            let mut wi = wi.clone();
-            wi.trust_domain = "not-test".into();
             ctx.dest_workload_info = Some(Arc::new(wi.clone()));
             assert!(!mock_proxy_state.assert_rbac(&ctx).await);
         }


### PR DESCRIPTION
Goes with https://github.com/istio/istio/pull/51204

There should be no downside to this - `istio-cni` could never return the "correct" value to ztunnel via zds anyway.