### PR TITLE
Make benchmarks a bit more consistent and realistic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,9 @@ opt-level = 3
 codegen-units = 1
 lto = true
 
+[profile.bench]
+inherits = "quick-release"
+
 [profile.symbols-release]
 inherits = "release"
 debug = true

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -98,8 +98,8 @@ impl WorkloadProxyNetworkHandler {
                 Err(e) => {
                     backoff = std::cmp::min(MAX_BACKOFF, backoff * 2);
                     warn!(
-                        "failed to connect to server: {:?}. retrying in {:?}",
-                        e, backoff
+                        "failed to connect to server {:?}: {:?}. retrying in {:?}",
+                        &self.uds, e, backoff
                     );
                     tokio::time::sleep(backoff).await;
                     continue;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -59,6 +59,8 @@ pub mod xds;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "linux")]
+pub mod namespaced;
+#[cfg(target_os = "linux")]
 pub mod netns;
 
 pub fn can_run_privilged_test() -> bool {

--- a/src/test_helpers/namespaced.rs
+++ b/src/test_helpers/namespaced.rs
@@ -1,0 +1,120 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use libc::getpid;
+use nix::unistd::mkdtemp;
+use std::fs;
+use std::fs::File;
+use std::path::PathBuf;
+
+#[macro_export]
+macro_rules! function {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        &name[..name.len() - 3]
+    }};
+}
+
+/// setup_netns_test prepares a test using network namespaces. This checks we have root,
+/// and automatically setups up a namespace based on the test name (to avoid conflicts).
+#[macro_export]
+macro_rules! setup_netns_test {
+    ($mode:expr) => {{
+        if unsafe { libc::getuid() } != 0 {
+            panic!("CI tests should run as root; this is supposed to happen automatically?");
+        }
+        ztunnel::test_helpers::helpers::initialize_telemetry();
+        let function_name = ztunnel::function!()
+            .strip_prefix(module_path!())
+            .unwrap()
+            .strip_prefix("::")
+            .unwrap();
+        let function_name = function_name
+            .strip_suffix("::{{closure}}")
+            .unwrap_or_else(|| function_name);
+        ztunnel::test_helpers::linux::WorkloadManager::new(function_name, $mode)?
+    }};
+}
+/// initialize_namespace_tests sets up the namespace tests.
+/// These utilize the `unshare` syscall to setup an environment where we:
+/// * Are "root"
+/// * Have our own network namespace to mess with (and create other network namespaces within)
+/// * Have a few shared files re-mounted to not impact the host
+///
+/// This should be called like
+/// ```
+/// #[ctor::ctor]
+//  fn initialize_namespace_tests() {
+//      ztunnel::test_helpers::namespaced::initialize_namespace_tests();
+//  }
+// ```
+/// The special ctor macro ensures this is run *before* any code. In particular, before tokio runtime.
+pub fn initialize_namespace_tests() {
+    use libc::getuid;
+    use nix::mount::{mount, MsFlags};
+    use nix::sched::{unshare, CloneFlags};
+    use std::io::Write;
+
+    // First, drop into a new user namespace.
+    let original_uid = unsafe { getuid() };
+    unshare(CloneFlags::CLONE_NEWUSER).unwrap();
+    let mut data_file = File::create("/proc/self/uid_map").expect("creation failed");
+
+    // Map our current user to root in the new network namespace
+    data_file
+        .write_all(format!("{} {} 1", 0, original_uid).as_bytes())
+        .expect("write failed");
+
+    // Setup a new network namespace
+    unshare(CloneFlags::CLONE_NEWNET).unwrap();
+
+    // Setup a new mount namespace
+    unshare(CloneFlags::CLONE_NEWNS).unwrap();
+
+    // Temporary directory will hold all our mounts
+    let tp = std::env::temp_dir().join("ztunnel_namespaced.XXXXXX");
+    let tmp = mkdtemp(&tp).expect("tmp dir");
+
+    // Create /var/run/netns and if it doesn't exist. Technically this requires root, but any system should have this
+    fs::create_dir_all("/var/run/netns").expect("host netns dir doesn't exist and we are not root");
+    let _ = File::create_new("/run/xtables.lock");
+    // Bind mount /var/run/netns so we can make our own independent network namespaces
+    fs::create_dir(tmp.join("netns")).expect("netns dir");
+    mount(
+        Some(&tmp.join("netns")),
+        "/var/run/netns",
+        None::<&PathBuf>,
+        MsFlags::MS_BIND,
+        None::<&PathBuf>,
+    )
+    .expect("network namespace bindmount");
+
+    // Bind xtables lock so we can access it (otherwise, permission denied)
+    File::create(tmp.join("xtables.lock")).expect("xtables file");
+    mount(
+        Some(&tmp.join("xtables.lock")),
+        "/run/xtables.lock",
+        None::<&PathBuf>,
+        MsFlags::MS_BIND,
+        None::<&PathBuf>,
+    )
+    .expect("xtables bindmount");
+
+    let pid = unsafe { getpid() };
+    eprintln!("Starting test in {tmp:?}. Debug with `sudo nsenter --mount --net -t {pid}`");
+}

