### PR TITLE
Fix test that takes 5s

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -700,7 +700,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn build_request_unknown_source() {
         run_build_request(
             "1.2.3.4",


### PR DESCRIPTION
Make the time faked so we don't need to wait the full 5s
