### PR TITLE
Keep track of logs for terminated connections

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -386,6 +386,8 @@ pub enum Error {
 
     #[error("connection failed to drain within the timeout")]
     DrainTimeOut,
+    #[error("connection closed due to connection drain")]
+    ClosedFromDrain,
 
     #[error("dns: {0}")]
     Dns(#[from] ProtoError),


### PR DESCRIPTION
Fixes https://github.com/istio/ztunnel/issues/1155

This ensures when we drain a process we emit metrics
