### PR TITLE
Hide error logs when peer shut's down for us

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -115,6 +115,7 @@ fn ignore_shutdown_errors(res: Result<(), io::Error>) -> Result<(), io::Error> {
             if e.kind() == io::ErrorKind::NotConnected
                 || e.kind() == io::ErrorKind::UnexpectedEof =>
         {
+            trace!(err=%e, "failed to shutdown peer, they already shutdown");
             Ok(())
         }
         _ => res,


### PR DESCRIPTION
See https://github.com/istio/istio/discussions/51586 for a real world
example
