### PR TITLE
Optimize throughput 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,16 +3146,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -3832,6 +3831,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-build",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ lto = true
 inherits = "quick-release"
 
 [profile.symbols-release]
-inherits = "quick-release"
+inherits = "release"
 debug = true
 
 # Release optimized but without as many dependencies, suitable for incremental development

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ split-iter = "0.1"
 arcstr = { version = "1.1", features = ["serde"] }
 tracing-core = "0.1.32"
 tracing-appender = "0.2.3"
+tokio-util = { version = "0.7.11", features = ["io-util"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"
@@ -125,7 +126,7 @@ lto = true
 inherits = "quick-release"
 
 [profile.symbols-release]
-inherits = "release"
+inherits = "quick-release"
 debug = true
 
 # Release optimized but without as many dependencies, suitable for incremental development

--- a/benches/README.md
+++ b/benches/README.md
@@ -13,3 +13,105 @@ $ cargo bench -- --save-baseline <name> # save baseline
 $ # ...change something...
 $ cargo bench -- --baseline <name> # compare against it
 ```
+
+## Performance
+
+Ztunnel performance largely falls into throughput and latency.
+While these are sometimes at odds with each other, as Ztunnel is a generic proxy, we aim to make it perform well on both metrics.
+
+### Request flows
+
+The primary responsibility of the proxy is copying bits between peers.
+Currently, this is always either `TCP<-->TCP` or `TCP<-->HBONE`.
+
+#### `TCP` to `TCP`
+
+This is the simplest case, and common amongst many proxies.
+[`copy.rs`](../src/copy.rs) does the bulk of the work, essentially just bi-directionally copying bytes between the two sockets.
+
+Typical bi-di copies are using a fixed buffer.
+To adapt to various workloads, we use dynamically sized buffers, that can grow from 1kb -> 16kb -> 256kb when enough traffic is received.
+This allows high throughput workloads to perform well, without excessive memory costs for low-bandwidth services.
+
+#### `TCP` to `HBONE`
+
+This case ends up being much more complex, as we flow through HTTP2 and TLS.
+The full flow looks as such (pseudocode):
+
+```
+copy_bidi():
+    loop {
+        data = tcp_in.read(up to 256k) # based on dynamic buffer size
+        h2.write(data)
+    }
+h2::write(data):
+    Buffer data as a DATA frame, up to a max of `max_send_buffer_size`. We configure this to 256k.
+    Asyncronously, the connection driver will pick up this data and call `rustls.write_vectored([256bytes, rest of data])`.
+rustls::write(data):
+    data=encrypt(data)
+    # TLS records are at most 16k
+    # In practice I have observed at most 4 chunks; unclear where this is configured.
+    tcp_out.write_vectored([chunks of 16k])
+```
+
+From an `iperf` load, this ends up looking something like this in `strace`:
+```
+% time     seconds  usecs/call     calls    errors syscall
+------ ----------- ----------- --------- --------- ----------------
+ 55.21    0.841290           5    140711           writev
+ 44.78    0.682359          17     38481           recvfrom
+ ```
+
+This will be from `writev([16kb * 4])` calls and `recvfrom(256kb)`.
+
+#### `HBONE` to `TCP`
+
+This flow is substantially different from the inverse direction.
+The receive flow is driven by `h2`. Under the hood this uses a [`LengthDelimitedCodec`](https://docs.rs/tokio-util/latest/tokio_util/codec/length_delimited/struct.LengthDelimitedCodec.html).
+`h2` will attempt to decode 1 frame at a time, using an internal buffer.
+This buffer starts at [`8kb`](https://github.com/tokio-rs/tokio/blob/ed4ddf443d93c3e14ae23699a5a2f81902ad1e66/tokio-util/src/codec/framed_impl.rs#L26) but will grow to meet the size of frames.
+We allow up to a max of `1mb` frame sizes (`config.frame_size`).
+
+Ultimately, this will call `rustls.read(buf)`.
+This goes through a few indirections, but ultimately ends up in `rustls.deframer_buffer`.
+This is what calls `read()` on the underlying IO, in our case the TCP connection.
+This buffer is configured to do [`4kb`](https://github.com/rustls/rustls/blob/8a8023addb9ae311f66b16e272e85654c9588eeb/rustls/src/msgs/deframer.rs#L724) reads generally.
+
+Upon reading the frame from the wire, these get [buffered up by `h2`](https://github.com/hyperium/h2/blob/4617f49b266d560a773372a90be283ba8b2400a9/src/proto/streams/stream.rs#L100).
+We read these in [`recv_stream.poll_data`](../src/proxy/h2.rs), trigger by the `copy_bidirectional`.
+Ultimately, this will write out 1 DATA frame worth of data to the upstream TCP connection
+
+From an `iperf` load, this ends up looking something like this in `strace`:
+```
+% time     seconds  usecs/call     calls    errors syscall
+------ ----------- ----------- --------- --------- ----------------
+ 61.08    1.253541          50     24703           sendto
+ 38.19    0.783733           2    360707         8 recvfrom
+```
+
+This will be from `sendto(256kb)` calls, with many `recvfrom()` calls ranging from 4k to 16k.
+
+#### Comparison to Envoy
+
+Under an `iperf` load, Envoy client:
+```
+% time     seconds  usecs/call     calls    errors syscall
+------ ----------- ----------- --------- --------- ----------------
+ 68.24    1.363149           3    440440         1 sendto
+ 31.72    0.633584          11     55114        31 readv
+```
+This is from many `sendto(16k)` calls, and `readv([16k]*8)`.
+
+Envoy Server:
+```
+% time     seconds  usecs/call     calls    errors syscall
+------ ----------- ----------- --------- --------- ----------------
+ 65.24    1.199264           1    757275         8 recvfrom
+ 34.73    0.638315          26     23670           writev
+```
+This is from many calls of `recvfrom(5); recvfrom(16k)`, and `writev([16k]*16)`.
+
+On my machine, Envoy maintains an advantage, handling ~11GB/s vs 9Gb/s for ztunnel.
+With multiple parallel streams, Ztunnel is unable to exceed 9Gb/s; Envoy can handle up to 17Gb/s *if you get lucky with thread distribution*.
+
+(All strace commands are looking at `-e trace=write,writev,read,recvfrom,sendto,readv`).

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2689,16 +2689,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -3361,6 +3360,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-build",
  "tower",

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -150,14 +150,18 @@ where
     let downstream_to_upstream = async {
         let res = copy_buf(&mut rd, &mut wu, stats, false).await;
         trace!(?res, "send");
+        tracing::error!("howardjohn: SHUT1");
         ignore_shutdown_errors(shutdown(&mut wu).await)?;
+        tracing::error!("howardjohn: SHUT11");
         res
     };
 
     let upstream_to_downstream = async {
         let res = copy_buf(&mut ru, &mut wd, stats, true).await;
         trace!(?res, "receive");
+        tracing::error!("howardjohn: SHUT2");
         ignore_shutdown_errors(shutdown(&mut wd).await)?;
+        tracing::error!("howardjohn: SHUT22");
         res
     };
 
@@ -246,8 +250,10 @@ where
             } else {
                 ready!(Pin::new(&mut *me.reader).poll_bytes(cx))?
             };
+            tracing::error!("howardjohn: got buffer {}", buffer.len());
             if buffer.is_empty() {
-                ready!(AsyncWriteBuf::poll_shutdown(Pin::new(&mut self.writer), cx))?;
+                tracing::error!("howardjohn: SHUtdown");
+                ready!(AsyncWriteBuf::poll_flush(Pin::new(&mut self.writer), cx))?;
                 return Poll::Ready(Ok(self.amt));
             }
 
@@ -390,6 +396,8 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.project();
-        AsyncWriteBuf::poll_shutdown(Pin::new(me.a), cx)
+        let res = AsyncWriteBuf::poll_shutdown(Pin::new(me.a), cx);
+        tracing::error!("howardjohn: poll shut {res:?}");
+        res
     }
 }

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -63,6 +63,7 @@ impl BufferedSplitter for TcpStreamSplitter {
     }
 }
 
+// AsyncWriteBuf is like AsyncWrite, but writes a Bytes instead of &[u8]. This allows avoiding copies.
 pub trait AsyncWriteBuf {
     fn poll_write_buf(
         self: Pin<&mut Self>,
@@ -76,6 +77,7 @@ pub trait AsyncWriteBuf {
     ) -> Poll<Result<(), std::io::Error>>;
 }
 
+// Allow &T to be AsyncWriteBuf
 impl<T: ?Sized + AsyncWriteBuf + Unpin> AsyncWriteBuf for &mut T {
     fn poll_write_buf(
         mut self: Pin<&mut Self>,
@@ -94,6 +96,7 @@ impl<T: ?Sized + AsyncWriteBuf + Unpin> AsyncWriteBuf for &mut T {
     }
 }
 
+// Allow anything that is AsyncWrite to be AsyncWriteBuf.
 pub struct WriteAdapter<T>(T);
 
 impl<T: AsyncWrite + Unpin> AsyncWriteBuf for WriteAdapter<T> {

--- a/src/proxy/h2.rs
+++ b/src/proxy/h2.rs
@@ -206,7 +206,7 @@ impl copy::AsyncWriteBuf for H2StreamWriteHalf {
         )))
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
         Poll::Ready(Ok(()))
     }
 
@@ -214,7 +214,9 @@ impl copy::AsyncWriteBuf for H2StreamWriteHalf {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
-        if self.write_slice(Bytes::new(), true).is_ok() {
+        let r = self.write_slice(Bytes::new(), true);
+        tracing::error!("howardjohn: poll h2 {r:?}");
+        if r.is_ok() {
             return Poll::Ready(Ok(()));
         }
 

--- a/src/proxy/h2.rs
+++ b/src/proxy/h2.rs
@@ -180,7 +180,7 @@ impl copy::ResizeBufRead for H2StreamReadHalf {
         self.as_mut().buf.advance(amt)
     }
 
-    fn resize(self: Pin<&mut Self>) {
+    fn resize(self: Pin<&mut Self>, _new_size: usize) {
         // NOP, we don't need to resize as we are abstracting the h2 buffer
     }
 }

--- a/src/proxy/h2/client.rs
+++ b/src/proxy/h2/client.rs
@@ -80,7 +80,6 @@ impl H2ConnectClient {
         let (dropped1, dropped2) = crate::proxy::h2::DropCounter::new(self.stream_count.clone());
         let read = crate::proxy::h2::H2StreamReadHalf {
             recv_stream: recv,
-            buf: Default::default(),
             _dropped: dropped1,
         };
         let write = crate::proxy::h2::H2StreamWriteHalf {

--- a/src/proxy/h2/client.rs
+++ b/src/proxy/h2/client.rs
@@ -120,7 +120,8 @@ pub async fn spawn_connection(
         .max_frame_size(cfg.frame_size)
         .initial_max_send_streams(cfg.pool_max_streams_per_conn as usize)
         .max_header_list_size(1024 * 16)
-        .max_send_buffer_size(1024 * 1024)
+        // 256kb. Aligned with copy.rs to avoid fragmentation
+        .max_send_buffer_size(16_384 * 16_384)
         .enable_push(false);
 
     let (send_req, connection) = builder

--- a/src/proxy/h2/server.rs
+++ b/src/proxy/h2/server.rs
@@ -60,7 +60,6 @@ impl H2Request {
         let send = send.send_response(resp, false)?;
         let read = crate::proxy::h2::H2StreamReadHalf {
             recv_stream: recv,
-            buf: Default::default(),
             _dropped: None, // We do not need to track on the server
         };
         let write = crate::proxy::h2::H2StreamWriteHalf {

--- a/src/proxy/h2/server.rs
+++ b/src/proxy/h2/server.rs
@@ -14,6 +14,7 @@
 
 use crate::config;
 use crate::proxy::Error;
+use bytes::Bytes;
 use futures_util::FutureExt;
 use http::request::Parts;
 use http::Response;
@@ -28,7 +29,7 @@ use tracing::{debug, warn};
 pub struct H2Request {
     request: Parts,
     recv: h2::RecvStream,
-    send: h2::server::SendResponse<crate::proxy::h2::SendBuf>,
+    send: h2::server::SendResponse<Bytes>,
 }
 
 impl H2Request {

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -99,7 +99,7 @@ impl InboundPassthrough {
                         }
                         .in_current_span();
 
-                        assertions::size_between_ref(1500, 2500, &serve_client);
+                        assertions::size_between_ref(1500, 2750, &serve_client);
                         tokio::spawn(serve_client);
                     }
                     Err(e) => {


### PR DESCRIPTION
This has two main optimizations:
* Allow larger buffers, up to 256k. Before we maxed out at 16k. Note this is dynamic, so we aren't just using more memory.
* Avoid copy of all data on the tcp -> Hbone send side. This requires us to use Bytes everywhere instead of `&[u8]` so we can give h2 a copy for free (ref count) vs a clone


Highlight:
```
throughput/hbone        
                        thrpt:  [12.506 Gb/s 12.629 Gb/s 12.768 Gb/s]
                 change:thrpt:  [+41.815% +43.964% +46.422%]
```