### PR TITLE
Remove mutex on copy path

### DIFF
--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -299,7 +299,7 @@ impl Inbound {
                     .instrument(trace_span!("proxy protocol"))
                     .await?;
             }
-            copy::copy_bidirectional(h2_stream, stream, &result_tracker)
+            copy::copy_bidirectional(h2_stream, copy::TcpStreamSplitter(stream), &result_tracker)
                 .instrument(trace_span!("hbone server"))
                 .await
         };

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -217,13 +217,17 @@ impl InboundPassthrough {
             let result_tracker = result_tracker.clone();
             trace!(%source_addr, %dest_addr, component="inbound plaintext", "connecting...");
 
-            let outbound =
-                super::freebind_connect(orig_src, dest_addr, pi.socket_factory.as_ref())
-                    .await
-                    .map_err(Error::ConnectionFailed)?;
+            let outbound = super::freebind_connect(orig_src, dest_addr, pi.socket_factory.as_ref())
+                .await
+                .map_err(Error::ConnectionFailed)?;
 
             trace!(%source_addr, destination=%dest_addr, component="inbound plaintext", "connected");
-            copy::copy_bidirectional(copy::TcpStreamSplitter(inbound_stream), copy::TcpStreamSplitter(outbound), &result_tracker).await
+            copy::copy_bidirectional(
+                copy::TcpStreamSplitter(inbound_stream),
+                copy::TcpStreamSplitter(outbound),
+                &result_tracker,
+            )
+            .await
         };
 
         let res = conn_guard.handle_connection(send).await;

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -109,7 +109,7 @@ impl InboundPassthrough {
     async fn proxy_inbound_plaintext(
         pi: Arc<ProxyInputs>,
         source_addr: SocketAddr,
-        mut inbound_stream: TcpStream,
+        inbound_stream: TcpStream,
         enable_orig_src: bool,
     ) {
         let start = Instant::now();
@@ -217,13 +217,13 @@ impl InboundPassthrough {
             let result_tracker = result_tracker.clone();
             trace!(%source_addr, %dest_addr, component="inbound plaintext", "connecting...");
 
-            let mut outbound =
+            let outbound =
                 super::freebind_connect(orig_src, dest_addr, pi.socket_factory.as_ref())
                     .await
                     .map_err(Error::ConnectionFailed)?;
 
             trace!(%source_addr, destination=%dest_addr, component="inbound plaintext", "connected");
-            copy::copy_bidirectional(&mut inbound_stream, &mut outbound, &result_tracker).await
+            copy::copy_bidirectional(copy::TcpStreamSplitter(inbound_stream), copy::TcpStreamSplitter(outbound), &result_tracker).await
         };
 
         let res = conn_guard.handle_connection(send).await;

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -315,7 +315,12 @@ impl OutboundConnection {
         .await?;
 
         // Proxying data between downstream and upstream
-        copy::copy_bidirectional(copy::TcpStreamSplitter(stream), copy::TcpStreamSplitter(outbound), connection_stats).await
+        copy::copy_bidirectional(
+            copy::TcpStreamSplitter(stream),
+            copy::TcpStreamSplitter(outbound),
+            connection_stats,
+        )
+        .await
     }
 
     fn conn_metrics_from_request(req: &Request) -> ConnectionOpen {

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -191,7 +191,7 @@ impl OutboundConnection {
 
     async fn proxy_to(
         &mut self,
-        mut source_stream: TcpStream,
+        source_stream: TcpStream,
         source_addr: SocketAddr,
         dest_addr: SocketAddr,
     ) {
@@ -237,7 +237,7 @@ impl OutboundConnection {
                     .await
             }
             Protocol::TCP => {
-                self.proxy_to_tcp(&mut source_stream, &req, &result_tracker)
+                self.proxy_to_tcp(source_stream, &req, &result_tracker)
                     .await
             }
         };
@@ -252,7 +252,7 @@ impl OutboundConnection {
         connection_stats: &ConnectionResult,
     ) -> Result<(), Error> {
         let upgraded = Box::pin(self.send_hbone_request(remote_addr, req)).await?;
-        copy::copy_bidirectional(stream, upgraded, connection_stats).await
+        copy::copy_bidirectional(copy::TcpStreamSplitter(stream), upgraded, connection_stats).await
     }
 
     async fn send_hbone_request(
@@ -296,18 +296,18 @@ impl OutboundConnection {
 
     async fn proxy_to_tcp(
         &mut self,
-        stream: &mut TcpStream,
+        stream: TcpStream,
         req: &Request,
         connection_stats: &ConnectionResult,
     ) -> Result<(), Error> {
         // Create a TCP connection to upstream
         // We do not need spoofing for inbound
         let local = if self.enable_orig_src && !self.pi.cfg.inpod_enabled {
-            super::get_original_src_from_stream(stream)
+            super::get_original_src_from_stream(&stream)
         } else {
             None
         };
-        let mut outbound = super::freebind_connect(
+        let outbound = super::freebind_connect(
             local,
             req.actual_destination,
             self.pi.socket_factory.as_ref(),
@@ -315,7 +315,7 @@ impl OutboundConnection {
         .await?;
 
         // Proxying data between downstream and upstream
-        copy::copy_bidirectional(stream, &mut outbound, connection_stats).await
+        copy::copy_bidirectional(copy::TcpStreamSplitter(stream), copy::TcpStreamSplitter(outbound), connection_stats).await
     }
 
     fn conn_metrics_from_request(req: &Request) -> ConnectionOpen {


### PR DESCRIPTION
I don't see any noticeable delta in perf tests, but in flamegraph this is ~0.2% CPU usage range. Very easy to remove it and drop a mutex on the hotpath