### PR TITLE
Fix outbound race condition where we don't have the source workload from XDS yet

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -460,7 +460,7 @@ impl OutboundConnection {
         let source_workload = match self
             .pi
             .state
-            .wait_for_workload(&downstream_network_addr, Duration::from_millis(100))
+            .wait_for_workload(&downstream_network_addr, Duration::from_millis(500))
             .await
         {
             Some(wl) => wl,

--- a/src/state.rs
+++ b/src/state.rs
@@ -958,6 +958,103 @@ mod tests {
     use test_case::test_case;
 
     #[tokio::test]
+    async fn test_wait_for_workload() {
+        let mut state = ProxyState::default();
+        let delayed_wl = Arc::new(test_helpers::test_default_workload());
+        state.workloads.insert(delayed_wl.clone(), true);
+
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
+        let mock_proxy_state = DemandProxyState::new(
+            Arc::new(RwLock::new(state)),
+            None,
+            ResolverConfig::default(),
+            ResolverOpts::default(),
+            metrics,
+        );
+
+        // Some from Address
+        let dst = NetworkAddress {
+            network: strng::EMPTY,
+            address: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        };
+
+        test_helpers::assert_eventually(
+            Duration::from_secs(1),
+            || mock_proxy_state.wait_for_workload(&dst, Duration::from_millis(50)),
+            Some(delayed_wl),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_workload_delay_fails() {
+        let state = ProxyState::default();
+
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
+        let mock_proxy_state = DemandProxyState::new(
+            Arc::new(RwLock::new(state)),
+            None,
+            ResolverConfig::default(),
+            ResolverOpts::default(),
+            metrics,
+        );
+
+        // Some from Address
+        let dst = NetworkAddress {
+            network: strng::EMPTY,
+            address: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        };
+
+        test_helpers::assert_eventually(
+            Duration::from_millis(10),
+            || mock_proxy_state.wait_for_workload(&dst, Duration::from_millis(5)),
+            None,
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_wait_for_workload_eventually() {
+        let state = ProxyState::default();
+        let wrap_state = Arc::new(RwLock::new(state));
+        let delayed_wl = Arc::new(test_helpers::test_default_workload());
+
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
+        let mock_proxy_state = DemandProxyState::new(
+            wrap_state.clone(),
+            None,
+            ResolverConfig::default(),
+            ResolverOpts::default(),
+            metrics,
+        );
+
+        // Some from Address
+        let dst = NetworkAddress {
+            network: strng::EMPTY,
+            address: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        };
+
+        let expected_wl = delayed_wl.clone();
+        let t = tokio::spawn(async move {
+            test_helpers::assert_eventually(
+                Duration::from_millis(500),
+                || mock_proxy_state.wait_for_workload(&dst, Duration::from_millis(250)),
+                Some(expected_wl),
+            )
+            .await;
+        });
+        wrap_state
+            .write()
+            .unwrap()
+            .workloads
+            .insert(delayed_wl, true);
+        t.await.expect("should not fail");
+    }
+
+    #[tokio::test]
     async fn lookup_address() {
         let mut state = ProxyState::default();
         state

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -33,6 +33,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, net};
 use thiserror::Error;
+use tokio::sync::watch::{Receiver, Sender};
 use tracing::{error, trace};
 use xds::istio::workload::ApplicationTunnel as XdsApplicationTunnel;
 use xds::istio::workload::GatewayAddress as XdsGatewayAddress;
@@ -589,8 +590,13 @@ pub fn network_addr(network: Strng, vip: IpAddr) -> NetworkAddress {
 }
 
 /// A WorkloadStore encapsulates all information about workloads in the mesh
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct WorkloadStore {
+    // TODO this could be expanded to Sender<Workload> + a full subscriber/streaming
+    // model, but for now just notifying watchers to wake when _any_ insert happens
+    // is simpler (and only requires a channelsize of 1)
+    insert_notifier: Sender<()>,
+
     /// byAddress maps workload network addresses to workloads
     by_addr: HashMap<NetworkAddress, Arc<Workload>>,
     /// byUid maps workload UIDs to workloads
@@ -601,7 +607,26 @@ pub struct WorkloadStore {
     by_identity: HashMap<Identity, HashSet<Strng>>,
 }
 
+impl Default for WorkloadStore {
+    fn default() -> Self {
+        WorkloadStore {
+            insert_notifier: Sender::new(()),
+            by_addr: Default::default(),
+            by_hostname: Default::default(),
+            by_identity: Default::default(),
+            by_uid: Default::default(),
+        }
+    }
+}
+
 impl WorkloadStore {
+    // Returns a new subscriber. Note that subscribers are only guaranteed to be notified on
+    // new values sent _after_ their creation, so callers should create, check current state,
+    // then sub.
+    pub fn new_subscriber(&self) -> Receiver<()> {
+        self.insert_notifier.subscribe()
+    }
+
     pub fn insert(&mut self, w: Arc<Workload>, track_identity: bool) {
         // First, remove the entry entirely to make sure things are cleaned up properly.
         self.remove(&w.uid);
@@ -621,6 +646,10 @@ impl WorkloadStore {
                 .or_default()
                 .insert(w.uid.clone());
         }
+
+        // We have stored a newly inserted workload, notify watchers
+        // (if any) to wake.
+        self.insert_notifier.send_replace(());
     }
 
     pub fn remove(&mut self, uid: &Strng) -> Option<Workload> {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -222,9 +222,6 @@ where
         mut writer: Writer<'_>,
         event: &Event<'_>,
     ) -> std::fmt::Result {
-        use tracing_log::NormalizeEvent;
-        use tracing_subscriber::fmt::time::FormatTime;
-        use tracing_subscriber::fmt::time::SystemTime;
         let normalized_meta = event.normalized_metadata();
         SystemTime.format_time(&mut writer)?;
         let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -848,8 +848,8 @@ mod tests {
         };
         while start_time.elapsed().unwrap() < TEST_TIMEOUT && !matched {
             sleep(POLL_RATE).await;
-            let wl = source.fetch_workload(&ip_network_addr).await;
-            matched = wl.as_deref() == converted.as_ref(); // Option<Workload> is Ok to compare without needing to unwrap
+            let wl = source.fetch_workload(&ip_network_addr);
+            matched = wl.await.as_deref() == converted.as_ref(); // Option<Workload> is Ok to compare without needing to unwrap
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/51193

~WIP as I need to add tests (and an inpod mode conditional)~

Q: Why didn't we use `demand` here?

A: We don't need to send a new XDS request here - this only (potentially) happens very early in the pod lifecycle, when the pod is making a "startup" outbound request, but XDS hasn't gotten around to pushing us the soure workload yet. It always does/will (or we *should* fail), we just have to wait for it, so sending a demand request for something that's already coming seems chatty - when all we really need to do is stall.

In `inpod` mode, it is always safe to stall-or-fail, as we by-definition should only be making outbound requests for Ambient workloads (which definitely have to be in the CP)