### PR TITLE
Support ip_families field in service

### DIFF
--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -62,7 +62,7 @@ message Service {
   string hostname = 3;
   // Address represents the addresses the service can be reached at.
   // There may be multiple addresses for a single service if it resides in multiple networks,
-  // multiple clusters, and/or if it's dual stack (TODO: support dual stack).
+  // multiple clusters, and/or if it's dual stack.
   // For a headless kubernetes service, this list will be empty.
   repeated NetworkAddress addresses = 4;
   // Ports for the service.
@@ -79,6 +79,20 @@ message Service {
   // Note: this applies only to connecting directly to the workload; when waypoints are used, the waypoint's load_balancing
   // configuration is used.
   LoadBalancing load_balancing = 8;
+
+  // IP families provides configuration about the IP families this service supports.
+  IPFamilies ip_families = 9;
+}
+
+enum IPFamilies {
+  // AUTOMATIC is inferred from the configured addresses.
+  AUTOMATIC = 0;
+  // Only IPv4 is supported
+  IPV4_ONLY = 1;
+  // Only IPv6 is supported
+  IPV6_ONLY = 2;
+  // Both IPv4 and IPv6 is supported
+  DUAL = 3;
 }
 
 message LoadBalancing {
@@ -162,7 +176,6 @@ message Workload {
   // a workload that backs a Kubernetes service will typically have only endpoints. A
   // workload that backs a headless Kubernetes service, however, will have both
   // addresses as well as a hostname used for direct access to the headless endpoint.
-  // TODO: support this field
   string hostname = 21;
 
   // Network represents the network this workload is on. This may be elided for the default network.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -685,6 +685,7 @@ mod tests {
                 routing_preference: vec![1, 2],
                 mode: 1,
             }), // ..Default::default() // intentionally don't default. we want all fields populated
+            ip_families: 0,
         };
 
         let auth = XdsAuthorization {

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
-use std::fmt::{Display, Formatter};
-use std::net::{IpAddr, SocketAddr};
-use std::ops::Deref;
-use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
-
 use drain::Watch;
 use hickory_proto::error::ProtoErrorKind;
 use hickory_proto::op::ResponseCode;
@@ -34,6 +26,13 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
+use std::collections::HashSet;
+use std::fmt::{Display, Formatter};
+use std::net::{IpAddr, SocketAddr};
+use std::ops::Deref;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::proxy::SocketFactory;
@@ -426,11 +425,15 @@ impl Store {
             Address::Service(service) => {
                 if service.vips.is_empty() {
                     // Headless service. Use the endpoint IPs.
+                    let family = service.ip_families;
                     service
                         .endpoints
                         .iter()
                         .filter_map(|(_, ep)| match &ep.address {
                             Some(addr) => {
+                                if let Some(false) = family.map(|f| f.accepts_ip(addr.address)) {
+                                    return None;
+                                }
                                 if is_record_type(&addr.address, record_type) {
                                     Some(addr.address)
                                 } else {
@@ -839,6 +842,7 @@ impl Forwarder for SystemForwarder {
 
 #[cfg(test)]
 mod tests {
+    use futures_util::StreamExt;
     use std::cmp::Ordering;
     use std::collections::HashMap;
     use std::net::{SocketAddrV4, SocketAddrV6};
@@ -855,11 +859,11 @@ mod tests {
     };
     use crate::test_helpers::helpers::initialize_telemetry;
     use crate::test_helpers::{new_proxy_state, test_default_workload};
-    use crate::xds::istio::workload::NetworkAddress as XdsNetworkAddress;
     use crate::xds::istio::workload::Port as XdsPort;
     use crate::xds::istio::workload::PortList as XdsPortList;
     use crate::xds::istio::workload::Service as XdsService;
     use crate::xds::istio::workload::Workload as XdsWorkload;
+    use crate::xds::istio::workload::{IpFamilies, NetworkAddress as XdsNetworkAddress};
     use crate::{metrics, test_helpers};
 
     const NS1: &str = "ns1";
@@ -1215,11 +1219,34 @@ mod tests {
                 ..Default::default()
             },
             Case {
-                name: "success: headless service returns workload ips",
+                name: "success: headless service returns workload ips for A",
                 host: "headless.ns1.svc.cluster.local.",
                 expect_records: vec![
                     a(n("headless.ns1.svc.cluster.local."), ipv4("30.30.30.30")),
                     a(n("headless.ns1.svc.cluster.local."), ipv4("31.31.31.31"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: headless service returns workload ips for AAAA",
+                host: "headless.ns1.svc.cluster.local.",
+                query_type: RecordType::AAAA,
+                expect_records: vec![
+                    aaaa(n("headless.ns1.svc.cluster.local."), ipv6("2001:db8::30")),
+                    aaaa(n("headless.ns1.svc.cluster.local."), ipv6("2001:db8::31"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: headless-ipv6 service returns records for AAAA",
+                host: "headless-ipv6.ns1.svc.cluster.local.",
+                query_type: RecordType::AAAA,
+                expect_records: vec![
+                aaaa(n("headless-ipv6.ns1.svc.cluster.local."), ipv6("2001:db8::33"))],
+                ..Default::default()
+            },
+            Case {
+                name: "success: headless-ipv6 service returns empty for A",
+                host: "headless-ipv6.ns1.svc.cluster.local.",
+                expect_records: vec![],
                 ..Default::default()
             },
             // TODO(https://github.com/istio/ztunnel/issues/1119)
@@ -1286,7 +1313,7 @@ mod tests {
             for (protocol, mut client) in [("tcp", tcp_client.clone()), ("udp", udp_client.clone())]
             {
                 let c = c.clone();
-                tasks.push(tokio::task::spawn(async move {
+                tasks.push(async move {
                     let name = format!("[{protocol}] {}", c.name);
                     let resp = send_request(&mut client, n(c.host), c.query_type).await;
                     assert_eq!(c.expect_authoritative, resp.authoritative(), "{}", name);
@@ -1303,12 +1330,11 @@ mod tests {
                         }
                         assert_eq!(c.expect_records, actual, "{}", name);
                     }
-                }));
+                });
             }
         }
-        for t in tasks {
-            t.await.unwrap();
-        }
+        let stream = futures::stream::iter(tasks).buffer_unordered(10);
+        let _ = stream.collect::<Vec<_>>().await;
     }
 
     #[tokio::test]
@@ -1575,6 +1601,8 @@ mod tests {
     }
 
     fn state() -> DemandProxyState {
+        let mut headless_ipv6 = xds_service("headless-ipv6", NS1, &[]);
+        headless_ipv6.set_ip_families(IpFamilies::Ipv6Only);
         let services = vec![
             xds_external_service("www.google.com", &[na(NW1, "1.1.1.1")]),
             xds_service("productpage", NS1, &[na(NW1, "9.9.9.9")]),
@@ -1615,6 +1643,7 @@ mod tests {
             xds_service("headless", NS1, &[]),
             xds_external_service("headless.example.com", &[]),
             xds_external_service("headless-no-endpoints.example.com", &[]),
+            headless_ipv6,
         ];
 
         let workloads = vec![
@@ -1627,7 +1656,7 @@ mod tests {
                 "headless.pod0.ns1.svc.cluster.local",
                 &NW1,
                 &[format!("{}/{}", NS1, kube_fqdn("headless", NS1)).as_str()],
-                &[ip("30.30.30.30")],
+                &[ip("30.30.30.30"), ip("2001:db8::30")],
             ),
             xds_workload(
                 "headless1",
@@ -1635,7 +1664,7 @@ mod tests {
                 "headless.pod1.ns1.svc.cluster.local",
                 &NW1,
                 &[format!("{}/{}", NS1, kube_fqdn("headless", NS1)).as_str()],
-                &[ip("31.31.31.31")],
+                &[ip("31.31.31.31"), ip("2001:db8::31")],
             ),
             xds_workload(
                 "headless-external",
@@ -1643,7 +1672,15 @@ mod tests {
                 "",
                 &NW1,
                 &[format!("{}/{}", NS1, "headless.example.com").as_str()],
-                &[ip("32.32.32.32")],
+                &[ip("32.32.32.32"), ip("2001:db8::32")],
+            ),
+            xds_workload(
+                "headless2",
+                NS1,
+                "headless2.pod2.ns1.svc.cluster.local",
+                &NW1,
+                &[format!("{}/{}", NS1, kube_fqdn("headless-ipv6", NS1)).as_str()],
+                &[ip("33.33.33.33"), ip("2001:db8::33")],
             ),
         ];
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -822,6 +822,7 @@ mod tests {
             subject_alt_names: vec![],
             waypoint: None,
             load_balancer: None,
+            ip_families: None,
         }
     }
 

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -630,6 +630,7 @@ mod tests {
                 subject_alt_names: vec![strng::format!("{name}.default.svc.cluster.local")],
                 waypoint: waypoint.service_attached(),
                 load_balancer: None,
+                ip_families: None,
             }
         });
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -1024,12 +1024,7 @@ mod tests {
             tunnel_protocol: 1,
             services: std::collections::HashMap::from([(
                 "/example.com".to_string(),
-                PortList {
-                    ports: vec![Port {
-                        service_port: 80,
-                        target_port: 1234,
-                    }],
-                },
+                PortList { ports: vec![] },
             )]),
             ..Default::default()
         });
@@ -1046,16 +1041,10 @@ mod tests {
                         address: "::3".parse::<Ipv6Addr>().unwrap().octets().into(),
                     },
                 ],
-                ports: vec![
-                    Port {
-                        service_port: 80,
-                        target_port: 0, // named port
-                    },
-                    Port {
-                        service_port: 8080,
-                        target_port: 0, // named port
-                    },
-                ],
+                ports: vec![Port {
+                    service_port: 80,
+                    target_port: 80,
+                }],
                 ..Default::default()
             };
             s.set_ip_families(f);
@@ -1068,7 +1057,7 @@ mod tests {
             vec![svc(IpFamilies::Ipv6Only), workload.clone()],
             Some(ExpectedRequest {
                 protocol: Protocol::HBONE,
-                hbone_destination: "[ff06::c3]:1234",
+                hbone_destination: "[ff06::c3]:80",
                 destination: "[ff06::c3]:15008",
             }),
         )
@@ -1080,7 +1069,7 @@ mod tests {
             vec![svc(IpFamilies::Ipv4Only), workload.clone()],
             Some(ExpectedRequest {
                 protocol: Protocol::HBONE,
-                hbone_destination: "127.0.0.2:1234",
+                hbone_destination: "127.0.0.2:80",
                 destination: "127.0.0.2:15008",
             }),
         )
@@ -1092,7 +1081,7 @@ mod tests {
             vec![svc(IpFamilies::Dual), workload.clone()],
             Some(ExpectedRequest {
                 protocol: Protocol::HBONE,
-                hbone_destination: "127.0.0.2:1234",
+                hbone_destination: "127.0.0.2:80",
                 destination: "127.0.0.2:15008",
             }),
         )
@@ -1104,7 +1093,7 @@ mod tests {
             vec![svc(IpFamilies::Dual), workload.clone()],
             Some(ExpectedRequest {
                 protocol: Protocol::HBONE,
-                hbone_destination: "[ff06::c3]:1234",
+                hbone_destination: "[ff06::c3]:80",
                 destination: "[ff06::c3]:15008",
             }),
         )

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -562,13 +562,13 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::proxy::connection_manager::ConnectionManager;
-    use crate::test_helpers::helpers::test_proxy_metrics;
+    use crate::test_helpers::helpers::{initialize_telemetry, test_proxy_metrics};
     use crate::test_helpers::new_proxy_state;
     use crate::xds::istio::workload::address::Type as XdsAddressType;
-    use crate::xds::istio::workload::Port;
     use crate::xds::istio::workload::Service as XdsService;
     use crate::xds::istio::workload::TunnelProtocol as XdsProtocol;
     use crate::xds::istio::workload::Workload as XdsWorkload;
+    use crate::xds::istio::workload::{IpFamilies, Port};
     use crate::xds::istio::workload::{NetworkAddress as XdsNetworkAddress, PortList};
     use crate::{identity, xds};
 
@@ -595,7 +595,10 @@ mod tests {
             uid: "cluster1//v1/Pod/ns/source-workload".to_string(),
             name: "source-workload".to_string(),
             namespace: "ns".to_string(),
-            addresses: vec![Bytes::copy_from_slice(&[127, 0, 0, 1])],
+            addresses: vec![
+                Bytes::copy_from_slice(&[127, 0, 0, 1]),
+                Bytes::copy_from_slice("::1".parse::<Ipv6Addr>().unwrap().octets().as_slice()),
+            ],
             node: "local-node".to_string(),
             ..Default::default()
         };
@@ -1004,6 +1007,105 @@ mod tests {
                 protocol: Protocol::TCP,
                 hbone_destination: "",
                 destination: "[ff06::c3]:80",
+            }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn service_ip_families() {
+        initialize_telemetry();
+        let workload = XdsAddressType::Workload(XdsWorkload {
+            uid: "cluster1//v1/Pod/default/dual".to_string(),
+            addresses: vec![
+                Bytes::copy_from_slice(&[127, 0, 0, 2]),
+                Bytes::copy_from_slice("ff06::c3".parse::<Ipv6Addr>().unwrap().octets().as_slice()),
+            ],
+            tunnel_protocol: 1,
+            services: std::collections::HashMap::from([(
+                "/example.com".to_string(),
+                PortList {
+                    ports: vec![Port {
+                        service_port: 80,
+                        target_port: 1234,
+                    }],
+                },
+            )]),
+            ..Default::default()
+        });
+        let svc = |f: IpFamilies| {
+            let mut s = XdsService {
+                hostname: "example.com".to_string(),
+                addresses: vec![
+                    XdsNetworkAddress {
+                        network: "".to_string(),
+                        address: vec![127, 0, 0, 3],
+                    },
+                    XdsNetworkAddress {
+                        network: "".to_string(),
+                        address: "::3".parse::<Ipv6Addr>().unwrap().octets().into(),
+                    },
+                ],
+                ports: vec![
+                    Port {
+                        service_port: 80,
+                        target_port: 0, // named port
+                    },
+                    Port {
+                        service_port: 8080,
+                        target_port: 0, // named port
+                    },
+                ],
+                ..Default::default()
+            };
+            s.set_ip_families(f);
+            XdsAddressType::Service(s)
+        };
+        // V6 only should always use V6 IP
+        run_build_request_multi(
+            "127.0.0.1",
+            "127.0.0.3:80",
+            vec![svc(IpFamilies::Ipv6Only), workload.clone()],
+            Some(ExpectedRequest {
+                protocol: Protocol::HBONE,
+                hbone_destination: "[ff06::c3]:1234",
+                destination: "[ff06::c3]:15008",
+            }),
+        )
+        .await;
+        // V4 only should always use V4 IP
+        run_build_request_multi(
+            "127.0.0.1",
+            "127.0.0.3:80",
+            vec![svc(IpFamilies::Ipv4Only), workload.clone()],
+            Some(ExpectedRequest {
+                protocol: Protocol::HBONE,
+                hbone_destination: "127.0.0.2:1234",
+                destination: "127.0.0.2:15008",
+            }),
+        )
+        .await;
+        // Dual stack should always prefer the original family (here ipv4)
+        run_build_request_multi(
+            "127.0.0.1",
+            "127.0.0.3:80",
+            vec![svc(IpFamilies::Dual), workload.clone()],
+            Some(ExpectedRequest {
+                protocol: Protocol::HBONE,
+                hbone_destination: "127.0.0.2:1234",
+                destination: "127.0.0.2:15008",
+            }),
+        )
+        .await;
+        // Dual stack should always prefer the original family (here ipv6)
+        run_build_request_multi(
+            "::1",
+            "[::3]:80",
+            vec![svc(IpFamilies::Dual), workload.clone()],
+            Some(ExpectedRequest {
+                protocol: Protocol::HBONE,
+                hbone_destination: "[ff06::c3]:1234",
+                destination: "[ff06::c3]:15008",
             }),
         )
         .await;

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -915,6 +915,7 @@ mod tests {
                     subject_alt_names: vec![],
                     waypoint: None,
                     load_balancing: None,
+                    ip_families: 0,
                 },
             )
             .unwrap();
@@ -947,6 +948,7 @@ mod tests {
                     subject_alt_names: vec![],
                     waypoint: None,
                     load_balancing: None,
+                    ip_families: 0,
                 },
             )
             .unwrap();
@@ -1002,6 +1004,7 @@ mod tests {
                     subject_alt_names: vec![],
                     waypoint: None,
                     load_balancing: None,
+                    ip_families: 0,
                 },
             )
             .unwrap();

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -187,6 +187,7 @@ pub fn mock_default_service() -> Service {
         subject_alt_names: vec![],
         waypoint: None,
         load_balancer: None,
+        ip_families: None,
     }
 }
 
@@ -292,6 +293,7 @@ fn test_custom_svc(
         subject_alt_names: vec!["spiffe://cluster.local/ns/default/sa/default".into()],
         waypoint: None,
         load_balancer: None,
+        ip_families: None,
     })
 }
 

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -270,6 +270,7 @@ impl<'a> TestServiceBuilder<'a> {
                 subject_alt_names: vec![],
                 waypoint: None,
                 load_balancer: None,
+                ip_families: None,
             },
             manager,
         }


### PR DESCRIPTION
Istio side https://github.com/istio/istio/pull/51606

This implements the new ip_families field for services:

Add a new IPFamilies field to service. This is used for two things:
  1. DNS lookups for headless services MUST not return unsupported families. Without this field, it is impossible to know which workload IPs to filter
  2. When we select a workload IP after resolving a service, we must pick a supported family. This is _possible_ to do without for non-headless services (by inferring from the VIPs field), but easier to be explicit.

Fixes https://github.com/istio/ztunnel/issues/1152