--- a/src/test_helpers/netns.rs
+++ b/src/test_helpers/netns.rs
@@ -125,6 +125,7 @@ impl Namespace {
     {
         let name = self.name.clone();
         let node_name = self.node_name.clone();
+        let t_name = format!("{name}-{node_name}");
         let (tx, rx) = sync::mpsc::sync_channel::<()>(0);
         let netns = self.netns.clone();
         // Change network namespaces changes the entire thread, so we want to run each network in its own thread
@@ -133,6 +134,7 @@ impl Namespace {
                 .run(|_n| {
                     let rt = tokio::runtime::Builder::new_current_thread()
                         .enable_all()
+                        .thread_name(t_name)
                         .build()
                         .unwrap();
                     rt.block_on(f(Ready(tx)).instrument(tracing::info_span!(

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -29,7 +29,7 @@ use hyper_util::rt::TokioIo;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::Instant;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use crate::hyper_util::TokioExecutor;
 use crate::{identity, tls};
@@ -77,20 +77,19 @@ pub async fn run_client(
                 transferred += r.read(&mut buf[..length]).await?;
             }
         }
-        debug!(
+        trace!(
             "throughput: {:.3} Gb/s, transferred {} Gb ({:.3}%) in {:?} ({:?})",
-            transferred as f64 / (start.elapsed().as_micros() as f64 / 1_000_000.0) / 0.125e9,
+            transferred as f64 / (start.elapsed().as_secs_f64()) / 0.125e9,
             transferred as f64 / 0.125e9,
             100.0 * transferred as f64 / target as f64,
             start.elapsed(),
             mode
         );
     }
-    let elapsed = start.elapsed().as_micros() as f64 / 1_000_000.0;
-    let throughput = transferred as f64 / elapsed / 0.125e9;
-    info!(
-        "throughput: {:.3} Gb/s, transferred {transferred} in {:?} ({:?})",
-        throughput,
+    debug!(
+        "throughput: {:.3} Gb/s, transferred {} Gb in {:?} ({:?})",
+        transferred as f64 / (start.elapsed().as_secs_f64()) / 0.125e9,
+        transferred as f64 / 0.125e9,
         start.elapsed(),
         mode
     );

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -18,21 +18,15 @@ mod namespaced {
     use futures::future::poll_fn;
     use http_body_util::Empty;
     use std::collections::HashMap;
-    use std::fs;
-    use std::fs::File;
 
     use std::net::{IpAddr, SocketAddr};
 
-    use std::path::PathBuf;
     use std::str::FromStr;
     use std::time::Duration;
     use ztunnel::rbac::{Authorization, RbacMatch, StringMatch};
 
     use hyper::Method;
     use hyper_util::rt::TokioIo;
-    use libc::getpid;
-
-    use nix::unistd::mkdtemp;
 
     use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadBuf};
     use tokio::net::TcpStream;
@@ -43,43 +37,20 @@ mod namespaced {
     use ztunnel::state::workload::{ApplicationTunnel, NetworkAddress};
     use ztunnel::test_helpers::app::ParsedMetrics;
     use ztunnel::test_helpers::app::TestApp;
-    use ztunnel::test_helpers::helpers::initialize_telemetry;
+
     use ztunnel::{identity, strng, telemetry};
 
     use crate::namespaced::WorkloadMode::Captured;
+    use ztunnel::setup_netns_test;
     use ztunnel::test_helpers::linux::TestMode::{InPod, SharedNode};
     use ztunnel::test_helpers::linux::WorkloadManager;
     use ztunnel::test_helpers::netns::{Namespace, Resolver};
     use ztunnel::test_helpers::*;
 
-    macro_rules! function {
-        () => {{
-            fn f() {}
-            fn type_name_of<T>(_: T) -> &'static str {
-                std::any::type_name::<T>()
-            }
-            let name = type_name_of(f);
-            &name[..name.len() - 3]
-        }};
-    }
-
-    /// setup_netns_test prepares a test using network namespaces. This checks we have root,
-    /// and automatically setups up a namespace based on the test name (to avoid conflicts).
-    macro_rules! setup_netns_test {
-        ($mode:expr) => {{
-            if unsafe { libc::getuid() } != 0 {
-                panic!("CI tests should run as root; this is supposed to happen automatically?");
-            }
-            initialize_telemetry();
-            let f = function!()
-                .strip_prefix(module_path!())
-                .unwrap()
-                .strip_prefix("::")
-                .unwrap()
-                .strip_suffix("::{{closure}}")
-                .unwrap();
-            WorkloadManager::new(f, $mode)?
-        }};
+    /// initialize_namespace_tests sets up the namespace tests.
+    #[ctor::ctor]
+    fn initialize_namespace_tests() {
+        ztunnel::test_helpers::namespaced::initialize_namespace_tests();
     }
 
     #[tokio::test]
@@ -836,69 +807,6 @@ mod namespaced {
         )
         .await;
         Ok(())
-    }
-
-    /// initialize_namespace_tests sets up the namespace tests.
-    /// These utilize the `unshare` syscall to setup an environment where we:
-    /// * Are "root"
-    /// * Have our own network namespace to mess with (and create other network namespaces within)
-    /// * Have a few shared files re-mounted to not impact the host
-    /// The special ctor macro ensures this is run *before* any code. In particular, before tokio runtime.
-    #[ctor::ctor]
-    fn initialize_namespace_tests() {
-        use libc::getuid;
-        use nix::mount::{mount, MsFlags};
-        use nix::sched::{unshare, CloneFlags};
-        use std::io::Write;
-
-        // First, drop into a new user namespace.
-        let original_uid = unsafe { getuid() };
-        unshare(CloneFlags::CLONE_NEWUSER).unwrap();
-        let mut data_file = File::create("/proc/self/uid_map").expect("creation failed");
-
-        // Map our current user to root in the new network namespace
-        data_file
-            .write_all(format!("{} {} 1", 0, original_uid).as_bytes())
-            .expect("write failed");
-
-        // Setup a new network namespace
-        unshare(CloneFlags::CLONE_NEWNET).unwrap();
-
-        // Setup a new mount namespace
-        unshare(CloneFlags::CLONE_NEWNS).unwrap();
-
-        // Temporary directory will hold all our mounts
-        let tp = std::env::temp_dir().join("ztunnel_namespaced.XXXXXX");
-        let tmp = mkdtemp(&tp).expect("tmp dir");
-
-        // Create /var/run/netns and if it doesn't exist. Technically this requires root, but any system should have this
-        fs::create_dir_all("/var/run/netns")
-            .expect("host netns dir doesn't exist and we are not root");
-        let _ = File::create_new("/run/xtables.lock");
-        // Bind mount /var/run/netns so we can make our own independent network namespaces
-        fs::create_dir(tmp.join("netns")).expect("netns dir");
-        mount(
-            Some(&tmp.join("netns")),
-            "/var/run/netns",
-            None::<&PathBuf>,
-            MsFlags::MS_BIND,
-            None::<&PathBuf>,
-        )
-        .expect("network namespace bindmount");
-
-        // Bind xtables lock so we can access it (otherwise, permission denied)
-        File::create(tmp.join("xtables.lock")).expect("xtables file");
-        mount(
-            Some(&tmp.join("xtables.lock")),
-            "/run/xtables.lock",
-            None::<&PathBuf>,
-            MsFlags::MS_BIND,
-            None::<&PathBuf>,
-        )
-        .expect("xtables bindmount");
-
-        let pid = unsafe { getpid() };
-        eprintln!("Starting test in {tmp:?}. Debug with `sudo nsenter --mount --net -t {pid}`");
     }
 
     const TEST_VIP: &str = "10.10.0.1";


### PR DESCRIPTION
* Make benchmark use network namespaces to realistically simulate real load. Note this importantly means we have 2 ztunnels on the path (instead of one sending to itself), and each runs with 2 worker threads instead of host CPU count.
* Now throughput matches what I see in real cluster
* Make RBAC tests actually useful. They were testing throughput which is not right; RBAC is only asserted at connection establishment, and we pre-warm the connections for throughput. Instead isolate to explicitly just RBAC tests.
* Make all throughput units useful (Gb/s or connections/s or requests/s)