### PR TITLE
Enable DNS server by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -400,10 +400,12 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
 
     validate_config(Config {
         proxy: parse_default(ENABLE_PROXY, true)?,
+        // Enable by default; running the server is not an issue, clients still need to opt-in to sending their
+        // DNS requests to Ztunnel.
         dns_proxy: pc
             .proxy_metadata
             .get(DNS_CAPTURE_METADATA)
-            .map_or(false, |value| value.to_lowercase() == "true"),
+            .map_or(true, |value| value.to_lowercase() == "true"),
 
         pool_max_streams_per_conn: parse_default(
             POOL_MAX_STREAMS_PER_CONNECTION,

--- a/src/inpod/test_helpers.rs
+++ b/src/inpod/test_helpers.rs
@@ -30,8 +30,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::istio::zds::{WorkloadRequest, WorkloadResponse, ZdsHello};
 
-use crate::drain;
 use crate::drain::{DrainTrigger, DrainWatcher};
+use crate::{dns, drain};
 use once_cell::sync::Lazy;
 use std::os::fd::{AsRawFd, OwnedFd};
 use tracing::debug;
@@ -73,6 +73,7 @@ impl Default for Fixture {
             crate::identity::mock::new_secret_manager(std::time::Duration::from_secs(10));
         let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
         let (drain_tx, drain_rx) = drain::new();
+        let dns_metrics = Some(dns::Metrics::new(&mut registry));
 
         let dstate = DemandProxyState::new(
             state.clone(),
@@ -88,7 +89,7 @@ impl Default for Fixture {
             dstate,
             cert_manager,
             metrics,
-            None,
+            dns_metrics,
             drain_rx.clone(),
         )
         .unwrap();


### PR DESCRIPTION
This enables the DNS server by default. This has no impact on the
*behavior* of applications out of the box -- they still need to opt-in
to redirecting traffic to it. However, by making this on by default, we
require only one knob to opt-in to DNS, rather than 2 which need to be
kept in sync.
