### PR TITLE
Disable IP spoofing on outbound

### DIFF
--- a/scripts/ztunnel-redirect.sh
+++ b/scripts/ztunnel-redirect.sh
@@ -3,53 +3,11 @@
 # This script sets up redirection in the ztunnel network namespace for namespaced tests (tests/README.md)
 set -ex
 
-INSTANCE_IP="${1:?INSTANCE_IP}"
-shift
-
-
 # tproxy mark, it's only used here.
-MARK=0x400/0xfff
-ORG_SRC_RET_MARK=0x4d3/0xfff
+MARK=0x539/0xfff
 
 # Below is from config.sh but used in redirect-worker.sh as well
 POD_OUTBOUND=15001
-POD_INBOUND=15008
-POD_INBOUND_PLAINTEXT=15006
-
-INBOUND_TUN=istioin
-OUTBOUND_TUN=istioout
-
-# TODO: look into why link local (169.254.x.x) address didn't work
-# they don't respond to ARP.
-INBOUND_TUN_IP=192.168.126.1
-ZTUNNEL_INBOUND_TUN_IP=192.168.126.2
-OUTBOUND_TUN_IP=192.168.127.1
-ZTUNNEL_OUTBOUND_TUN_IP=192.168.127.2
-TUN_PREFIX=30
-
-HOST_IP=$(ip route | grep default | awk '{print $3}')
-
-ip link add name p$INBOUND_TUN type geneve id 1000 remote $HOST_IP
-ip addr add $ZTUNNEL_INBOUND_TUN_IP/$TUN_PREFIX dev p$INBOUND_TUN
-
-ip link add name p$OUTBOUND_TUN type geneve id 1001 remote $HOST_IP
-ip addr add $ZTUNNEL_OUTBOUND_TUN_IP/$TUN_PREFIX dev p$OUTBOUND_TUN
-
-ip link set p$INBOUND_TUN up
-ip link set p$OUTBOUND_TUN up
-
-echo 0 > /proc/sys/net/ipv4/conf/p$INBOUND_TUN/rp_filter
-echo 0 > /proc/sys/net/ipv4/conf/p$OUTBOUND_TUN/rp_filter
-
-ip rule add priority 20000 fwmark $MARK lookup 100
-ip rule add priority 20003 fwmark $ORG_SRC_RET_MARK lookup 100
-ip route add local 0.0.0.0/0 dev lo table 100
-
-ip route add table 101 $HOST_IP dev eth0 scope link
-ip route add table 101 0.0.0.0/0 via $OUTBOUND_TUN_IP dev p$OUTBOUND_TUN
-
-ip route add table 102 $HOST_IP dev eth0 scope link
-ip route add table 102 0.0.0.0/0 via $INBOUND_TUN_IP dev p$INBOUND_TUN
 
 set +e
 num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -c '^-')
@@ -78,19 +36,17 @@ set -e
 
 $IPTABLES -w -t mangle -F PREROUTING
 $IPTABLES -w -t nat -F OUTPUT
-
-$IPTABLES -w -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -m tcp --dport=$POD_INBOUND -j TPROXY --tproxy-mark $MARK --on-port $POD_INBOUND --on-ip 127.0.0.1
-$IPTABLES -w -t mangle -A PREROUTING -p tcp -i p$OUTBOUND_TUN -j TPROXY --tproxy-mark $MARK --on-port $POD_OUTBOUND --on-ip 127.0.0.1
-$IPTABLES -w -t mangle -A PREROUTING -p tcp -i p$INBOUND_TUN -j TPROXY --tproxy-mark $MARK --on-port $POD_INBOUND_PLAINTEXT --on-ip 127.0.0.1
-
-$IPTABLES -w -t mangle -A PREROUTING -p tcp -i eth0 ! --dst $INSTANCE_IP -j MARK --set-mark $ORG_SRC_RET_MARK
+# Redirect outbound traffic that is NOT from ztunnel (identified by mark)
+# We do not currently bother redirecting inbound traffic since we don't test it, but a more complete solution would.
+# Note: in real world, this would be a UID/GID match like sidecars. Setting mark is enabled only for testing (for now?)
+$IPTABLES -w -t nat -A OUTPUT -p tcp ! -o lo -m mark ! --mark $MARK -j REDIRECT --to-ports "${POD_OUTBOUND}"
 
 # With normal linux routing we need to disable the rp_filter
 # as we get packets from a tunnel that doesn't have default routes.
 echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
 echo 0 > /proc/sys/net/ipv4/conf/default/rp_filter
 echo 0 > /proc/sys/net/ipv4/conf/eth0/rp_filter
