### PR TITLE
dns: drop (unneeded) on-demand DNS caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ accessible by making an HTTP request to either "/stats/prometheus" or "/metrics"
 - DNS Upstream Failures (`istio_dns_upstream_failures_total`)
 - DNS Upstream Request Duration (`istio_dns_upstream_request_duration_seconds`)
 - On Demand DNS Requests (`istio_on_demand_dns_total`)
-- On Demand DNS Cache Misses (`istio_on_demand_dns_cache_misses_total`)
 
 #### In-Pod metrics
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -325,7 +325,11 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
     };
 
     use hickory_resolver::system_conf::read_system_conf;
-    let (dns_resolver_cfg, dns_resolver_opts) = read_system_conf().unwrap();
+    let (dns_resolver_cfg, mut dns_resolver_opts) = read_system_conf().unwrap();
+    // Increase some defaults. Note these are NOT coming from /etc/resolv.conf (only some fields do, we don't override those),
+    // but rather hickory's hardcoded defaults
+    dns_resolver_opts.cache_size = 4096;
+    // TODO: should we override server_ordering_strategy based on our IP support?
 
     let dns_proxy_addr = match pc.proxy_metadata.get(DNS_PROXY_ADDR_METADATA) {
         Some(dns_addr) => dns_addr

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -41,7 +41,6 @@ pub struct Metrics {
 
     // on-demand DNS is not a part of DNS proxy, but part of ztunnel proxy itself
     pub on_demand_dns: Family<OnDemandDnsLabels, Counter>,
-    pub on_demand_dns_cache_misses: Family<OnDemandDnsLabels, Counter>,
 }
 
 impl Metrics {
@@ -311,12 +310,6 @@ impl Metrics {
             "The total number of requests that used on-demand DNS (unstable)",
             on_demand_dns.clone(),
         );
-        let on_demand_dns_cache_misses = Family::default();
-        registry.register(
-            "on_demand_dns_cache_misses",
-            "The total number of cache misses for requests on-demand DNS (unstable)",
-            on_demand_dns_cache_misses.clone(),
-        );
 
         Self {
             connection_opens,
@@ -324,7 +317,6 @@ impl Metrics {
             received_bytes,
             sent_bytes,
             on_demand_dns,
-            on_demand_dns_cache_misses,
         }
     }
 }

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -239,10 +239,8 @@ async fn test_vip_request() {
 }
 
 fn on_demand_dns_assertions(metrics: ParsedMetrics) {
-    for metric in &[
-        ("istio_on_demand_dns_total"),
-        ("istio_on_demand_dns_cache_misses_total"),
-    ] {
+    {
+        let metric = &("istio_on_demand_dns_total");
         let m = metrics.query(metric, &Default::default());
         assert!(m.is_some(), "expected metric {metric}");
         // expecting one cache hit and one cache miss
@@ -253,7 +251,6 @@ fn on_demand_dns_assertions(metrics: ParsedMetrics) {
         let value = m.unwrap()[0].value.clone();
         let expected = match *metric {
             "istio_on_demand_dns_total" => prometheus_parse::Value::Untyped(2.0),
-            "istio_on_demand_dns_cache_misses_total" => prometheus_parse::Value::Untyped(1.0),
             &_ => {
                 panic!("dev error; unexpected metric");
             }


### PR DESCRIPTION
The client we use already has its own cache, probably better than ours.
However, currently we construct it on each request, dropping the cache
(and also probably making connection re-use, etc, not happen). We then
add our own cache on top.

This change stores the client so we can use it as a cache, and drops our
bespoke cache.
