### PR TITLE
Improve error log output format

### DIFF
--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -337,7 +337,7 @@ pub fn log_early_deny<E: std::error::Error>(
                 "inbound"
             },
 
-            error = %err,
+            error = format!("{}", err),
 
             "connection failed"
     );


### PR DESCRIPTION
Before/after:
```
error=no healthy upstream: 10.96.69.42:80
error="no healthy upstream: 10.96.69.42:80"
```