-
+#
 #$IPTABLES -t mangle -I PREROUTING -j LOG --log-prefix "mangle pre [zt] "
 #$IPTABLES -t mangle -I POSTROUTING -j LOG --log-prefix "mangle post [zt] "
 #$IPTABLES -t mangle -I INPUT -j LOG --log-prefix "mangle inp [zt] "

--- a/src/config.rs
+++ b/src/config.rs
@@ -226,6 +226,10 @@ pub struct Config {
     pub inpod_uds: PathBuf,
     pub inpod_port_reuse: bool,
     pub inpod_mark: u32,
+
+    // Mark to assign to all packets. Only allowed in `--feature testing` mode.
+    // This is to enable the testing of 'dedicated' mode.
+    pub testing_dedicated_mark: u32,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -492,6 +496,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         inpod_port_reuse: parse_default(INPOD_PORT_REUSE, true)?,
         inpod_mark: parse_default(INPOD_MARK, DEFAULT_INPOD_MARK)?,
         fake_self_inbound: false,
+        testing_dedicated_mark: 0,
     })
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,7 @@ const KUBERNETES_SERVICE_HOST: &str = "KUBERNETES_SERVICE_HOST";
 const NETWORK: &str = "NETWORK";
 const NODE_NAME: &str = "NODE_NAME";
 const PROXY_MODE: &str = "PROXY_MODE";
-const INPOD_MARK: &str = "INPOD_MARK";
+const PACKET_MARK: &str = "PACKET_MARK";
 const INPOD_UDS: &str = "INPOD_UDS";
 const INPOD_PORT_REUSE: &str = "INPOD_PORT_REUSE";
 const INSTANCE_IP: &str = "INSTANCE_IP";
@@ -225,11 +225,12 @@ pub struct Config {
 
     pub inpod_uds: PathBuf,
     pub inpod_port_reuse: bool,
-    pub inpod_mark: u32,
 
-    // Mark to assign to all packets. Only allowed in `--feature testing` mode.
-    // This is to enable the testing of 'dedicated' mode.
-    pub testing_dedicated_mark: u32,
+    // Mark to assign to all packets.
+    // This is required for in-pod mode.
+    // For dedicated mode, it is not strictly required, but can be useful in some environments to
+    // distinguish proxy traffic from application traffic.
+    pub packet_mark: Option<u32>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -388,6 +389,15 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         illegal_ports.insert(addr.port());
     }
 
+    let proxy_mode = match parse::<String>(PROXY_MODE)? {
+        Some(proxy_mode) => match proxy_mode.as_str() {
+            PROXY_MODE_DEDICATED => ProxyMode::Dedicated,
+            PROXY_MODE_SHARED => ProxyMode::Shared,
+            _ => return Err(Error::EnvVar(PROXY_MODE.to_string(), proxy_mode)),
+        },
+        None => ProxyMode::Shared,
+    };
+
     validate_config(Config {
         proxy: parse_default(ENABLE_PROXY, true)?,
         dns_proxy: pc
@@ -456,14 +466,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
 
         network: parse(NETWORK)?.unwrap_or_default(),
         local_node: parse(NODE_NAME)?,
-        proxy_mode: match parse::<String>(PROXY_MODE)? {
-            Some(proxy_mode) => match proxy_mode.as_str() {
-                PROXY_MODE_DEDICATED => ProxyMode::Dedicated,
-                PROXY_MODE_SHARED => ProxyMode::Shared,
-                _ => return Err(Error::EnvVar(PROXY_MODE.to_string(), proxy_mode)),
-            },
-            None => ProxyMode::Shared,
-        },
+        proxy_mode,
         local_ip: parse(INSTANCE_IP)?,
         cluster_id,
         cluster_domain,
@@ -494,9 +497,15 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         dns_resolver_opts,
         inpod_uds: parse_default(INPOD_UDS, PathBuf::from("/var/run/ztunnel/ztunnel.sock"))?,
         inpod_port_reuse: parse_default(INPOD_PORT_REUSE, true)?,
-        inpod_mark: parse_default(INPOD_MARK, DEFAULT_INPOD_MARK)?,
+        packet_mark: parse(PACKET_MARK)?.or_else(|| {
+            if proxy_mode == ProxyMode::Shared {
+                // For inpod, mark is required so default it
+                Some(DEFAULT_INPOD_MARK)
+            } else {
+                None
+            }
+        }),
         fake_self_inbound: false,
-        testing_dedicated_mark: 0,
     })
 }
 

