### PR TITLE
identity: triple check proxies can only request appropriate certificates

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -23,6 +23,7 @@ pub mod manager;
 pub use manager::*;
 
 mod auth;
+use crate::state::WorkloadInfo;
 pub use auth::*;
 
 #[cfg(any(test, feature = "testing"))]
@@ -49,6 +50,8 @@ pub enum Error {
     Spiffe(String),
     #[error("the identity is no longer needed")]
     Forgotten,
+    #[error("BUG: identity requested {0}, but only allowed {1:?}")]
+    BugInvalidIdentityRequest(Identity, Arc<WorkloadInfo>),
 }
 
 impl From<tls::Error> for Error {

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -102,6 +102,13 @@ impl fmt::Display for Identity {
 }
 
 impl Identity {
+    pub fn from_parts(td: Strng, ns: Strng, sa: Strng) -> Identity {
+        Identity::Spiffe {
+            trust_domain: td,
+            namespace: ns,
+            service_account: sa,
+        }
+    }
     pub fn to_strng(self: &Identity) -> Strng {
         match self {
             Identity::Spiffe {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -27,9 +27,9 @@ use tokio::net::TcpStream;
 
 use tracing::{debug, info, instrument, trace_span, Instrument};
 
-use super::Error;
+use super::{Error, ScopedSecretManager};
 use crate::baggage::parse_baggage_header;
-use crate::identity::{Identity, SecretManager};
+use crate::identity::Identity;
 
 use crate::proxy::h2::server::H2Request;
 use crate::proxy::metrics::{ConnectionOpen, Reporter};
@@ -447,7 +447,7 @@ impl<'a, T: Display> Display for OptionDisplay<'a, T> {
 
 #[derive(Clone)]
 struct InboundCertProvider {
-    cert_manager: Arc<SecretManager>,
+    cert_manager: ScopedSecretManager,
     state: DemandProxyState,
     network: Strng,
 }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -572,11 +572,13 @@ mod tests {
         };
 
         let sock_fact = std::sync::Arc::new(crate::proxy::DefaultSocketFactory);
-        let cert_mgr = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let cert_mgr = proxy::ScopedSecretManager::new(identity::mock::new_secret_manager(
+            Duration::from_secs(10),
+        ));
         let original_src = false; // for testing, not needed
         let outbound = OutboundConnection {
             pi: Arc::new(ProxyInputs {
-                cert_manager: identity::mock::new_secret_manager(Duration::from_secs(10)),
+                cert_manager: cert_mgr.clone(),
                 state,
                 cfg: cfg.clone(),
                 metrics: test_proxy_metrics(),


### PR DESCRIPTION
This is not fixing a bug, but rather adding a 3rd line of defense
against one of the worst *potentional* vulnerabilities in ztunnel: a
confused deputy causing incorrect certificates to be used.

We know have many checks:
* We check the IP of the request, and give it an identity matching the
  workload associate with that IP
* We check the socket the request landed on is running in the pod
  matching ^
* (new) We check any request identities by a proxy are of the pod we
  are running the proxy in (for inpod). This means if there were a
coding error accidentally requesting the wrong cert, it would be denied.
