### PR TITLE
logs: do not allocate absurd buffers

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -46,7 +46,7 @@ pub fn setup_logging() -> tracing_appender::non_blocking::WorkerGuard {
     Lazy::force(&APPLICATION_START_TIME);
     let (non_blocking, _guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
         .lossy(false)
-        .buffered_lines_limit(128_000)
+        .buffered_lines_limit(1000) // Buffer up to 1000 lines to avoid blocking on logs
         .finish(std::io::stdout());
     tracing_subscriber::registry()
         .with(fmt_layer(non_blocking))


### PR DESCRIPTION
This is 4mb which ends up as 8mb RAM in k8s reporting. Drop it down to
1000 - that is plenty and drops to 2mb RAM usage total. Yay, 4x decrease
for free
