### PR TITLE
Make xds wait longer (500ms -> 5s)

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -477,7 +477,7 @@ impl OutboundConnection {
         let source_workload = match self
             .pi
             .state
-            .wait_for_workload(&downstream_network_addr, Duration::from_millis(500))
+            .wait_for_workload(&downstream_network_addr, Duration::from_secs(5))
             .await
         {
             Some(wl) => wl,


### PR DESCRIPTION
500ms is fairly tight. In a real world cluster, I hit this ~100% of the
time. This is with kind single node cluster, so when Istiod is at it's
fastest. Due to debounce, etc, its pretty easy to exceed this time.
