### PR TITLE
Drop requests to service without any backends

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -354,6 +354,9 @@ pub enum Error {
     #[error("no valid routing destination for workload: {0}")]
     NoValidDestination(Box<Workload>),
 
+    #[error("no healthy upstream: {0}")]
+    NoHealthyUpstream(SocketAddr),
+
     #[error("no ip addresses were resolved for workload: {0}")]
     NoResolvedAddresses(String),
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -388,6 +388,9 @@ impl OutboundConnection {
             .fetch_upstream(source_workload.network.clone(), &source_workload, target)
             .await?
         else {
+            if svc_addressed {
+                return Err(Error::NoHealthyUpstream(target));
+            }
             debug!("built request as passthrough; no upstream found");
             return Ok(Request {
                 protocol: Protocol::TCP,
@@ -836,6 +839,28 @@ mod tests {
                 hbone_destination: "127.0.0.3:80",
                 destination: "127.0.0.10:15008",
             }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn build_request_empty_service() {
+        run_build_request(
+            "127.0.0.1",
+            "127.0.0.3:80",
+            XdsAddressType::Service(XdsService {
+                addresses: vec![XdsNetworkAddress {
+                    network: "".to_string(),
+                    address: vec![127, 0, 0, 3],
+                }],
+                ports: vec![Port {
+                    service_port: 80,
+                    target_port: 8080,
+                }],
+                ..Default::default()
+            }),
+            // Should use the waypoint
+            None,
         )
         .await;
     }


### PR DESCRIPTION
Before we would passthrough. This would then get dropped by kube-proxy
anyways *usually*, but in some cases like SE could just be incorrect
entirely. Either way, rejection is correct.
