### PR TITLE
Abstract and fix draining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,15 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "drain"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d105028bd2b5dfcb33318fd79a445001ead36004dd8dffef1bdd7e493d8bc1e"
-dependencies = [
- "tokio",
-]
-
-[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3769,7 +3760,6 @@ dependencies = [
  "criterion",
  "ctor",
  "diff",
- "drain",
  "duration-str",
  "flurry",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ base64 = "0.22"
 byteorder = "1.5"
 bytes = { version = "1.5", features = ["serde"] }
 chrono = "0.4"
-drain = "0.1"
+# Rename to avoid conflicts with our own pacakge name, which wraps this
+drain-internal = { package= "drain", version = "0.1" }
 duration-str = "0.7"
 futures = "0.3"
 futures-core = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ base64 = "0.22"
 byteorder = "1.5"
 bytes = { version = "1.5", features = ["serde"] }
 chrono = "0.4"
-# Rename to avoid conflicts with our own pacakge name, which wraps this
-drain-internal = { package= "drain", version = "0.1" }
 duration-str = "0.7"
 futures = "0.3"
 futures-core = "0.3"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -560,15 +560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "drain"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1a0abf3fcefad9b4dd0e414207a7408e12b68414a01e6bb19b897d5bd7632d"
-dependencies = [
- "tokio",
-]
-
-[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,7 +3295,6 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "drain",
  "duration-str",
  "flurry",
  "futures",

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -23,7 +23,6 @@ use crate::{signal, telemetry};
 
 use base64::engine::general_purpose::STANDARD;
 use bytes::Bytes;
-use drain::Watch;
 use http_body_util::Full;
 use hyper::body::Incoming;
 use hyper::{header::HeaderValue, header::CONTENT_TYPE, Request, Response};
@@ -36,6 +35,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 use std::{net::SocketAddr, time::Duration};
 
+use crate::drain::DrainWatcher;
 use tokio::time;
 use tracing::{error, info, warn};
 use tracing_subscriber::filter;
@@ -106,7 +106,7 @@ impl Service {
         config: Arc<Config>,
         proxy_state: DemandProxyState,
         shutdown_trigger: signal::ShutdownTrigger,
-        drain_rx: Watch,
+        drain_rx: DrainWatcher,
         cert_manager: Arc<SecretManager>,
     ) -> anyhow::Result<Self> {
         Server::<State>::bind(

--- a/src/app.rs
+++ b/src/app.rs
@@ -359,7 +359,9 @@ impl Bound {
 
         // Start a drain; this will attempt to end all connections
         // or itself be interrupted by a stronger TERM signal, whichever comes first.
-        self.drain_tx.start_drain_and_wait().await;
+        self.drain_tx
+            .start_drain_and_wait(drain::DrainMode::Graceful)
+            .await;
 
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,14 +16,14 @@ use std::future::Future;
 
 use crate::proxyfactory::ProxyFactory;
 
+use crate::drain;
+use anyhow::Context;
+use prometheus_client::registry::Registry;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
-
-use anyhow::Context;
-use prometheus_client::registry::Registry;
 use tokio::task::JoinSet;
 use tracing::{warn, Instrument};
 
@@ -45,7 +45,7 @@ pub async fn build_with_cert(
     // Any component which wants time to gracefully exit should take in a drain_rx clone,
     // await drain_rx.signaled(), then cleanup.
     // Note: there is still a hard timeout if the draining takes too long
-    let (drain_tx, drain_rx) = drain::channel();
+    let (drain_tx, drain_rx) = drain::new();
 
     // Register readiness tasks.
     let ready = readiness::Ready::new();
@@ -320,7 +320,7 @@ fn init_inpod_proxy_mgr(
     config: &config::Config,
     proxy_gen: ProxyFactory,
     ready: readiness::Ready,
-    drain_rx: drain::Watch,
+    drain_rx: drain::DrainWatcher,
 ) -> anyhow::Result<std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + Sync>>> {
     let metrics = Arc::new(crate::inpod::metrics::Metrics::new(
         registry.sub_registry_with_prefix("workload_manager"),
@@ -349,7 +349,7 @@ pub struct Bound {
     pub udp_dns_proxy_address: Option<SocketAddr>,
 
     pub shutdown: signal::Shutdown,
-    drain_tx: drain::Signal,
+    drain_tx: drain::DrainTrigger,
 }
 
 impl Bound {
@@ -359,7 +359,7 @@ impl Bound {
 
         // Start a drain; this will attempt to end all connections
         // or itself be interrupted by a stronger TERM signal, whichever comes first.
-        self.drain_tx.drain().await;
+        self.drain_tx.start_drain_and_wait().await;
 
         Ok(())
     }

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -17,39 +17,43 @@ use std::time::Duration;
 use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
-#[derive(Debug)]
-pub struct DrainTrigger(drain_internal::Signal);
+// #[derive(Debug)]
+// pub struct DrainTrigger(internal::Signal);
 
-impl DrainTrigger {
-    /// start_drain_and_wait initiates a draining sequence. The future will not complete until the drain
-    /// is complete (all outstanding DrainWatchers are dropped).
-    pub async fn start_drain_and_wait(self) {
-        self.0.drain().await
-    }
-}
+// impl DrainTrigger {
+//     /// start_drain_and_wait initiates a draining sequence. The future will not complete until the drain
+//     /// is complete (all outstanding DrainWatchers are dropped).
+//     pub async fn start_drain_and_wait(self) {
+//         self.0.drain().await
+//     }
+// }
 
-#[derive(Clone, Debug)]
-pub struct DrainWatcher(drain_internal::Watch);
+// #[derive(Clone, Debug)]
+pub use internal::DrainMode;
+pub use internal::ReleaseShutdown as DrainBlocker;
+pub use internal::Signal as DrainTrigger;
+pub use internal::Watch as DrainWatcher;
+// pub struct DrainWatcher(internal::Watch);
+//
+// impl DrainWatcher {
+//     /// wait_for_drain will return once a drain has been initiated.
+//     /// The drain will not complete until the returned DrainBlocker is dropped
+//     pub async fn wait_for_drain(self) -> DrainBlocker {
+//         DrainBlocker(self.0.signaled().await)
+//     }
+// }
 
-impl DrainWatcher {
-    /// wait_for_drain will return once a drain has been initiated.
-    /// The drain will not complete until the returned DrainBlocker is dropped
-    pub async fn wait_for_drain(self) -> DrainBlocker {
-        DrainBlocker(self.0.signaled().await)
-    }
-}
-
-#[allow(dead_code)]
+// #[allow(dead_code)]
 /// DrainBlocker provides a token that must be dropped to unblock the drain.
-pub struct DrainBlocker(drain_internal::ReleaseShutdown);
+// pub struct DrainBlocker(internal::ReleaseShutdown);
 
 /// New constructs a new pair for draining
 /// * DrainTrigger can be used to start a draining sequence and wait for it to complete.
 /// * DrainWatcher should be held by anything that wants to participate in the draining. This can be cloned,
 ///   and a drain will not complete until all outstanding DrainWatchers are dropped.
 pub fn new() -> (DrainTrigger, DrainWatcher) {
-    let (tx, rx) = drain_internal::channel();
-    (DrainTrigger(tx), DrainWatcher(rx))
+    let (tx, rx) = internal::channel();
+    (tx, rx)
 }
 
 /// run_with_drain provides a wrapper to run a future with graceful shutdown/draining support.
@@ -78,17 +82,139 @@ pub async fn run_with_drain<F, Fut, O>(
     tokio::select! {
         _res = fut => {}
         res = drain.wait_for_drain() => {
-            debug!(component, "drain started, waiting {:?} for any connections to complete", deadline);
-            if tokio::time::timeout(deadline, sub_drain_signal.start_drain_and_wait()).await.is_err() {
-                // Not all connections completed within time, we will force shut them down
-                warn!(component, "drain duration expired with pending connections, forcefully shutting down");
+            if res.mode() == DrainMode::Graceful {
+                debug!(component, "drain started, waiting {:?} for any connections to complete", deadline);
+                if tokio::time::timeout(deadline, sub_drain_signal.start_drain_and_wait(DrainMode::Graceful)).await.is_err() {
+                    // Not all connections completed within time, we will force shut them down
+                    warn!(component, "drain duration expired with pending connections, forcefully shutting down");
+                }
+            } else {
+                debug!(component, "terminating");
             }
             // Trigger force shutdown. In theory, this is only needed in the timeout case. However,
             // it doesn't hurt to always trigger it.
             let _ = trigger_force_shutdown.send(());
 
-            info!(component, "drain complete");
+            info!(component, "shutdown complete");
             drop(res);
         }
     };
+}
+
+mod internal {
+    use tokio::sync::{mpsc, watch};
+
+    /// Creates a drain channel.
+    ///
+    /// The `Signal` is used to start a drain, and the `Watch` will be notified
+    /// when a drain is signaled.
+    pub fn channel() -> (Signal, Watch) {
+        let (signal_tx, signal_rx) = watch::channel(None);
+        let (drained_tx, drained_rx) = mpsc::channel(1);
+
+        let signal = Signal {
+            drained_rx,
+            signal_tx,
+        };
+        let watch = Watch {
+            drained_tx,
+            signal_rx,
+        };
+        (signal, watch)
+    }
+
+    enum Never {}
+
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum DrainMode {
+        Immediate,
+        Graceful,
+    }
+
+    /// Send a drain command to all watchers.
+    pub struct Signal {
+        drained_rx: mpsc::Receiver<Never>,
+        signal_tx: watch::Sender<Option<DrainMode>>,
+    }
+
+    /// Watch for a drain command.
+    ///
+    /// All `Watch` instances must be dropped for a `Signal::signal` call to
+    /// complete.
+    #[derive(Clone)]
+    pub struct Watch {
+        drained_tx: mpsc::Sender<Never>,
+        signal_rx: watch::Receiver<Option<DrainMode>>,
+    }
+
+    #[must_use = "ReleaseShutdown should be dropped explicitly to release the runtime"]
+    #[derive(Clone)]
+    #[allow(dead_code)]
+    pub struct ReleaseShutdown(mpsc::Sender<Never>, DrainMode);
+
+    impl ReleaseShutdown {
+        pub fn mode(&self) -> DrainMode {
+            self.1
+        }
+    }
+
+    impl Signal {
+        /// Waits for all [`Watch`] instances to be dropped.
+        pub async fn closed(&mut self) {
+            self.signal_tx.closed().await;
+        }
+
+        /// Asynchronously signals all watchers to begin draining gracefully and waits for all
+        /// handles to be dropped.
+        pub async fn start_drain_and_wait(mut self, mode: DrainMode) {
+            // Update the state of the signal watch so that all watchers are observe
+            // the change.
+            let _ = self.signal_tx.send(Some(mode));
+
+            // Wait for all watchers to release their drain handle.
+            match self.drained_rx.recv().await {
+                None => {}
+                Some(n) => match n {},
+            }
+        }
+    }
+
+    impl Watch {
+        /// Returns a `ReleaseShutdown` handle after the drain has been signaled. The
+        /// handle must be dropped when a shutdown action has been completed to
+        /// unblock graceful shutdown.
+        pub async fn wait_for_drain(mut self) -> ReleaseShutdown {
+            // This future completes once `Signal::signal` has been invoked so that
+            // the channel's state is updated.
+            let mode = self
+                .signal_rx
+                .wait_for(Option::is_some)
+                .await
+                .map(|mode| mode.expect("already asserted it is_some"))
+                // If we got an error, then the signal was dropped entirely. Presumably this means a graceful shutdown is not required.
+                .unwrap_or(DrainMode::Immediate);
+
+            // Return a handle that holds the drain channel, so that the signal task
+            // is only notified when all handles have been dropped.
+            ReleaseShutdown(self.drained_tx, mode)
+        }
+    }
+
+    impl std::fmt::Debug for Signal {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Signal").finish_non_exhaustive()
+        }
+    }
+
+    impl std::fmt::Debug for Watch {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Watch").finish_non_exhaustive()
+        }
+    }
+
+    impl std::fmt::Debug for ReleaseShutdown {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ReleaseShutdown").finish_non_exhaustive()
+        }
+    }
 }

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -1,0 +1,94 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::time::Duration;
+use tokio::sync::watch;
+use tracing::{debug, info, warn};
+
+#[derive(Debug)]
+pub struct DrainTrigger(drain_internal::Signal);
+
+impl DrainTrigger {
+    /// start_drain_and_wait initiates a draining sequence. The future will not complete until the drain
+    /// is complete (all outstanding DrainWatchers are dropped).
+    pub async fn start_drain_and_wait(self) {
+        self.0.drain().await
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DrainWatcher(drain_internal::Watch);
+
+impl DrainWatcher {
+    /// wait_for_drain will return once a drain has been initiated.
+    /// The drain will not complete until the returned DrainBlocker is dropped
+    pub async fn wait_for_drain(self) -> DrainBlocker {
+        DrainBlocker(self.0.signaled().await)
+    }
+}
+
+#[allow(dead_code)]
+/// DrainBlocker provides a token that must be dropped to unblock the drain.
+pub struct DrainBlocker(drain_internal::ReleaseShutdown);
+
+/// New constructs a new pair for draining
+/// * DrainTrigger can be used to start a draining sequence and wait for it to complete.
+/// * DrainWatcher should be held by anything that wants to participate in the draining. This can be cloned,
+///   and a drain will not complete until all outstanding DrainWatchers are dropped.
+pub fn new() -> (DrainTrigger, DrainWatcher) {
+    let (tx, rx) = drain_internal::channel();
+    (DrainTrigger(tx), DrainWatcher(rx))
+}
+
+/// run_with_drain provides a wrapper to run a future with graceful shutdown/draining support.
+/// A caller should construct a future with takes two arguments:
+/// * drain: while holding onto this, the future is marked as active, which will block the server from shutting down.
+///   Additionally, it can be watched (with drain.signaled()) to see when to start a graceful shutdown.
+/// * force_shutdown: when this is triggered, the future must forcefully shutdown any ongoing work ASAP.
+///   This means the graceful drain exceeded the hard deadline, and all work must terminate now.
+///   This is only required for spawned() tasks; otherwise, the future is dropped entirely, canceling all work.
+pub async fn run_with_drain<F, Fut, O>(
+    component: String,
+    drain: DrainWatcher,
+    deadline: Duration,
+    make_future: F,
+) where
+    F: FnOnce(DrainWatcher, watch::Receiver<()>) -> Fut,
+    Fut: Future<Output = O>,
+    O: Send + 'static,
+{
+    let (sub_drain_signal, sub_drain) = new();
+    let (trigger_force_shutdown, force_shutdown) = watch::channel(());
+    // Stop accepting once we drain.
+    // We will then allow connections up to `deadline` to terminate on their own.
+    // After that, they will be forcefully terminated.
+    let fut = make_future(sub_drain, force_shutdown);
+    tokio::select! {
+        _res = fut => {}
+        res = drain.wait_for_drain() => {
+            debug!(component, "drain started, waiting {:?} for any connections to complete", deadline);
+            if tokio::time::timeout(deadline, sub_drain_signal.start_drain_and_wait()).await.is_err() {
+                // Not all connections completed within time, we will force shut them down
+                warn!(component, "drain duration expired with pending connections, forcefully shutting down");
+            }
+            // Trigger force shutdown. In theory, this is only needed in the timeout case. However,
+            // it doesn't hurt to always trigger it.
+            let _ = trigger_force_shutdown.send(());
+
+            info!(component, "drain complete");
+            drop(res);
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod cert_fetcher;
 pub mod config;
 pub mod copy;
 pub mod dns;
+pub mod drain;
 pub mod hyper_util;
 pub mod identity;
 #[cfg(target_os = "linux")]

--- a/src/metrics/server.rs
+++ b/src/metrics/server.rs
@@ -16,7 +16,6 @@ use bytes::Bytes;
 use std::sync::Mutex;
 use std::{net::SocketAddr, sync::Arc};
 
-use drain::Watch;
 use http_body_util::Full;
 use hyper::body::Incoming;
 use hyper::{Request, Response};
@@ -24,6 +23,7 @@ use prometheus_client::encoding::text::encode;
 use prometheus_client::registry::Registry;
 
 use crate::config::Config;
+use crate::drain::DrainWatcher;
 use crate::hyper_util;
 
 pub struct Server {
@@ -33,7 +33,7 @@ pub struct Server {
 impl Server {
     pub async fn new(
         config: Arc<Config>,
-        drain_rx: Watch,
+        drain_rx: DrainWatcher,
         registry: Registry,
     ) -> anyhow::Result<Self> {
         hyper_util::Server::<Mutex<Registry>>::bind(

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -48,8 +48,10 @@ impl ConnectionDrain {
     // always inline, this is for convenience so that we don't forget to drop the rx but there's really no reason it needs to grow the stack
     #[inline(always)]
     async fn drain(self) {
-        drop(self.rx); // very important, drain cannont complete if there are outstand rx
-        self.tx.start_drain_and_wait().await;
+        drop(self.rx); // very important, drain cannot complete if there are outstand rx
+        self.tx
+            .start_drain_and_wait(drain::DrainMode::Immediate)
+            .await;
     }
 }
 
@@ -622,7 +624,7 @@ mod tests {
         } // release lock
 
         // send the signal which stops policy watcher
-        tx.start_drain_and_wait().await;
+        tx.start_drain_and_wait(drain::DrainMode::Immediate).await;
     }
 
     // small helper to assert that the Watches are working in a timely manner

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -16,7 +16,6 @@ use crate::proxy::Error;
 
 use crate::state::DemandProxyState;
 use crate::state::ProxyRbacContext;
-use drain;
 use serde::{Serialize, Serializer};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -24,6 +23,8 @@ use std::fmt::Formatter;
 use std::future::Future;
 use std::net::SocketAddr;
 
+use crate::drain;
+use crate::drain::{DrainTrigger, DrainWatcher};
 use std::sync::Arc;
 use std::sync::RwLock;
 use tracing::{debug, error, info, warn};
@@ -32,14 +33,14 @@ struct ConnectionDrain {
     // TODO: this should almost certainly be changed to a type which has counted references exposed.
     // tokio::sync::watch can be subscribed without taking a write lock and exposes references
     // and also a receiver_count method
-    tx: drain::Signal,
-    rx: drain::Watch,
+    tx: DrainTrigger,
+    rx: DrainWatcher,
     count: usize,
 }
 
 impl ConnectionDrain {
     fn new() -> Self {
-        let (tx, rx) = drain::channel();
+        let (tx, rx) = drain::new();
         ConnectionDrain { tx, rx, count: 1 }
     }
 
@@ -48,7 +49,7 @@ impl ConnectionDrain {
     #[inline(always)]
     async fn drain(self) {
         drop(self.rx); // very important, drain cannont complete if there are outstand rx
-        self.tx.drain().await;
+        self.tx.start_drain_and_wait().await;
     }
 }
 
@@ -76,7 +77,7 @@ impl Default for ConnectionManager {
 pub struct ConnectionGuard {
     cm: ConnectionManager,
     conn: InboundConnection,
-    watch: Option<drain::Watch>,
+    watch: Option<DrainWatcher>,
 }
 
 impl ConnectionGuard {
@@ -90,7 +91,7 @@ impl ConnectionGuard {
                 self.cm.release(&self.conn);
                 res
             }
-            _signaled = watch.signaled() => Err(Error::AuthorizationPolicyLateRejection)
+            _signaled = watch.wait_for_drain() => Err(Error::AuthorizationPolicyLateRejection)
         }
     }
 }
@@ -194,7 +195,7 @@ impl ConnectionManager {
     // this must be done before a connection can be tracked
     // allows policy to be asserted against the connection
     // even no tasks have a receiver channel yet
-    fn register(&self, c: &InboundConnection) -> Option<drain::Watch> {
+    fn register(&self, c: &InboundConnection) -> Option<DrainWatcher> {
         match self.drains.write().expect("mutex").entry(c.clone()) {
             Entry::Occupied(mut cd) => {
                 cd.get_mut().count += 1;
@@ -282,14 +283,14 @@ impl Serialize for ConnectionManager {
 
 pub struct PolicyWatcher {
     state: DemandProxyState,
-    stop: drain::Watch,
+    stop: DrainWatcher,
     connection_manager: ConnectionManager,
 }
 
 impl PolicyWatcher {
     pub fn new(
         state: DemandProxyState,
-        stop: drain::Watch,
+        stop: DrainWatcher,
         connection_manager: ConnectionManager,
     ) -> Self {
         PolicyWatcher {
@@ -303,7 +304,7 @@ impl PolicyWatcher {
         let mut policies_changed = self.state.read().policies.subscribe();
         loop {
             tokio::select! {
-                _ = self.stop.clone().signaled() => {
+                _ = self.stop.clone().wait_for_drain() => {
                     break;
                 }
                 _ = policies_changed.changed() => {
@@ -322,7 +323,8 @@ impl PolicyWatcher {
 
 #[cfg(test)]
 mod tests {
-    use drain::Watch;
+    use crate::drain;
+    use crate::drain::DrainWatcher;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
     use prometheus_client::registry::Registry;
     use std::net::{Ipv4Addr, SocketAddrV4};
@@ -559,7 +561,7 @@ mod tests {
             metrics,
         );
         let connection_manager = ConnectionManager::default();
-        let (tx, stop) = drain::channel();
+        let (tx, stop) = drain::new();
         let state_mutator = ProxyStateUpdateMutator::new_no_fetch();
 
         // clones to move into spawned task
@@ -620,12 +622,12 @@ mod tests {
         } // release lock
 
         // send the signal which stops policy watcher
-        tx.drain().await;
+        tx.start_drain_and_wait().await;
     }
 
     // small helper to assert that the Watches are working in a timely manner
-    async fn assert_close(c: Watch) {
-        let result = tokio::time::timeout(Duration::from_secs(1), c.signaled()).await;
+    async fn assert_close(c: DrainWatcher) {
+        let result = tokio::time::timeout(Duration::from_secs(1), c.wait_for_drain()).await;
         assert!(result.is_ok())
     }
 }

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -19,13 +19,13 @@ use std::time::Instant;
 use drain::Watch;
 use tokio::net::TcpStream;
 use tokio::sync::watch;
-use tokio::time::timeout;
 
-use tracing::{debug, error, info, trace, warn, Instrument};
+use tracing::{debug, error, info, trace, Instrument};
 
 use crate::config::ProxyMode;
 
 use crate::proxy::metrics::Reporter;
+use crate::proxy::util::run_with_drain;
 use crate::proxy::Error;
 use crate::proxy::{metrics, util, ProxyInputs};
 use crate::state::workload::NetworkAddress;
@@ -66,36 +66,31 @@ impl InboundPassthrough {
     }
 
     pub(super) async fn run(self) {
-        let (sub_drain_signal, sub_drain) = drain::channel();
-        let deadline = self.pi.cfg.self_termination_deadline;
-        let (trigger_force_shutdown, force_shutdown) = watch::channel(());
-        let accept = async move {
+        let pi = self.pi.clone();
+        let accept = |drain: Watch, force_shutdown: watch::Receiver<()>| {
+            async move {
             loop {
                 // Asynchronously wait for an inbound socket.
                 let socket = self.listener.accept().await;
                 let start = Instant::now();
                 let mut force_shutdown = force_shutdown.clone();
-                let drain = sub_drain.clone();
+                let drain = drain.clone();
                 let pi = self.pi.clone();
                 match socket {
                     Ok((stream, remote)) => {
                         let serve_client = async move {
-                            debug!(dur=?start.elapsed(), "inbound passthrough connection started");
+                            debug!(component="inbound passthrough", "connection started");
                             // Since this task is spawned, make sure we are guaranteed to terminate
                             tokio::select! {
                                 _ = force_shutdown.changed() => {
-                                    debug!("inbound passthrough connection forcefully terminated signaled");
+                                    debug!(component="inbound passthrough", "connection forcefully terminated");
                                 }
-                                _ = Self::proxy_inbound_plaintext(
-                            pi, // pi cloned above; OK to move
-                            socket::to_canonical(remote),
-                            stream,
-                            self.enable_orig_src,
-                        ) => {}
+                                _ = Self::proxy_inbound_plaintext(pi, socket::to_canonical(remote), stream, self.enable_orig_src) => {
+                                }
                             }
                             // Mark we are done with the connection, so drain can complete
                             drop(drain);
-                            debug!(dur=?start.elapsed(), "inbound passthrough connection completed");
+                            debug!(component="inbound passthrough", dur=?start.elapsed(), "connection completed");
                         }
                         .in_current_span();
 
@@ -111,27 +106,10 @@ impl InboundPassthrough {
                 }
             }
         }
-        .in_current_span();
+        .in_current_span()
+        };
 
-        // Stop accepting once we drain.
-        // We will then allow connections up to `deadline` to terminate on their own.
-        // After that, they will be forcefully terminated.
-        tokio::select! {
-            res = accept => { res }
-            res = self.drain.signaled() => {
-                debug!("inbound passthrough drained, waiting {:?} for any outbound connections to close", deadline);
-                if let Err(e) = timeout(deadline, sub_drain_signal.drain()).await {
-                    // Not all connections completed within time, we will force shut them down
-                    warn!("drain duration expired with pending connections, forcefully shutting down: {e:?}");
-                }
-                // Trigger force shutdown. In theory, this is only needed in the timeout case. However,
-                // it doesn't hurt to always trigger it.
-                let _ = trigger_force_shutdown.send(());
-
-                info!("outbound drain complete");
-                drop(res);
-            }
-        }
+        run_with_drain("inbound passthrough".to_string(), self.drain, &pi, accept).await
     }
 
     async fn proxy_inbound_plaintext(

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -776,7 +776,9 @@ mod test {
         assert_opens_drops!(srv, 2, 1);
 
         // Trigger the persistent client to stop, we should evict that connection as well
-        client_stop_signal.start_drain_and_wait().await;
+        client_stop_signal
+            .start_drain_and_wait(drain::DrainMode::Immediate)
+            .await;
         assert_opens_drops!(srv, 2, 1);
     }
 

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -564,9 +564,8 @@ mod test {
     use std::net::SocketAddr;
     use std::time::Instant;
 
-    use crate::{identity, proxy};
+    use crate::{drain, identity, proxy};
 
-    use drain::Watch;
     use futures_util::{future, StreamExt};
     use hyper::body::Incoming;
 
@@ -584,6 +583,7 @@ mod test {
 
     use crate::test_helpers::helpers::initialize_telemetry;
 
+    use crate::drain::DrainWatcher;
     use ztunnel::test_helpers::*;
 
     use super::*;
@@ -765,7 +765,7 @@ mod test {
         let (pool, mut srv) = setup_test_with_idle(4, Duration::from_millis(100)).await;
 
         let key = key(&srv, 1);
-        let (client_stop_signal, client_stop) = drain::channel();
+        let (client_stop_signal, client_stop) = drain::new();
         // Spin up 1 connection
         spawn_persistent_client(pool.clone(), key.clone(), srv.addr, client_stop).await;
         spawn_clients_concurrently(pool.clone(), key.clone(), srv.addr, 2).await;
@@ -776,7 +776,7 @@ mod test {
         assert_opens_drops!(srv, 2, 1);
 
         // Trigger the persistent client to stop, we should evict that connection as well
-        client_stop_signal.drain().await;
+        client_stop_signal.start_drain_and_wait().await;
         assert_opens_drops!(srv, 2, 1);
     }
 
@@ -847,7 +847,7 @@ mod test {
         mut pool: WorkloadHBONEPool,
         key: WorkloadKey,
         remote_addr: SocketAddr,
-        stop: Watch,
+        stop: DrainWatcher,
     ) {
         let req = || {
             http::Request::builder()
@@ -866,7 +866,7 @@ mod test {
             start.elapsed().as_millis()
         );
         tokio::spawn(async move {
-            let _ = stop.signaled().await;
+            let _ = stop.wait_for_drain().await;
             debug!("persistent client stop");
             // Close our connection
             drop(c1);

--- a/src/proxy/util.rs
+++ b/src/proxy/util.rs
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proxy::ProxyInputs;
-use drain::Watch;
-use std::future::Future;
 use std::io::{Error, ErrorKind};
-use tokio::sync::watch;
-use tracing::{debug, info, warn};
 
 pub fn is_runtime_shutdown(e: &Error) -> bool {
     if e.kind() == ErrorKind::Other
@@ -26,46 +21,4 @@ pub fn is_runtime_shutdown(e: &Error) -> bool {
         return true;
     }
     false
-}
-
-/// run_with_drain provides a wrapper to run a future with graceful shutdown/draining support.
-/// A caller should construct a future with takes two arguments:
-/// * drain: while holding onto this, the future is marked as active, which will block the server from shutting down.
-///   Additionally, it can be watched (with drain.signaled()) to see when to start a graceful shutdown.
-/// * force_shutdown: when this is triggered, the future must forcefully shutdown any ongoing work ASAP.
-///   This means the graceful drain exceeded the hard deadline, and all work must terminate now.
-///   This is only required for spawned() tasks; otherwise, the future is dropped entirely, canceling all work.
-pub async fn run_with_drain<F, Fut, O>(
-    component: String,
-    drain: Watch,
-    pi: &ProxyInputs,
-    make_future: F,
-) where
-    F: FnOnce(Watch, watch::Receiver<()>) -> Fut,
-    Fut: Future<Output = O>,
-    O: Send + 'static,
-{
-    let deadline = pi.cfg.self_termination_deadline;
-    let (sub_drain_signal, sub_drain) = drain::channel();
-    let (trigger_force_shutdown, force_shutdown) = watch::channel(());
-    // Stop accepting once we drain.
-    // We will then allow connections up to `deadline` to terminate on their own.
-    // After that, they will be forcefully terminated.
-    let fut = make_future(sub_drain, force_shutdown);
-    tokio::select! {
-        _res = fut => {}
-        res = drain.signaled() => {
-            debug!(component, "drain started, waiting {:?} for any connections to complete", deadline);
-            if tokio::time::timeout(deadline, sub_drain_signal.drain()).await.is_err() {
-                // Not all connections completed within time, we will force shut them down
-                warn!(component, "drain duration expired with pending connections, forcefully shutting down");
-            }
-            // Trigger force shutdown. In theory, this is only needed in the timeout case. However,
-            // it doesn't hurt to always trigger it.
-            let _ = trigger_force_shutdown.send(());
-
-            info!(component, "drain complete");
-            drop(res);
-        }
-    };
 }

--- a/src/proxy/util.rs
+++ b/src/proxy/util.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::proxy::ProxyInputs;
+use drain::Watch;
+use std::future::Future;
 use std::io::{Error, ErrorKind};
+use tokio::sync::watch;
+use tracing::{debug, info, warn};
 
 pub fn is_runtime_shutdown(e: &Error) -> bool {
     if e.kind() == ErrorKind::Other
@@ -21,4 +26,46 @@ pub fn is_runtime_shutdown(e: &Error) -> bool {
         return true;
     }
     false
+}
+
+/// run_with_drain provides a wrapper to run a future with graceful shutdown/draining support.
+/// A caller should construct a future with takes two arguments:
+/// * drain: while holding onto this, the future is marked as active, which will block the server from shutting down.
+///   Additionally, it can be watched (with drain.signaled()) to see when to start a graceful shutdown.
+/// * force_shutdown: when this is triggered, the future must forcefully shutdown any ongoing work ASAP.
+///   This means the graceful drain exceeded the hard deadline, and all work must terminate now.
+///   This is only required for spawned() tasks; otherwise, the future is dropped entirely, canceling all work.
+pub async fn run_with_drain<F, Fut, O>(
+    component: String,
+    drain: Watch,
+    pi: &ProxyInputs,
+    make_future: F,
+) where
+    F: FnOnce(Watch, watch::Receiver<()>) -> Fut,
+    Fut: Future<Output = O>,
+    O: Send + 'static,
+{
+    let deadline = pi.cfg.self_termination_deadline;
+    let (sub_drain_signal, sub_drain) = drain::channel();
+    let (trigger_force_shutdown, force_shutdown) = watch::channel(());
+    // Stop accepting once we drain.
+    // We will then allow connections up to `deadline` to terminate on their own.
+    // After that, they will be forcefully terminated.
+    let fut = make_future(sub_drain, force_shutdown);
+    tokio::select! {
+        _res = fut => {}
+        res = drain.signaled() => {
+            debug!(component, "drain started, waiting {:?} for any connections to complete", deadline);
+            if tokio::time::timeout(deadline, sub_drain_signal.drain()).await.is_err() {
+                // Not all connections completed within time, we will force shut them down
+                warn!(component, "drain duration expired with pending connections, forcefully shutting down");
+            }
+            // Trigger force shutdown. In theory, this is only needed in the timeout case. However,
+            // it doesn't hurt to always trigger it.
+            let _ = trigger_force_shutdown.send(());
+
+            info!(component, "drain complete");
+            drop(res);
+        }
+    };
 }

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -15,11 +15,11 @@
 use crate::config;
 use crate::identity::SecretManager;
 use crate::state::{DemandProxyState, WorkloadInfo};
-use drain::Watch;
 use std::sync::Arc;
 use tracing::error;
 
 use crate::dns;
+use crate::drain::DrainWatcher;
 
 use crate::proxy::connection_manager::ConnectionManager;
 use crate::proxy::{Error, Metrics};
@@ -34,7 +34,7 @@ pub struct ProxyFactory {
     cert_manager: Arc<SecretManager>,
     proxy_metrics: Arc<Metrics>,
     dns_metrics: Option<Arc<dns::Metrics>>,
-    drain: Watch,
+    drain: DrainWatcher,
 }
 
 impl ProxyFactory {
@@ -44,7 +44,7 @@ impl ProxyFactory {
         cert_manager: Arc<SecretManager>,
         proxy_metrics: Arc<Metrics>,
         dns_metrics: Option<dns::Metrics>,
-        drain: Watch,
+        drain: DrainWatcher,
     ) -> std::io::Result<Self> {
         let dns_metrics = match dns_metrics {
             Some(metrics) => Some(Arc::new(metrics)),
@@ -73,7 +73,7 @@ impl ProxyFactory {
 
     pub async fn new_proxies_from_factory(
         &self,
-        proxy_drain: Option<Watch>,
+        proxy_drain: Option<DrainWatcher>,
         proxy_workload_info: Option<WorkloadInfo>,
         socket_factory: Arc<dyn crate::proxy::SocketFactory + Send + Sync>,
     ) -> Result<ProxyResult, Error> {

--- a/src/readiness/server.rs
+++ b/src/readiness/server.rs
@@ -16,12 +16,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use drain::Watch;
 use http_body_util::Full;
 use hyper::body::Incoming;
 use hyper::{Request, Response};
 use itertools::Itertools;
 
+use crate::drain::DrainWatcher;
 use crate::hyper_util;
 use crate::{config, readiness};
 
@@ -33,7 +33,7 @@ pub struct Server {
 impl Server {
     pub async fn new(
         config: Arc<config::Config>,
-        drain_rx: Watch,
+        drain_rx: DrainWatcher,
         ready: readiness::Ready,
     ) -> anyhow::Result<Self> {
         hyper_util::Server::<readiness::Ready>::bind(

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -59,7 +59,7 @@ pub struct ShutdownTrigger {
 
 impl ShutdownTrigger {
     pub async fn shutdown_now(&self) {
-        self.shutdown_tx.send(()).await.unwrap();
+        let _ = self.shutdown_tx.send(()).await;
     }
 }
 

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -15,10 +15,11 @@
 use crate::config::Address;
 use crate::dns::resolver::{Answer, Resolver};
 use crate::dns::Metrics;
+use crate::drain::DrainTrigger;
 use crate::proxy::Error;
 use crate::state::workload::Workload;
 use crate::test_helpers::new_proxy_state;
-use crate::{dns, metrics};
+use crate::{dns, drain, metrics};
 use futures_util::ready;
 use futures_util::stream::{Stream, StreamExt};
 use hickory_client::client::{AsyncClient, ClientHandle};
@@ -213,7 +214,7 @@ pub struct TestDnsServer {
     tcp: SocketAddr,
     udp: SocketAddr,
     resolver: Arc<dyn Resolver>,
-    _drain: drain::Signal,
+    _drain: DrainTrigger,
 }
 
 impl TestDnsServer {
@@ -249,7 +250,7 @@ pub async fn run_dns(responses: HashMap<Name, Vec<IpAddr>>) -> anyhow::Result<Te
         let istio_registry = metrics::sub_registry(&mut registry);
         Arc::new(Metrics::new(istio_registry))
     };
-    let (signal, drain) = drain::channel();
+    let (signal, drain) = drain::new();
     let factory = crate::proxy::DefaultSocketFactory {};
 
     let state = new_proxy_state(&[], &[], &[]);

--- a/src/test_helpers/inpod.rs
+++ b/src/test_helpers/inpod.rs
@@ -75,6 +75,7 @@ pub fn start_ztunnel_server<P: AsRef<Path> + Send + 'static>(
             info!("ack received, len {}", read_amount);
             // Now await for FDs
             while let Some((uid, fd)) = rx.recv().await {
+                let orig_uid = uid.clone();
                 let uid = crate::inpod::WorkloadUid::new(uid);
                 if fd >= 0 {
                     send_workload_added(&mut ztun_sock, uid, fd).await;
@@ -83,8 +84,8 @@ pub fn start_ztunnel_server<P: AsRef<Path> + Send + 'static>(
                 };
 
                 // receive ack from ztunnel
-                let ack = read_msg(&mut ztun_sock).await;
-                info!("ack received, len {:?}", ack);
+                let _ = read_msg(&mut ztun_sock).await;
+                info!(uid=orig_uid, %fd, "ack received");
                 rx.ack().await.expect("ack failed");
             }
         });

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -213,7 +213,6 @@ async fn run_requests_test(
     // Test a round trip outbound call (via socks5)
     let echo = tcp::TestServer::new(tcp::Mode::ReadWrite, 0).await;
     let echo_addr = echo.address();
-    let dns_drain: Option<drain::Signal> = None;
     let mut cfg = config::Config {
         local_node: (!node.is_empty()).then(|| node.to_string()),
         ..test_config_with_port(echo_addr.port())
@@ -247,7 +246,6 @@ async fn run_requests_test(
         }
     })
     .await;
-    drop(dns_drain);
 }
 
 #[tokio::test]

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -503,8 +503,18 @@ mod namespaced {
 
         cjh.join().unwrap()?;
 
-        let res = client.run_and_wait(move || async move { Ok(TcpStream::connect(srv).await?) });
-        assert!(res.is_err(), "requests should fail after shutdown");
+        assert_eventually(
+            Duration::from_secs(2),
+            || async {
+                client
+                    .run_and_wait(move || async move { Ok(TcpStream::connect(srv).await?) })
+                    .is_err()
+            },
+            true,
+        )
+        .await;
+        // let res = client.run_and_wait(move || async move { Ok(TcpStream::connect(srv).await?) });
+        // assert!(res.is_err(), "requests should fail after shutdown");
         Ok(())
     }
 

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -22,6 +22,7 @@ mod namespaced {
     use std::net::{IpAddr, SocketAddr};
 
     use std::str::FromStr;
+    use std::thread::JoinHandle;
     use std::time::Duration;
     use ztunnel::rbac::{Authorization, RbacMatch, StringMatch};
 
@@ -469,6 +470,115 @@ mod namespaced {
         )
         .await;
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ztunnel_shutdown() -> anyhow::Result<()> {
+        let mut manager = setup_netns_test!(InPod);
+        let local = manager.deploy_ztunnel(DEFAULT_NODE).await?;
+        let server = manager
+            .workload_builder("server", DEFAULT_NODE)
+            .register()
+            .await?;
+        run_tcp_server(server)?;
+
+        let client = manager
+            .workload_builder("client", DEFAULT_NODE)
+            .register()
+            .await?;
+        let (mut tx, rx) = mpsc_ack(1);
+        let srv = resolve_target(manager.resolver(), "server");
+
+        // Run a client which will send some traffic when signaled to do so
+        let cjh = run_long_running_tcp_client(&client, rx, srv)?;
+
+        // First, send the initial request and wait for it
+        tx.send_and_wait(()).await?;
+        // Now start shutdown. Ztunnel should keep things working since we have pending open connections
+        local.shutdown.shutdown_now().await;
+        // Requests should still succeed...
+        tx.send_and_wait(()).await?;
+        // Close the connection
+        drop(tx);
+
+        cjh.join().unwrap()?;
+
+        let res = client.run_and_wait(move || async move { Ok(TcpStream::connect(srv).await?) });
+        assert!(res.is_err(), "requests should fail after shutdown");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_server_shutdown() -> anyhow::Result<()> {
+        let mut manager = setup_netns_test!(InPod);
+        manager.deploy_ztunnel(DEFAULT_NODE).await?;
+        let server = manager
+            .workload_builder("server", DEFAULT_NODE)
+            .register()
+            .await?;
+        run_tcp_server(server)?;
+
+        let client = manager
+            .workload_builder("client", DEFAULT_NODE)
+            .register()
+            .await?;
+        let (mut tx, rx) = mpsc_ack(1);
+        let srv = resolve_target(manager.resolver(), "server");
+
+        // Run a client which will send some traffic when signaled to do so
+        let cjh = run_long_running_tcp_client(&client, rx, srv)?;
+
+        // First, send the initial request and wait for it
+        tx.send_and_wait(()).await?;
+        // Now shutdown the server. In real world, the server app would shutdown, then ztunnel would remove itself.
+        // In this test, we will leave the server app running, but shutdown ztunnel.
+        manager.delete_workload("server").await.unwrap();
+        // Requests should still succeed...
+        // TODO: requests here should actually immediately fail
+        tx.send_and_wait(()).await?;
+        // Close the connection
+        drop(tx);
+
+        cjh.join().unwrap()?;
+
+        // Now try to connect and make sure it fails
+        client
+            .run_and_wait(move || async move {
+                let mut stream = TcpStream::connect(srv).await.unwrap();
+                // We should be able to connect (since client is running), but not send a request
+                let send = timeout(
+                    Duration::from_millis(50),
+                    double_read_write_stream(&mut stream),
+                )
+                .await;
+                assert!(send.is_err());
+                Ok(())
+            })
+            .unwrap();
+        Ok(())
+    }
+
+    fn run_long_running_tcp_client(
+        client: &Namespace,
+        mut rx: MpscAckReceiver<()>,
+        srv: SocketAddr,
+    ) -> anyhow::Result<JoinHandle<anyhow::Result<()>>> {
+        client.run(move || async move {
+            let mut stream = timeout(Duration::from_secs(5), TcpStream::connect(srv))
+                .await
+                .unwrap()
+                .unwrap();
+            while let Some(()) = rx.recv().await {
+                timeout(
+                    Duration::from_secs(5),
+                    double_read_write_stream(&mut stream),
+                )
+                .await
+                .unwrap();
+                rx.ack().await.unwrap();
+            }
+            Ok(())
+        })
     }
 
     #[tokio::test]


### PR DESCRIPTION
* Centralize draining logic in one helper function
* Fix inbound draining (HBONE). Before, we did not shut down the
  listener upon draining. This meant new connections would go to the old
ztunnel on a ztunnel restart.
* Simplify inbound draining; do not re-create the force shutdown logic,
  and instead let the common abstraction do it (which does it slightly
better)
* socsk5: add propery draining with force shutdown. Remove double-spawn,
  which adds some complexity around the proxy_to_cancellable.

This is primarily tested in https://github.com/istio/istio/pull/51710,
which sends a large stream of requests and restarts ztunnel and the
backend app (2 different tests). With this change, these tests pass.

It would be good to get more isolated tests in this repo in the future
as well