--- a/src/inpod/config.rs
+++ b/src/inpod/config.rs
@@ -28,7 +28,7 @@ impl InPodConfig {
     pub fn new(cfg: &config::Config) -> std::io::Result<Self> {
         Ok(InPodConfig {
             cur_netns: Arc::new(InpodNetns::current()?),
-            mark: std::num::NonZeroU32::new(cfg.inpod_mark),
+            mark: std::num::NonZeroU32::new(cfg.packet_mark.expect("in pod requires packet mark")),
             reuse_port: cfg.inpod_port_reuse,
         })
     }
@@ -195,7 +195,7 @@ mod test {
             }
 
             crate::config::Config {
-                inpod_mark: 123,
+                packet_mark: Some(123),
                 ..crate::config::parse_config().unwrap()
             }
         }};

--- a/src/inpod/test_helpers.rs
+++ b/src/inpod/test_helpers.rs
@@ -65,7 +65,7 @@ impl Default for Fixture {
         let mut registry = Registry::default();
 
         let cfg = crate::config::Config {
-            inpod_mark: 1,
+            packet_mark: Some(1),
             ..crate::config::construct_config(Default::default()).unwrap()
         };
         let state = Arc::new(RwLock::new(ProxyState::default()));

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -104,6 +104,36 @@ impl SocketFactory for DefaultSocketFactory {
     }
 }
 
+pub struct MarkSocketFactory(pub u32);
+
+impl SocketFactory for MarkSocketFactory {
+    fn new_tcp_v4(&self) -> io::Result<TcpSocket> {
+        DefaultSocketFactory.new_tcp_v4().and_then(|s| {
+            socket::set_mark(&s, self.0)?;
+            Ok(s)
+        })
+    }
+
+    fn new_tcp_v6(&self) -> io::Result<TcpSocket> {
+        DefaultSocketFactory.new_tcp_v6().and_then(|s| {
+            socket::set_mark(&s, self.0)?;
+            Ok(s)
+        })
+    }
+
+    fn tcp_bind(&self, addr: SocketAddr) -> io::Result<socket::Listener> {
+        DefaultSocketFactory.tcp_bind(addr)
+    }
+
+    fn udp_bind(&self, addr: SocketAddr) -> io::Result<tokio::net::UdpSocket> {
+        DefaultSocketFactory.udp_bind(addr)
+    }
+
+    fn ipv6_enabled_localhost(&self) -> io::Result<bool> {
+        DefaultSocketFactory.ipv6_enabled_localhost()
+    }
+}
+
 pub struct Proxy {
     inbound: Inbound,
     inbound_passthrough: InboundPassthrough,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -547,10 +547,6 @@ pub async fn freebind_connect(
             }
         };
 
