### PR TITLE
[1.22] Improve logging of errors in copy (#1188)

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::proxy;
 use crate::proxy::ConnectionResult;
-use crate::proxy::Error::{BackendDisconnected, ClientDisconnected};
+use crate::proxy::Error::{BackendDisconnected, ClientDisconnected, ReceiveError, SendError};
 use pin_project_lite::pin_project;
 use std::cmp;
 use std::future::Future;
@@ -75,18 +76,38 @@ where
     use tokio::io::AsyncWriteExt;
     let (mut rd, mut wd) = downstream.split_into_buffered_reader();
     let (mut ru, mut wu) = upstream.split_into_buffered_reader();
-
     let downstream_to_upstream = async {
-        let res = copy_buf(&mut rd, &mut wu, stats, false).await;
+        let translate_error = |e: io::Error| {
+            SendError(Box::new(match e.kind() {
+                io::ErrorKind::NotConnected => BackendDisconnected,
+                io::ErrorKind::WriteZero => BackendDisconnected,
+                io::ErrorKind::UnexpectedEof => ClientDisconnected,
+                _ => e.into(),
+            }))
+        };
+        let res = ignore_io_errors(copy_buf(&mut rd, &mut wu, stats, false).await)
+            .map_err(translate_error);
         trace!(?res, "send");
-        ignore_shutdown_errors(wu.shutdown().await)?;
+        ignore_shutdown_errors(wu.shutdown().await)
+            .map_err(translate_error)
+            .map_err(|e| proxy::Error::ShutdownError(Box::new(e)))?;
         res
     };
 
     let upstream_to_downstream = async {
-        let res = copy_buf(&mut ru, &mut wd, stats, true).await;
+        let translate_error = |e: io::Error| {
+            ReceiveError(Box::new(match e.kind() {
+                io::ErrorKind::NotConnected => ClientDisconnected,
+                io::ErrorKind::WriteZero => ClientDisconnected,
+                _ => e.into(),
+            }))
+        };
+        let res = ignore_io_errors(copy_buf(&mut ru, &mut wd, stats, true).await)
+            .map_err(translate_error);
         trace!(?res, "receive");
-        ignore_shutdown_errors(wd.shutdown().await)?;
+        ignore_shutdown_errors(wd.shutdown().await)
+            .map_err(translate_error)
+            .map_err(|e| proxy::Error::ShutdownError(Box::new(e)))?;
         res
     };
 
@@ -94,17 +115,31 @@ where
     let (sent, received) = tokio::join!(downstream_to_upstream, upstream_to_downstream);
 
     // Convert some error messages to easier to understand
-    let sent = sent.map_err(|e| match e.kind() {
-        io::ErrorKind::NotConnected => BackendDisconnected,
-        io::ErrorKind::UnexpectedEof => ClientDisconnected,
-        _ => e.into(),
-    })?;
-    let received = received.map_err(|e| match e.kind() {
-        io::ErrorKind::NotConnected => ClientDisconnected,
-        _ => e.into(),
-    })?;
+    let sent = sent?;
+    let received = received?;
     trace!(sent, received, "copy complete");
     Ok(())
+}
+
+// During copying, we may encounter errors from either side closing their connection. Typically, we
+// get a fully graceful shutdown with no errors on either end, but can if one end sends a RST directly,
+// or if we have other non-graceful behavior, we may see errors. This is generally ok - a TCP connection
+// can close at any time, really. Avoid reporting these as errors, as generally users expect errors to
+// occur only when we cannot connect to the backend at all.
+fn ignore_io_errors<T: Default>(res: Result<T, io::Error>) -> Result<T, io::Error> {
+    use io::ErrorKind::*;
+    match &res {
+        Err(e) => match e.kind() {
+            NotConnected | UnexpectedEof | ConnectionReset | BrokenPipe => {
+                trace!(err=%e, "io terminated ungracefully");
+                // Returning Default here is very hacky, but the data we are returning isn't critical so its no so bad to lose it.
+                // Changing this would require refactoring all the interfaces to always return the bytes written even on error.
+                Ok(Default::default())
+            }
+            _ => res,
+        },
+        _ => res,
+    }
 }
 
 // During shutdown, the other end may have already disconnected. That is fine, they shutdown for us.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -242,11 +242,18 @@ pub enum Error {
     #[error("io error: {0}")]
     Io(#[from] io::Error),
 
+    #[error("while closing connection: {0}")]
+    ShutdownError(Box<Error>),
+
     #[error("destination disconnected before all data was written")]
     BackendDisconnected,
+    #[error("receive: {0}")]
+    ReceiveError(Box<Error>),
 
     #[error("client disconnected before all data was written")]
     ClientDisconnected,
+    #[error("send: {0}")]
+    SendError(Box<Error>),
 
     #[error("connection failed: {0}")]
     ConnectionFailed(io::Error),


### PR DESCRIPTION
Cherrypick Fixes https://github.com/istio/ztunnel/issues/1183 from #1188.

This has been the number 1 source of confusion for ztunnel adoption in 1.22, so I think its worth a backport.
