### PR TITLE
Properly handle named targetPort services

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -35,6 +35,7 @@ use crate::proxy::{util, Error, ProxyInputs, TraceParent, BAGGAGE_HEADER, TRACEP
 use crate::proxy::h2::H2Stream;
 use crate::state::service::ServiceDescription;
 use crate::state::workload::{address::Address, NetworkAddress, Protocol, Workload};
+use crate::state::ServiceResolutionMode;
 use crate::{assertions, copy, proxy, socket};
 
 pub struct Outbound {
@@ -385,7 +386,12 @@ impl OutboundConnection {
         };
 
         let Some(us) = state
-            .fetch_upstream(source_workload.network.clone(), &source_workload, target)
+            .fetch_upstream(
+                source_workload.network.clone(),
+                &source_workload,
+                target,
+                ServiceResolutionMode::Standard,
+            )
             .await?
         else {
             if svc_addressed {
@@ -535,17 +541,26 @@ mod tests {
     use crate::test_helpers::helpers::test_proxy_metrics;
     use crate::test_helpers::new_proxy_state;
     use crate::xds::istio::workload::address::Type as XdsAddressType;
-    use crate::xds::istio::workload::NetworkAddress as XdsNetworkAddress;
     use crate::xds::istio::workload::Port;
     use crate::xds::istio::workload::Service as XdsService;
     use crate::xds::istio::workload::TunnelProtocol as XdsProtocol;
     use crate::xds::istio::workload::Workload as XdsWorkload;
+    use crate::xds::istio::workload::{NetworkAddress as XdsNetworkAddress, PortList};
     use crate::{identity, xds};
 
     async fn run_build_request(
         from: &str,
         to: &str,
         xds: XdsAddressType,
+        expect: Option<ExpectedRequest<'_>>,
+    ) {
+        run_build_request_multi(from, to, vec![xds], expect).await;
+    }
+
+    async fn run_build_request_multi(
+        from: &str,
+        to: &str,
+        xds: Vec<XdsAddressType>,
         expect: Option<ExpectedRequest<'_>>,
     ) {
         let cfg = Arc::new(Config {
@@ -569,10 +584,15 @@ mod tests {
             service_account: "waypoint-sa".to_string(),
             ..Default::default()
         };
-        let state = match xds {
-            XdsAddressType::Workload(wl) => new_proxy_state(&[source, waypoint, wl], &[], &[]),
-            XdsAddressType::Service(svc) => new_proxy_state(&[source, waypoint], &[svc], &[]),
-        };
+        let mut workloads = vec![source, waypoint];
+        let mut services = vec![];
+        for x in xds {
+            match x {
+                XdsAddressType::Workload(wl) => workloads.push(wl),
+                XdsAddressType::Service(svc) => services.push(svc),
+            };
+        }
+        let state = new_proxy_state(&workloads, &services, &[]);
 
         let sock_fact = std::sync::Arc::new(crate::proxy::DefaultSocketFactory);
         let cert_mgr = proxy::ScopedSecretManager::new(identity::mock::new_secret_manager(
@@ -861,6 +881,69 @@ mod tests {
             }),
             // Should use the waypoint
             None,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn build_request_target_port() {
+        run_build_request_multi(
+            "127.0.0.1",
+            "127.0.0.3:80",
+            vec![
+                XdsAddressType::Service(XdsService {
+                    hostname: "example.com".to_string(),
+                    addresses: vec![XdsNetworkAddress {
+                        network: "".to_string(),
+                        address: vec![127, 0, 0, 3],
+                    }],
+                    ports: vec![
+                        Port {
+                            service_port: 80,
+                            target_port: 0, // named port
+                        },
+                        Port {
+                            service_port: 8080,
+                            target_port: 0, // named port
+                        },
+                    ],
+                    ..Default::default()
+                }),
+                XdsAddressType::Workload(XdsWorkload {
+                    uid: "cluster1//v1/Pod/default/matching-pod".to_string(),
+                    addresses: vec![Bytes::copy_from_slice(&[127, 0, 0, 2])],
+                    services: std::collections::HashMap::from([(
+                        "/example.com".to_string(),
+                        PortList {
+                            ports: vec![Port {
+                                service_port: 80,
+                                target_port: 1234,
+                            }],
+                        },
+                    )]),
+                    ..Default::default()
+                }),
+                // This pod does not have a port 80 defined at all
+                XdsAddressType::Workload(XdsWorkload {
+                    uid: "cluster1//v1/Pod/default/unmatching-pod".to_string(),
+                    addresses: vec![Bytes::copy_from_slice(&[127, 0, 0, 4])],
+                    services: std::collections::HashMap::from([(
+                        "/example.com".to_string(),
+                        PortList {
+                            ports: vec![Port {
+                                service_port: 8080,
+                                target_port: 9999,
+                            }],
+                        },
+                    )]),
+                    ..Default::default()
+                }),
+            ],
+            Some(ExpectedRequest {
+                protocol: Protocol::TCP,
+                hbone_destination: "",
+                destination: "127.0.0.2:1234",
+            }),
         )
         .await;
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -247,6 +247,7 @@ impl ProxyState {
         network: Strng,
         source_workload: &Workload,
         addr: SocketAddr,
+        resolution_mode: ServiceResolutionMode,
     ) -> Option<(Arc<Workload>, u16, Option<Arc<Service>>)> {
         if let Some(svc) = self
             .services
@@ -254,21 +255,19 @@ impl ProxyState {
         {
             // Randomly pick an upstream
             // TODO: do this more efficiently, and not just randomly
-            let Some(ep) = self.load_balance(source_workload, &svc) else {
+            let Some((ep, wl)) = self.load_balance(source_workload, &svc, addr, resolution_mode)
+            else {
                 debug!("VIP {} has no healthy endpoints", addr);
                 return None;
             };
-            let Some(wl) = self.workloads.find_uid(&ep.workload_uid) else {
-                debug!("failed to fetch workload for {}", ep.workload_uid);
-                return None;
-            };
 
+            let svc_port = svc.ports.get(&addr.port()).copied().unwrap_or_default();
             let target_port = if let Some(&port) = ep.port.get(&addr.port()) {
                 // prefer endpoint port mapping
                 port
-            } else if let Some(&port) = svc.ports.get(&addr.port()) {
+            } else if svc_port > 0 {
                 // otherwise, see if the service has this port
-                port
+                svc_port
             } else if let Some(ApplicationTunnel { port: Some(_), .. }) = &wl.application_tunnel {
                 // when using app tunnel, we don't require the port to be found on the service
                 addr.port()
@@ -293,18 +292,66 @@ impl ProxyState {
         None
     }
 
-    fn load_balance<'a>(&self, src: &Workload, svc: &'a Service) -> Option<&'a Endpoint> {
+    fn load_balance<'a>(
+        &self,
+        src: &Workload,
+        svc: &'a Service,
+        svc_addr: SocketAddr,
+        resolution_mode: ServiceResolutionMode,
+    ) -> Option<(&'a Endpoint, Arc<Workload>)> {
+        let target_port = svc.ports.get(&svc_addr.port()).copied();
+
+        if resolution_mode == ServiceResolutionMode::Standard && target_port.is_none() {
+            // Port doesn't exist on the service at all, this is invalid
+            debug!(
+                "service {} does not have port {}",
+                svc.hostname,
+                svc_addr.port()
+            );
+            return None;
+        };
+
+        let endpoints = svc.endpoints.values().filter_map(|ep| {
+            let Some(wl) = self.workloads.find_uid(&ep.workload_uid) else {
+                debug!("failed to fetch workload for {}", ep.workload_uid);
+                return None;
+            };
+            match resolution_mode {
+                ServiceResolutionMode::Standard => {
+                    if target_port.unwrap_or_default() == 0
+                        && !ep.port.contains_key(&svc_addr.port())
+                    {
+                        // Filter workload out, it doesn't have a matching port
+                        trace!(
+                            "filter endpoint {}, it does not have service port {}",
+                            ep.workload_uid,
+                            svc_addr.port()
+                        );
+                        return None;
+                    }
+                }
+                ServiceResolutionMode::Waypoint => {
+                    if target_port.is_none() && wl.application_tunnel.is_none() {
+                        // We ignore this for app_tunnel; in this case, the port does not need to be on the service.
+                        // This is only valid for waypoints, which are not explicitly addressed by users.
+                        // We do happen to do a lookup by `waypoint-svc:15008`, this is not a literal call on that service;
+                        // the port is not required at all if they have application tunnel, as it will be handled by ztunnel on the other end.
+                        trace!(
+                            "filter waypoint endpoint {}, target port is not defined",
+                            ep.workload_uid
+                        );
+                        return None;
+                    }
+                }
+            }
+            Some((ep, wl))
+        });
+
         match svc.load_balancer {
-            None => svc.endpoints.values().choose(&mut rand::thread_rng()),
+            None => endpoints.choose(&mut rand::thread_rng()),
             Some(ref lb) => {
-                let ranks = svc
-                    .endpoints
-                    .iter()
-                    .filter_map(|(_, ep)| {
-                        let Some(wl) = self.workloads.find_uid(&ep.workload_uid) else {
-                            debug!("failed to fetch workload for {}", ep.workload_uid);
-                            return None;
-                        };
+                let ranks = endpoints
+                    .filter_map(|(ep, wl)| {
                         // Load balancer will define N targets we want to match
                         // Consider [network, region, zone]
                         // Rank = 3 means we match all of them
@@ -336,14 +383,14 @@ impl ProxyState {
                         {
                             return None;
                         }
-                        Some((rank, ep))
+                        Some((rank, ep, wl))
                     })
                     .collect::<Vec<_>>();
-                let max = *ranks.iter().map(|(rank, _ep)| rank).max()?;
+                let max = *ranks.iter().map(|(rank, _ep, _wl)| rank).max()?;
                 ranks
                     .into_iter()
-                    .filter(|(rank, _ep)| *rank == max)
-                    .map(|(_, ep)| ep)
+                    .filter(|(rank, _ep, _wl)| *rank == max)
+                    .map(|(_, ep, wl)| (ep, wl))
                     .choose(&mut rand::thread_rng())
             }
         }
@@ -630,15 +677,16 @@ impl DemandProxyState {
         network: Strng,
         source_workload: &Workload,
         addr: SocketAddr,
+        resolution_mode: ServiceResolutionMode,
     ) -> Result<Option<Upstream>, Error> {
         self.fetch_address(&network_addr(network.clone(), addr.ip()))
             .await;
-        let Some((wl, port, svc)) =
-            self.state
-                .read()
-                .unwrap()
-                .find_upstream(network, source_workload, addr)
-        else {
+        let Some((wl, port, svc)) = self.state.read().unwrap().find_upstream(
+            network,
+            source_workload,
+            addr,
+            resolution_mode,
+        ) else {
             return Ok(None);
         };
         let svc_desc = svc.clone().map(|s| ServiceDescription::from(s.as_ref()));
@@ -668,11 +716,14 @@ impl DemandProxyState {
             }
         };
         let wp_socket_addr = SocketAddr::new(wp_nw_addr.address, gw_address.hbone_mtls_port);
-        self.fetch_upstream(wp_nw_addr.network.clone(), source_workload, wp_socket_addr)
-            .await?
-            .ok_or_else(|| {
-                Error::UnknownWaypoint(format!("waypoint {} not found", wp_nw_addr.address))
-            })
+        self.fetch_upstream(
+            wp_nw_addr.network.clone(),
+            source_workload,
+            wp_socket_addr,
+            ServiceResolutionMode::Waypoint,
+        )
+        .await?
+        .ok_or_else(|| Error::UnknownWaypoint(format!("waypoint {} not found", wp_nw_addr.address)))
     }
 
     pub async fn fetch_service_waypoint(
@@ -763,6 +814,14 @@ impl DemandProxyState {
     }
 }
 
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+pub enum ServiceResolutionMode {
+    // We are resolving a normal service
+    Standard,
+    // We are resolving a waypoint proxy
+    Waypoint,
+}
+
 #[derive(serde::Serialize)]
 pub struct ProxyStateManager {
     #[serde(flatten)]
@@ -839,6 +898,7 @@ mod tests {
     use self::workload::{application_tunnel::Protocol as AppProtocol, ApplicationTunnel};
 
     use super::*;
+    use crate::test_helpers::helpers::initialize_telemetry;
     use crate::test_helpers::TEST_SERVICE_NAMESPACE;
     use crate::{strng, test_helpers};
     use test_case::test_case;
@@ -1022,7 +1082,7 @@ mod tests {
             if let PortMappingTestCase::ServiceMapping = self {
                 return HashMap::from([(80, 8080)]);
             }
-            HashMap::from([])
+            HashMap::from([(80, 0)])
         }
 
         fn endpoint_mapping(&self) -> HashMap<u16, u16> {
@@ -1056,6 +1116,7 @@ mod tests {
     #[test_case(PortMappingTestCase::AppTunnel; "app tunnel")]
     #[tokio::test]
     async fn find_upstream_port_mappings(tc: PortMappingTestCase) {
+        initialize_telemetry();
         let wl = Workload {
             uid: "cluster1//v1/Pod/default/ep_no_port_mapping".into(),
             name: "ep_no_port_mapping".into(),
@@ -1095,8 +1156,13 @@ mod tests {
         state.workloads.insert(wl.clone().into(), true);
         state.services.insert(svc);
 
+        let mode = match tc {
+            PortMappingTestCase::AppTunnel => ServiceResolutionMode::Waypoint,
+            _ => ServiceResolutionMode::Standard,
+        };
+
         let (_, port, _) = state
-            .find_upstream("".into(), &wl, "10.0.0.1:80".parse().unwrap())
+            .find_upstream("".into(), &wl, "10.0.0.1:80".parse().unwrap(), mode)
             .expect("upstream to be found");
         assert_eq!(port, tc.expected_port());
     }
@@ -1170,6 +1236,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_balance() {
+        initialize_telemetry();
         let mut state = ProxyState::default();
         let wl_no_locality = Workload {
             uid: "cluster1//v1/Pod/default/wl_no_locality".into(),
@@ -1297,6 +1364,7 @@ mod tests {
                     LoadBalancerScopes::Zone,
                 ],
             }),
+            ports: HashMap::from([(80u16, 80u16)]),
             ..test_helpers::mock_default_service()
         };
         let failover_svc = Service {
@@ -1309,6 +1377,7 @@ mod tests {
                     LoadBalancerScopes::Zone,
                 ],
             }),
+            ports: HashMap::from([(80u16, 80u16)]),
             ..test_helpers::mock_default_service()
         };
         state
@@ -1321,8 +1390,13 @@ mod tests {
 
         let assert_endpoint = |src: &Workload, svc: &Service, ips: Vec<&str>, desc: &str| {
             let got = state
-                .load_balance(src, svc)
-                .and_then(|ep| ep.address.clone())
+                .load_balance(
+                    src,
+                    svc,
+                    "0.0.0.0:80".parse().unwrap(),
+                    ServiceResolutionMode::Standard,
+                )
+                .and_then(|(ep, _)| ep.address.clone())
                 .map(|addr| addr.address.to_string());
             if ips.is_empty() {
                 assert!(got.is_none(), "{}", desc);

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -700,7 +700,7 @@ pub enum WorkloadError {
 mod tests {
     use super::*;
     use crate::config::ConfigSource;
-    use crate::state::{DemandProxyState, ProxyState};
+    use crate::state::{DemandProxyState, ProxyState, ServiceResolutionMode};
     use crate::test_helpers::helpers::initialize_telemetry;
     use crate::xds::istio::workload::Port as XdsPort;
     use crate::xds::istio::workload::PortList as XdsPortList;
@@ -1258,6 +1258,7 @@ mod tests {
                 strng::EMPTY,
                 &wl,
                 "127.0.1.1:80".parse().unwrap(),
+                ServiceResolutionMode::Standard,
             ) {
                 let n = &workload.name; // borrow name instead of cloning
                 found.insert(n.to_string()); // insert an owned copy of the borrowed n
@@ -1313,6 +1314,7 @@ mod tests {
                 strng::EMPTY,
                 wl.as_ref().unwrap(),
                 "127.10.0.1:80".parse().unwrap(),
+                ServiceResolutionMode::Standard,
             )
             .expect("should get");
         // Make sure we get a valid VIP
@@ -1331,6 +1333,7 @@ mod tests {
                 "remote".into(),
                 wl.as_ref().unwrap(),
                 "127.10.0.2:80".parse().unwrap(),
+                ServiceResolutionMode::Standard,
             )
             .expect("should get");
         // Make sure we get a valid VIP


### PR DESCRIPTION
When we connect to a service with a named targetPort, we should exclude
endpoints that do not have that port defined. Today, we send to it which
doesn't work (port 0 attempted).

This is mostly straightforward but a bit of quirks around app_tunnel.

Note I also made load_balance directly return the workload. This avoids
2 lookups, but also I have 3(!) WIPs locally that need it, so good to
get it in.
