### PR TITLE
Improve logging of errors in copy

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -291,6 +291,9 @@ pub enum Error {
     #[error("io error: {0}")]
     Io(#[from] io::Error),
 
+    #[error("while closing connection: {0}")]
+    ShutdownError(Box<Error>),
+
     #[error("destination disconnected before all data was written")]
     BackendDisconnected,
     #[error("receive: {0}")]

--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -99,7 +99,7 @@ impl InboundPassthrough {
                         }
                         .in_current_span();
 
-                        assertions::size_between_ref(1500, 2750, &serve_client);
+                        assertions::size_between_ref(1500, 3000, &serve_client);
                         tokio::spawn(serve_client);
                     }
                     Err(e) => {


### PR DESCRIPTION
Fixes https://github.com/istio/ztunnel/issues/1183.

Before, we logged basically any error during copying. It turns out this
confuses users a lot when they see "connection reset by peer" just
because the other end shutdown. There are a number of sequences of
events that can lead to non-graceful termination of copying, and
exposing those to users just brings confusion based on some feedback.

For instance, Postgresql always closes connections with a hard RST.
This, previously, meant every postgres connection was reported as an
"error" in Ztunnel - no good.

Looking at Envoy codebase, they do NOT report these as errors: once the
connection is started, it can close for any reason silently (*except at
debug level, of course).

We take the same approach here. Also, add more context on where we are
failing (shutdown, write, etc)