-        // we don't need original src with inpod outbound mode.
-        // we do need it in inbound and inbound passthrough TODO: refactor so this is derived from config
-        // local = None; // commented out for now as we only want to disable this in inpod + outbound mode
-
         match local {
             None => {
                 let socket = create_socket(addr.is_ipv4())?;

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -67,11 +67,12 @@ impl ProxyFactory {
     }
 
     pub async fn new_proxies(&self) -> Result<ProxyResult, Error> {
-        let factory = if self.config.testing_dedicated_mark != 0 {
-            new_mark_socket_factory(self.config.testing_dedicated_mark)
-        } else {
-            Arc::new(crate::proxy::DefaultSocketFactory)
-        };
+        let factory: Arc<dyn crate::proxy::SocketFactory + Send + Sync> =
+            if let Some(mark) = self.config.packet_mark {
+                Arc::new(crate::proxy::MarkSocketFactory(mark))
+            } else {
+                Arc::new(crate::proxy::DefaultSocketFactory)
+            };
         self.new_proxies_from_factory(None, None, factory).await
     }
 
@@ -132,14 +133,4 @@ pub struct ProxyResult {
     pub proxy: Option<Proxy>,
     pub dns_proxy: Option<dns::Server>,
     pub connection_manager: Option<ConnectionManager>,
-}
-
-#[cfg(feature = "testing")]
-fn new_mark_socket_factory(mark: u32) -> Arc<dyn crate::proxy::SocketFactory + Send + Sync> {
-    Arc::new(crate::test_helpers::MarkSocketFactory(mark))
-}
-
-#[cfg(not(feature = "testing"))]
-fn new_mark_socket_factory(_mark: u32) -> Arc<dyn crate::proxy::SocketFactory + Send + Sync> {
-    unimplemented!("testing_dedicated_mark requires --features testing")
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -31,7 +31,8 @@ use anyhow::anyhow;
 use bytes::{BufMut, Bytes};
 use hickory_resolver::config::*;
 
-use crate::strng;
+use crate::proxy::{DefaultSocketFactory, SocketFactory};
+use crate::{socket, strng};
 use http_body_util::{BodyExt, Full};
 use hyper::Response;
 use prometheus_client::registry::Registry;
@@ -553,4 +554,34 @@ pub fn mpsc_ack<T>(buffer: usize) -> (MpscAckSender<T>, MpscAckReceiver<T>) {
     let (tx, rx) = tokio::sync::mpsc::channel::<T>(buffer);
     let (ack_tx, ack_rx) = tokio::sync::mpsc::channel::<()>(1);
     (MpscAckSender { tx, ack_rx }, MpscAckReceiver { rx, ack_tx })
+}
+
+pub struct MarkSocketFactory(pub u32);
+
+impl SocketFactory for MarkSocketFactory {
+    fn new_tcp_v4(&self) -> std::io::Result<tokio::net::TcpSocket> {
+        DefaultSocketFactory.new_tcp_v4().and_then(|s| {
+            socket::set_mark(&s, self.0)?;
+            Ok(s)
+        })
+    }
+
+    fn new_tcp_v6(&self) -> std::io::Result<tokio::net::TcpSocket> {
+        DefaultSocketFactory.new_tcp_v6().and_then(|s| {
+            socket::set_mark(&s, self.0)?;
+            Ok(s)
+        })
+    }
+
+    fn tcp_bind(&self, addr: std::net::SocketAddr) -> std::io::Result<socket::Listener> {
+        DefaultSocketFactory.tcp_bind(addr)
+    }
+
+    fn udp_bind(&self, addr: std::net::SocketAddr) -> std::io::Result<tokio::net::UdpSocket> {
+        DefaultSocketFactory.udp_bind(addr)
+    }
+
+    fn ipv6_enabled_localhost(&self) -> std::io::Result<bool> {
+        DefaultSocketFactory.ipv6_enabled_localhost()
+    }
 }

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -145,11 +145,8 @@ impl WorkloadManager {
             local_ip: Some(ns.ip()),
             inpod_uds,
             proxy_mode,
-            testing_dedicated_mark: if proxy_mode == ProxyMode::Dedicated {
-                1337
-            } else {
-                0
-            },
+            // We use packet mark even in dedicated to distinguish proxy from application
+            packet_mark: Some(1337),
             require_original_source: if proxy_mode == ProxyMode::Dedicated {
                 Some(false)
             } else {

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -985,7 +985,12 @@ mod namespaced {
             .workload_builder("client", client_node.node())
             .register()
             .await?;
-        run_tcp_client(client, manager.resolver(), "server")?;
+        let target = if manager.mode() == Dedicated && !matches!(server_node, Uncaptured) {
+            "ztunnel-remote-node"
+        } else {
+            "server"
+        };
+        run_tcp_client(client, manager.resolver(), target)?;
 
         let metrics = [
             (CONNECTIONS_OPENED, 1),


### PR DESCRIPTION
This is not needed at all, as the ztunnel now always runs in the same
network as the workload (both inpod and dedicated).

The main part of this effort was the testing. The 'dedicated' mode is
not really testing 'dedicated mode', but rather than legacy geneve
stuff. This PR moves it closer to testing a real world setup (which runs
like an Istio sidecar/VM).

The challenge here is setting up iptables. For real world, we just run
the process and ztunnel as different namespaces. I couldn't find a way
to do that in our case, since we have one thread and some user namespace
magic (the latter was the bigger problem). To workaround this, I use a
mark, which is not compiled in by default.

The end result is we have two modes (in tests and real world):
* In pod mode
* Dedicated mode, with ztunnel running directly next to the app in the
  same network, with iptables rules doing traffic capture
