### PR TITLE
Drop unused field in WDS

### DIFF
--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -204,10 +204,8 @@ message Workload {
   // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.
   bool native_tunnel = 14;
 
-  
-  // If an application, such as a sandwiched waypoint proxy, supports
-  // directly receiving information from zTunnel they can set application_protocol.
-  // This supersedes native_tunnel.
+  // If an application, such as a sandwiched waypoint proxy, supports directly
+  // receiving information from zTunnel they can set application_protocol.
   ApplicationTunnel application_tunnel = 23;
 
   // The services for which this workload is an endpoint.
@@ -274,7 +272,6 @@ enum TunnelProtocol {
   // Future options may include things like QUIC/HTTP3, etc.
 }
 
-
 // ApplicationProtocol specifies a workload  (application or gateway) can
 // consume tunnel information.
 message ApplicationTunnel {
@@ -290,7 +287,7 @@ message ApplicationTunnel {
     PROXY = 1;
   }
 
-  // A target natively handles this type of traffic.  
+  // A target natively handles this type of traffic.
   Protocol protocol = 1;
 
   // optional: if set, traffic should be sent to this port after the last zTunnel hop
@@ -307,10 +304,8 @@ message GatewayAddress {
   }
   // port to reach the gateway at for mTLS HBONE connections
   uint32 hbone_mtls_port = 3;
-  // port to reach the gateway at for single tls HBONE connections
-  // used for sending unauthenticated traffic originating outside the mesh to a waypoint-enabled destination
-  // A value of 0 = unset
-  uint32 hbone_single_tls_port = 4;
+  reserved "hbone_single_tls_port";
+  reserved 4;
 }
 
 // NetworkAddress represents an address bound to a specific network.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -625,7 +625,6 @@ mod tests {
                     address: [127, 0, 0, 10].to_vec(),
                 })),
                 hbone_mtls_port: 15008,
-                hbone_single_tls_port: 15003,
             }),
             network_gateway: Some(XdsGatewayAddress {
                 destination: Some(XdsDestination::Address(XdsNetworkAddress {
@@ -633,7 +632,6 @@ mod tests {
                     address: [127, 0, 0, 11].to_vec(),
                 })),
                 hbone_mtls_port: 15008,
-                hbone_single_tls_port: 15003,
             }),
             tunnel_protocol: Default::default(),
             uid: "uid".to_string(),
@@ -776,8 +774,7 @@ mod tests {
         assert!(resp_str.contains(
             r#"waypoint": {
         "destination": "defaultnw/127.0.0.10",
-        "hboneMtlsPort": 15008,
-        "hboneSingleTlsPort": 15003
+        "hboneMtlsPort": 15008
       }"#
         ));
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -832,7 +832,6 @@ mod tests {
                 address: IpAddr::V4(mock_default_gateway_ipaddr()),
             }),
             hbone_mtls_port: 15008,
-            hbone_single_tls_port: Some(15003),
         }
     }
 
@@ -843,7 +842,6 @@ mod tests {
                 hostname: "gateway".into(),
             }),
             hbone_mtls_port: 15008,
-            hbone_single_tls_port: Some(15003),
         }
     }
 

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -701,7 +701,6 @@ mod tests {
                     address: s.parse().expect("a valid waypoint IP"),
                 }),
                 hbone_mtls_port: 15008,
-                hbone_single_tls_port: None,
             })
         }
 
@@ -715,7 +714,6 @@ mod tests {
                     address: w.parse().expect("a valid waypoint IP"),
                 }),
                 hbone_mtls_port: 15008,
-                hbone_single_tls_port: None,
             })
         }
     }

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -792,7 +792,6 @@ mod tests {
                         },
                     )),
                     hbone_mtls_port: 15008,
-                    hbone_single_tls_port: 15003,
                 }),
                 ..Default::default()
             }),
@@ -821,7 +820,6 @@ mod tests {
                         },
                     )),
                     hbone_mtls_port: 15008,
-                    hbone_single_tls_port: 15003,
                 }),
                 ..Default::default()
             }),
@@ -857,7 +855,6 @@ mod tests {
                         },
                     )),
                     hbone_mtls_port: 15008,
-                    hbone_single_tls_port: 15003,
                 }),
                 ..Default::default()
             }),

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -97,7 +97,6 @@ impl From<xds::istio::workload::WorkloadStatus> for HealthStatus {
 pub struct GatewayAddress {
     pub destination: gatewayaddress::Destination,
     pub hbone_mtls_port: u16,
-    pub hbone_single_tls_port: Option<u16>,
 }
 
 pub mod gatewayaddress {
@@ -310,11 +309,6 @@ impl TryFrom<&XdsGatewayAddress> for GatewayAddress {
                             byte_to_ip(&Bytes::copy_from_slice(&addr.address))?,
                         )),
                         hbone_mtls_port: value.hbone_mtls_port as u16,
-                        hbone_single_tls_port: if value.hbone_single_tls_port == 0 {
-                            None
-                        } else {
-                            Some(value.hbone_single_tls_port as u16)
-                        },
                     }
                 }
                 xds::istio::workload::gateway_address::Destination::Hostname(hn) => {
@@ -324,11 +318,6 @@ impl TryFrom<&XdsGatewayAddress> for GatewayAddress {
                             hostname: Strng::from(&hn.hostname),
                         }),
                         hbone_mtls_port: value.hbone_mtls_port as u16,
-                        hbone_single_tls_port: if value.hbone_single_tls_port == 0 {
-                            None
-                        } else {
-                            Some(value.hbone_single_tls_port as u16)
-                        },
                     }
                 }
             },

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -367,7 +367,6 @@ pub fn local_xds_config(
                         address: waypoint_ip,
                     }),
                     hbone_mtls_port: 15008,
-                    hbone_single_tls_port: Some(15003),
                 }),
                 ..test_default_workload()
             },

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -295,7 +295,6 @@ impl<'a> TestServiceBuilder<'a> {
                 address: waypoint,
             }),
             hbone_mtls_port: 15008,
-            hbone_single_tls_port: Some(15003),
         });
         self
     }
@@ -363,7 +362,6 @@ impl<'a> TestWorkloadBuilder<'a> {
                 address: waypoint,
             }),
             hbone_mtls_port: 15008,
-            hbone_single_tls_port: Some(15003),
         });
         self
     }


### PR DESCRIPTION
This is cleanup from an earlier change on Istio side. This is deadcode.

workload.proto changes are copy+paste from Istio
