### PR TITLE
Add warning log to check NetworkPolicy for 15008 denial

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -335,6 +335,9 @@ pub enum Error {
     #[error("while closing connection: {0}")]
     ShutdownError(Box<Error>),
 
+    #[error("connection timed out, maybe a NetworkPolicy is blocking HBONE port 15008: {0}")]
+    MaybeHBONENetworkPolicyError(io::Error),
+
     #[error("destination disconnected before all data was written")]
     BackendDisconnected,
     #[error("receive: {0}")]

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -39,10 +39,10 @@ use crate::identity::Identity;
 
 use flurry;
 
-use pingora_pool;
-
 use crate::proxy::h2::client::H2ConnectClient;
 use crate::proxy::h2::H2Stream;
+use pingora_pool;
+use tokio::io;
 
 // A relatively nonstandard HTTP/2 connection pool designed to allow multiplexing proxied workload connections
 // over a (smaller) number of HTTP/2 mTLS tunnels.
@@ -88,8 +88,12 @@ impl ConnSpawner {
 
         let cert = self.cert_manager.fetch_certificate(&key.src_id).await?;
         let connector = cert.outbound_connector(key.dst_id.clone())?;
-        let tcp_stream =
-            super::freebind_connect(None, key.dst, self.socket_factory.as_ref()).await?;
+        let tcp_stream = super::freebind_connect(None, key.dst, self.socket_factory.as_ref())
+            .await
+            .map_err(|e: io::Error| match e.kind() {
+                io::ErrorKind::TimedOut => Error::MaybeHBONENetworkPolicyError(e),
+                _ => e.into(),
+            })?;
 
         let tls_stream = connector.connect(tcp_stream).await?;
         trace!("connector connected, handshaking");


### PR DESCRIPTION
This is the top feedback from users running into issues. Example

```
2024-07-26T17:18:00.953004Z     error   access  connection complete     src.addr=10.244.0.9:58592 src.workload="shell-56bd5dbdbf-gz6cq" src.namespace="default" src.identity="spiffe://cluster.local/ns/default/sa/default" dst.addr=10.244.0.10:15008 dst.hbone_addr=10.244.0.10:80 dst.service="echo.default.svc.cluster.local" dst.workload="echo-66d88ff694-pnk6h" dst.namespace="default" dst.identity="spiffe://cluster.local/ns/default/sa/default" direction="outbound" bytes_sent=0 bytes_recv=0 duration="10002ms" error="connection timed out, maybe a NetworkPolicy is blocking HBONE port 15008: deadline has elapsed"
```
