### PR TITLE
Chill out at the proto level as well as the socket level if we have issues connecting to the ambient node agent.

### DIFF
--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -143,7 +143,7 @@ impl WorkloadProxyManager {
     }
 
     pub async fn run(mut self, drain: Watch) -> Result<(), anyhow::Error> {
-        self.run_internal(drain).await;
+        self.run_internal(drain).await?;
 
         // We broke the loop, this can only happen when drain was signaled
         // or we got a terminal protocol error. Drain our proxies.
@@ -158,7 +158,7 @@ impl WorkloadProxyManager {
     // - we have a ProtocolError (we have a serious version mismatch)
     // We should never _have_ a protocol error as the gRPC proto should be forwards+backwards compatible,
     // so this is mostly a safeguard
-    async fn run_internal(&mut self, drain: Watch) {
+    async fn run_internal(&mut self, drain: Watch) -> Result<(), anyhow::Error> {
         // for now just drop block_ready, until we support knowing that our state is in sync.
         debug!("workload proxy manager is running");
         // hold the  release shutdown until we are done with `state.drain` below.
@@ -186,7 +186,8 @@ impl WorkloadProxyManager {
                 }
                 Err(Error::ProtocolError) => {
                     error!("protocol mismatch error while processing stream, shutting down");
-                    return
+                    self.readiness.not_ready();
+                    return Err(anyhow::anyhow!("protocol error"))
                 }
                 Err(e) => {
                     // for other errors, just retry
@@ -196,6 +197,8 @@ impl WorkloadProxyManager {
             debug!("workload proxy manager is NOT ready");
             self.readiness.not_ready();
         };
+
+        Ok(())
     }
 }
 

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -155,6 +155,14 @@ impl WorkloadProxyManager {
     async fn run_internal(&mut self, drain: Watch) {
         // for now just drop block_ready, until we support knowing that our state is in sync.
         debug!("workload proxy manager is running");
+
+        // the UDS socket `connect` has its own retry+backoff logic, but
+        // we also need to backoff at the protocol level if we successfully connect to the socket,
+        // in case we can't agree with the server on the protocol/message format
+        // (so we don't keep succesfully connecting, and spamming them with bad messages)
+        const MAX_BACKOFF: Duration = Duration::from_secs(15);
+        let mut backoff = Duration::from_millis(10);
+
         // hold the  release shutdown until we are done with `state.drain` below.
         let _rs = loop {
             // Accept a connection
@@ -184,6 +192,9 @@ impl WorkloadProxyManager {
             };
             debug!("workload proxy manager is NOT ready");
             self.readiness.not_ready();
+            backoff = std::cmp::min(MAX_BACKOFF, backoff * 2);
+            warn!("could not announce, retrying in {:?}", backoff);
+            tokio::time::sleep(backoff).await;
         };
     }
 }

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -187,7 +187,7 @@ impl WorkloadProxyManager {
                 Err(Error::ProtocolError) => {
                     error!("protocol mismatch error while processing stream, shutting down");
                     self.readiness.not_ready();
-                    return Err(anyhow::anyhow!("protocol error"))
+                    return Err(anyhow::anyhow!("protocol error"));
                 }
                 Err(e) => {
                     // for other errors, just retry


### PR DESCRIPTION
Related to: https://github.com/istio/istio/issues/51519

Context:

We already had a backoff for connecting to the node agent's socket - that's good.

But if we successfully connect to the socket and the connection then fails for some other, protocol-related reason (proto mismatch, server expects a different message, etc etc), we immediately reconnect and try again, which basically defeats the inner backoff.

~So, just have an inner and outer backoff. We could get away with just the outer one, but having two is a little more granular.~

EDIT: Rather than backing off, just treat protocol errors as terminal, and quit.

Connection/stream error -> retry
Protocol error -> bail, shutdown, should never happen.