### PR TITLE
Better proto err logging/announce retries

### DIFF
--- a/src/inpod.rs
+++ b/src/inpod.rs
@@ -50,8 +50,8 @@ pub enum Error {
     SendAckError(String),
     #[error("error sending nack: {0}")]
     SendNackError(String),
-    #[error("protocol error")]
-    ProtocolError,
+    #[error("protocol error: {0}")]
+    ProtocolError(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]

--- a/src/inpod.rs
+++ b/src/inpod.rs
@@ -52,6 +52,8 @@ pub enum Error {
     SendNackError(String),
     #[error("protocol error: {0}")]
     ProtocolError(String),
+    #[error("announce error: {0}")]
+    AnnounceError(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]

--- a/src/inpod/protocol.rs
+++ b/src/inpod/protocol.rs
@@ -31,6 +31,7 @@ pub struct WorkloadStreamProcessor {
     drain: Watch,
 }
 
+
 #[allow(dead_code)]
 impl WorkloadStreamProcessor {
     pub fn new(stream: UnixStream, drain: Watch) -> Self {
@@ -41,7 +42,7 @@ impl WorkloadStreamProcessor {
         let r = ZdsHello {
             version: Version::V1 as i32,
         };
-        self.send_msg(r).await
+        self.send_msg(r.clone()).await
     }
 
     pub async fn send_ack(&mut self) -> std::io::Result<()> {

--- a/src/inpod/protocol.rs
+++ b/src/inpod/protocol.rs
@@ -31,7 +31,6 @@ pub struct WorkloadStreamProcessor {
     drain: Watch,
 }
 
-
 #[allow(dead_code)]
 impl WorkloadStreamProcessor {
     pub fn new(stream: UnixStream, drain: Watch) -> Self {

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -14,7 +14,7 @@
 
 use drain::Signal;
 use std::sync::Arc;
-use tracing::{debug, info, error, Instrument};
+use tracing::{debug, info, Instrument};
 
 use super::{metrics::Metrics, Error, WorkloadMessage};
 
@@ -130,7 +130,9 @@ impl WorkloadProxyManagerState {
                 info!("pod keep received. will not delete it when snapshot is sent");
                 if self.snapshot_received {
                     // this can only happen before snapshot is received.
-                    return Err(Error::ProtocolError("pod keep received after snapshot".into()));
+                    return Err(Error::ProtocolError(
+                        "pod keep received after snapshot".into(),
+                    ));
                 }
                 self.snapshot_names.insert(workload_uid);
                 Ok(())
@@ -141,7 +143,9 @@ impl WorkloadProxyManagerState {
                     // TODO: consider if this is an error. if not, do this instead:
                     // self.snapshot_names.remove(&workload_uid)
                     // self.pending_workloads.remove(&workload_uid)
-                    return Err(Error::ProtocolError("pod delete received before snapshot".into()));
+                    return Err(Error::ProtocolError(
+                        "pod delete received before snapshot".into(),
+                    ));
                 }
                 self.del_workload(&workload_uid);
                 Ok(())

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -184,10 +184,10 @@ impl WorkloadProxyManager {
                 Ok(()) => {
                     info!("process stream ended with eof");
                 }
-                Err(Error::ProtocolError) => {
+                Err(Error::ProtocolError(e)) => {
                     error!("protocol mismatch error while processing stream, shutting down");
                     self.readiness.not_ready();
-                    return Err(anyhow::anyhow!("protocol error"));
+                    return Err(anyhow::anyhow!("protocol error {:?}", e));
                 }
                 Err(e) => {
                     // for other errors, just retry
@@ -263,7 +263,7 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
         processor
             .send_hello()
             .await
-            .map_err(|_| Error::ProtocolError)?;
+            .map_err(|_| Error::ProtocolError("could not announce to node agent".into()))?;
 
         loop {
             let msg = match self.read_message_and_retry_proxies(&mut processor).await {

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::readiness;
+use backoff::{backoff::Backoff, ExponentialBackoff};
 use drain::Watch;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -26,6 +27,8 @@ use super::protocol::WorkloadStreamProcessor;
 
 const RETRY_DURATION: Duration = Duration::from_secs(5);
 
+const CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL: Duration = Duration::from_secs(15);
+
 struct WorkloadProxyNetworkHandler {
     uds: PathBuf,
 }
@@ -35,6 +38,7 @@ struct WorkloadProxyReadinessHandler {
     // Manually drop as we don't want to mark ready if we are dropped.
     // This can happen when the server drains.
     block_ready: Option<std::mem::ManuallyDrop<readiness::BlockReady>>,
+    backoff: ExponentialBackoff,
 }
 
 pub struct WorkloadProxyManager {
@@ -52,10 +56,20 @@ struct WorkloadProxyManagerProcessor<'a> {
 }
 
 impl WorkloadProxyReadinessHandler {
-    fn new(ready: readiness::Ready) -> Self {
+    fn new(ready: readiness::Ready, reconnect_backoff: Option<ExponentialBackoff>) -> Self {
+
+        let backoff = reconnect_backoff.unwrap_or(ExponentialBackoff{
+            initial_interval: Duration::from_millis(5),
+            max_interval: CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL,
+            multiplier: 2.0,
+            randomization_factor: 0.2,
+            ..Default::default()
+        });
+
         let mut r = Self {
             ready,
             block_ready: None,
+            backoff,
         };
         r.not_ready();
         r
@@ -71,9 +85,12 @@ impl WorkloadProxyReadinessHandler {
 
             std::mem::drop(block_ready);
         }
+
+        self.backoff.reset()
     }
 
     fn not_ready(&mut self) {
+        debug!("workload proxy manager is NOT ready");
         if self.block_ready.is_none() {
             self.block_ready = Some(std::mem::ManuallyDrop::new(
                 self.ready.register_task("workload proxy manager"),
@@ -88,7 +105,6 @@ impl WorkloadProxyNetworkHandler {
     }
 
     async fn connect(&self) -> UnixStream {
-        const MAX_BACKOFF: Duration = Duration::from_secs(15);
         let mut backoff = Duration::from_millis(10);
 
         debug!("connecting to server: {:?}", self.uds);
@@ -96,7 +112,7 @@ impl WorkloadProxyNetworkHandler {
         loop {
             match super::packet::connect(&self.uds).await {
                 Err(e) => {
-                    backoff = std::cmp::min(MAX_BACKOFF, backoff * 2);
+                    backoff = std::cmp::min(CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL, backoff * 2);
                     warn!(
                         "failed to connect to server {:?}: {:?}. retrying in {:?}",
                         &self.uds, e, backoff
@@ -137,7 +153,7 @@ impl WorkloadProxyManager {
         let mgr = WorkloadProxyManager {
             state,
             networking,
-            readiness: WorkloadProxyReadinessHandler::new(ready),
+            readiness: WorkloadProxyReadinessHandler::new(ready, None),
         };
         Ok(mgr)
     }
@@ -162,6 +178,7 @@ impl WorkloadProxyManager {
         // for now just drop block_ready, until we support knowing that our state is in sync.
         debug!("workload proxy manager is running");
         // hold the  release shutdown until we are done with `state.drain` below.
+
         let _rs = loop {
             // Accept a connection
             let stream = tokio::select! {
@@ -184,17 +201,38 @@ impl WorkloadProxyManager {
                 Ok(()) => {
                     info!("process stream ended with eof");
                 }
+                // If we successfully accepted a connection, but the first thing we try (announce)
+                // fails, it can mean 2 things:
+                // 1. The connection was killed because the node agent happened to restart at a bad time
+                // 2. The connection was killed because we have a protocol mismatch with the node agent.
+                //
+                // For case 1, we must keep retrying. For case 2 we shouldn't retry, as we will spam
+                // an incompatible server with messages and connections it can't understand.
+                //
+                // We also cannot easily tell these cases apart due to the simplistic protocol in use here,
+                // so a happy medium is to backoff if we get announce errors - they could be legit or
+                // non-legit disconnections, we can't tell.
+                Err(Error::AnnounceError(e)) => {
+                    error!("could not announce to node agent, retrying with backoff");
+                    self.readiness.not_ready();
+
+                    // This will retry infinitely for as long as the socket doesn't EOF, but not immediately.
+                    let wait = self.readiness.backoff.next_backoff().unwrap_or(CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL);
+                    warn!("node agent connect failed ({e}), retrying in {wait:?}");
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
                 Err(Error::ProtocolError(e)) => {
                     error!("protocol mismatch error while processing stream, shutting down");
                     self.readiness.not_ready();
-                    return Err(anyhow::anyhow!("protocol error {:?}", e));
+                    return Err(anyhow::anyhow!("protocol error {:?}", e))
                 }
                 Err(e) => {
                     // for other errors, just retry
                     warn!("process stream ended: {:?}", e);
                 }
             };
-            debug!("workload proxy manager is NOT ready");
+
             self.readiness.not_ready();
         };
 
@@ -263,7 +301,7 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
         processor
             .send_hello()
             .await
-            .map_err(|_| Error::ProtocolError("could not announce to node agent".into()))?;
+            .map_err(|_| Error::AnnounceError("could not announce to node agent".into()))?;
 
         loop {
             let msg = match self.read_message_and_retry_proxies(&mut processor).await {
@@ -340,6 +378,8 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
 pub(crate) mod tests {
 
     use super::super::protocol::WorkloadStreamProcessor;
+    
+    use tokio::io::AsyncWriteExt;
 
     use super::*;
 
@@ -357,6 +397,13 @@ pub(crate) mod tests {
             }
             Ok(()) => {}
             Err(e) => panic!("expected error due to EOF {:?}", e),
+        }
+    }
+
+    fn assert_announce_error(res: Result<(), Error>) {
+        match res {
+            Err(Error::AnnounceError(_)) => {},
+            _ => panic!("expected announce error")
         }
     }
 
@@ -402,12 +449,35 @@ pub(crate) mod tests {
             read_msg(&mut s2).await;
         });
 
-        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new());
+        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new(), None);
         let mut processor_helper = WorkloadProxyManagerProcessor::new(&mut state, &mut readiness);
 
         let res = processor_helper.process(processor).await;
         // make sure that the error is due to eof:
         assert_end_stream(res);
+        assert!(!readiness.ready.pending().is_empty());
+        state.drain().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_process_failed_announce() {
+        let f = fixture!();
+        let (s1, mut s2) = UnixStream::pair().unwrap();
+        let processor = WorkloadStreamProcessor::new(s1, f.drain_rx.clone());
+        let mut state = f.state;
+
+        // fake server that simply slams the socket shut and bails
+        let server = tokio::spawn(async move {
+            let _ = s2.shutdown().await;
+        });
+
+        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new(), None);
+        let mut processor_helper = WorkloadProxyManagerProcessor::new(&mut state, &mut readiness);
+
+        let res = processor_helper.process(processor).await;
+        // make sure that the error is due to announce fail:
+        assert_announce_error(res);
         assert!(!readiness.ready.pending().is_empty());
         state.drain().await;
         server.await.unwrap();
@@ -432,7 +502,7 @@ pub(crate) mod tests {
             read_msg(&mut s2).await;
         });
 
-        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new());
+        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new(), None);
         let mut processor_helper = WorkloadProxyManagerProcessor::new(&mut state, &mut readiness);
 
         let res = processor_helper.process(processor).await;
@@ -473,7 +543,7 @@ pub(crate) mod tests {
             read_msg(&mut s2).await;
         });
 
-        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new());
+        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new(), None);
         let mut processor_helper = WorkloadProxyManagerProcessor::new(&mut state, &mut readiness);
 
         let res = processor_helper.process(processor).await;
@@ -506,7 +576,7 @@ pub(crate) mod tests {
             read_msg(&mut s2).await;
         });
 
-        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new());
+        let mut readiness = WorkloadProxyReadinessHandler::new(readiness::Ready::new(), None);
 
         let mut processor_helper = WorkloadProxyManagerProcessor::new(&mut state, &mut readiness);
         let res = processor_helper.process(processor).await;

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -57,8 +57,7 @@ struct WorkloadProxyManagerProcessor<'a> {
 
 impl WorkloadProxyReadinessHandler {
     fn new(ready: readiness::Ready, reconnect_backoff: Option<ExponentialBackoff>) -> Self {
-
-        let backoff = reconnect_backoff.unwrap_or(ExponentialBackoff{
+        let backoff = reconnect_backoff.unwrap_or(ExponentialBackoff {
             initial_interval: Duration::from_millis(5),
             max_interval: CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL,
             multiplier: 2.0,
@@ -112,7 +111,8 @@ impl WorkloadProxyNetworkHandler {
         loop {
             match super::packet::connect(&self.uds).await {
                 Err(e) => {
-                    backoff = std::cmp::min(CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL, backoff * 2);
+                    backoff =
+                        std::cmp::min(CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL, backoff * 2);
                     warn!(
                         "failed to connect to server {:?}: {:?}. retrying in {:?}",
                         &self.uds, e, backoff
@@ -217,7 +217,11 @@ impl WorkloadProxyManager {
                     self.readiness.not_ready();
 
                     // This will retry infinitely for as long as the socket doesn't EOF, but not immediately.
-                    let wait = self.readiness.backoff.next_backoff().unwrap_or(CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL);
+                    let wait = self
+                        .readiness
+                        .backoff
+                        .next_backoff()
+                        .unwrap_or(CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL);
                     warn!("node agent connect failed ({e}), retrying in {wait:?}");
                     tokio::time::sleep(wait).await;
                     continue;
@@ -225,7 +229,7 @@ impl WorkloadProxyManager {
                 Err(Error::ProtocolError(e)) => {
                     error!("protocol mismatch error while processing stream, shutting down");
                     self.readiness.not_ready();
-                    return Err(anyhow::anyhow!("protocol error {:?}", e))
+                    return Err(anyhow::anyhow!("protocol error {:?}", e));
                 }
                 Err(e) => {
                     // for other errors, just retry
@@ -378,7 +382,7 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
 pub(crate) mod tests {
 
     use super::super::protocol::WorkloadStreamProcessor;
-    
+
     use tokio::io::AsyncWriteExt;
 
     use super::*;
@@ -402,8 +406,8 @@ pub(crate) mod tests {
 
     fn assert_announce_error(res: Result<(), Error>) {
         match res {
-            Err(Error::AnnounceError(_)) => {},
-            _ => panic!("expected announce error")
+            Err(Error::AnnounceError(_)) => {}
+            _ => panic!("expected announce error"),
         }
     }
 


### PR DESCRIPTION
I _think_ this will fix https://github.com/istio/istio/issues/51709

Context: We used to retry on protocol errors indefinitely. https://github.com/istio/ztunnel/pull/1136 made protocol errors fatal. Note that we always have retried on _unix socket connection failures_, but until https://github.com/istio/ztunnel/pull/1136 didn't fail on _protocol_ errors once the connection is established.

https://github.com/istio/istio/pull/51574 added a test which forcibly recycles `istio-cni` and makes sure zt can recover without the dataplane being disrupted (it should).

This _mostly_ works but sometimes we can get [unlucky in that test ](https://storage.googleapis.com/istio-prow/logs/integ-ambient_istio_postsubmit/1805371660040146944/artifacts/ambient-cni-64174fcad69e4bd89a4/TestTrafficWithEstablishedPodsIfCNIMissing/jwt-claim-route/matched_with_nested_claim_using_claim_to_header:200/to_captured/_test_context/istio-state549725766/primary-0/ztunnel-kr5zs_istio-proxy.previous.log) and (I think) get disconnected

1. After we successfully "accept"
2. Before we successfully send our announcement (which is always the first thing we do, and which is not ACK'd)

Now, we could just do what we used to do and retry on any failed send/recv, waiting for a new connection attempt at that point, but that gets back into the problem of spamming the node agent with spurious connections if we happen to have a proto mismatch and the announce is doomed to fail for as long as we have that node agent on our node.

Basically, because this is a very simple DIY UDP protocol, we have no way to tell why the other end hung up before we even get started - because they shut down, or because they killed the conn due to fundamental proto mismatch.

So this just does what @howardjohn originally suggested in  #1136 - adds a backoff _if_ the first time we try to send something we fail.

We reset the backoff when our internal readiness state goes green.

This is still not ideal - we will fail infinitely (well, aside from kube readiness probe limits) if it happens to be a protocol mismatch, until we get a connection to a server that can talk to us - but will fail infinitely with a backoff and a (capped) timeout, so it's a tad nicer, and should fix the issue where we have unlucky timing around `istio-cni` termination.