### PR TITLE
h2: avoid excessive buffer size

### DIFF
--- a/src/proxy/h2/client.rs
+++ b/src/proxy/h2/client.rs
@@ -119,8 +119,8 @@ pub async fn spawn_connection(
         .max_frame_size(cfg.frame_size)
         .initial_max_send_streams(cfg.pool_max_streams_per_conn as usize)
         .max_header_list_size(1024 * 16)
-        // 256kb. Aligned with copy.rs to avoid fragmentation
-        .max_send_buffer_size(16_384 * 16_384)
+        // 4mb. Aligned with window_size such that we can fill up the buffer, then flush it all in one go, without buffering up too much.
+        .max_send_buffer_size(cfg.window_size as usize)
         .enable_push(false);
 
     let (send_req, connection) = builder


### PR DESCRIPTION
This was a typo - 16k*16k is MASSIVE. We really only need 4mb to give
good results without risking unbounded buffering
