### PR TITLE
Add option for disabling IPv6

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -341,7 +341,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
     // TODO: should we override server_ordering_strategy based on our IP support?
 
     let dns_proxy_addr: Address = match pc.proxy_metadata.get(DNS_PROXY_ADDR_METADATA) {
-        Some(dns_addr) => Address::from_str(ipv6_enabled, dns_addr)
+        Some(dns_addr) => Address::new(ipv6_enabled, dns_addr)
             .unwrap_or_else(|_| panic!("failed to parse DNS_PROXY_ADDR: {}", dns_addr)),
         None => Address::Localhost(ipv6_enabled, DEFAULT_DNS_PORT),
     };
@@ -631,7 +631,7 @@ impl IntoIterator for Address {
 }
 
 impl Address {
-    fn from_str(ipv6_enabled: bool, s: &str) -> anyhow::Result<Self> {
+    fn new(ipv6_enabled: bool, s: &str) -> anyhow::Result<Self> {
         if s.starts_with("localhost:") {
             let (_host, ports) = s.split_once(':').expect("already checked it has a :");
             let port: u16 = ports.parse()?;

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -1262,7 +1262,7 @@ mod tests {
         let factory = crate::proxy::DefaultSocketFactory;
         let proxy = Server::new(
             domain,
-            config::Address::Localhost(0),
+            config::Address::Localhost(false, 0),
             NW1,
             state,
             forwarder,
@@ -1381,7 +1381,7 @@ mod tests {
         let factory = crate::proxy::DefaultSocketFactory;
         let server = Server::new(
             domain,
-            config::Address::Localhost(0),
+            config::Address::Localhost(false, 0),
             NW1,
             state,
             forwarder,
@@ -1458,7 +1458,7 @@ mod tests {
         let factory = crate::proxy::DefaultSocketFactory;
         let server = Server::new(
             domain,
-            config::Address::Localhost(0),
+            config::Address::Localhost(false, 0),
             NW1,
             state,
             forwarder,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -121,7 +121,7 @@ pub fn test_config_with_port_xds_addr_and_root_cert(
         stats_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         outbound_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         inbound_plaintext_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-        dns_proxy_addr: config::Address::Localhost(0),
+        dns_proxy_addr: config::Address::Localhost(false, 0),
         illegal_ports: HashSet::new(), // for "direct" tests, since the ports are latebound, we can't test illegal ports
         fake_self_inbound: true, // for "direct" tests, since the ports are latebound, we have to do this. Yes, this is test concerns leaking into prod code
         ..config::parse_config().unwrap()

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config::Address;
 use crate::dns::resolver::{Answer, Resolver};
 use crate::dns::Metrics;
 use crate::proxy::Error;
@@ -263,7 +264,7 @@ pub async fn run_dns(responses: HashMap<Name, Vec<IpAddr>>) -> anyhow::Result<Te
     });
     let srv = crate::dns::Server::new(
         "example.com".to_string(),
-        "127.0.0.1:0".parse()?,
+        Address::Localhost(false, 0),
         "",
         state,
         forwarder,


### PR DESCRIPTION
Fixes https://github.com/istio/ztunnel/issues/1131

Testing was manual. I don't see any way we can test this in CI, since it
only works if the kernel is booted with IPv6 turned off - the sysctl to
dynamically set it will NOT break.
