### PR TITLE
Add support for `publishNotReadyAddresses`

### DIFF
--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -137,12 +137,20 @@ message LoadBalancing {
     // 4. Any endpoints
     FAILOVER = 2;
   }
+  enum HealthPolicy {
+    // Only select healthy endpoints
+    ONLY_HEALTHY = 0;
+    // Include all endpoints, even if they are unhealthy.
+    ALLOW_ALL = 1;
+  }
 
   // routing_preference defines what scopes we want to keep traffic within.
   // The `mode` determines how these routing preferences are handled
   repeated Scope routing_preference = 1;
   // mode defines how we should handle the routing preferences.
   Mode mode = 2;
+  // health_policy defines how we should filter endpoints
+  HealthPolicy health_policy = 3;
 }
 
 // Workload represents a workload - an endpoint (or collection behind a hostname).

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -685,6 +685,7 @@ mod tests {
             load_balancing: Some(XdsLoadBalancing {
                 routing_preference: vec![1, 2],
                 mode: 1,
+                health_policy: 1,
             }), // ..Default::default() // intentionally don't default. we want all fields populated
             ip_families: 0,
         };

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -874,6 +874,7 @@ mod tests {
                 },
                 address: addr,
                 port: ports.clone(),
+                status: state::workload::HealthStatus::Healthy,
             },
         );
         Service {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -515,6 +515,7 @@ mod tests {
         test_helpers,
     };
 
+    use crate::state::workload::HealthStatus;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
     use prometheus_client::registry::Registry;
     use test_case::test_case;
@@ -621,6 +622,7 @@ mod tests {
                         },
                         address: ep_addr,
                         port: std::collections::HashMap::new(),
+                        status: HealthStatus::Healthy,
                     },
                 )]
                 .into_iter()

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -173,7 +173,7 @@ impl Service {
         self.endpoints.contains_key(&endpoint_uid(&wl.uid, addr))
     }
 
-    pub fn accepts_endpoint_health(&self, ep_health: HealthStatus) -> bool {
+    pub fn should_include_endpoint(&self, ep_health: HealthStatus) -> bool {
         ep_health == HealthStatus::Healthy
             || self
                 .load_balancer
@@ -366,7 +366,7 @@ impl ServiceStore {
         let ep_uid = endpoint_uid(&ep.workload_uid, ep.address.as_ref());
         if let Some(svc) = self.get_by_namespaced_host(&ep.service) {
             // We may or may not accept the endpoint based on it's health
-            if !svc.accepts_endpoint_health(ep.status) {
+            if !svc.should_include_endpoint(ep.status) {
                 return;
             }
             let mut svc = Arc::unwrap_or_clone(svc);
@@ -432,7 +432,7 @@ impl ServiceStore {
         let namespaced_hostname = service.namespaced_hostname();
         if let Some(endpoints) = self.staged_services.remove(&namespaced_hostname) {
             for (wip, ep) in endpoints {
-                if service.accepts_endpoint_health(ep.status) {
+                if service.should_include_endpoint(ep.status) {
                     service.endpoints.insert(wip.clone(), ep);
                 }
             }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -15,11 +15,11 @@
 use crate::config::ConfigSource;
 use crate::config::{self, RootCert};
 use crate::state::service::{Endpoint, Service};
-use crate::state::workload::Protocol;
 use crate::state::workload::Protocol::{HBONE, TCP};
 use crate::state::workload::{
     gatewayaddress, GatewayAddress, NamespacedHostname, NetworkAddress, Workload,
 };
+use crate::state::workload::{HealthStatus, Protocol};
 use crate::state::{DemandProxyState, ProxyState};
 use crate::xds::istio::security::Authorization as XdsAuthorization;
 use crate::xds::istio::workload::address;
@@ -292,6 +292,7 @@ fn test_custom_svc(
                 },
                 address: addr,
                 port: HashMap::from([(80u16, echo_port)]),
+                status: HealthStatus::Healthy,
             },
         )]),
         subject_alt_names: vec!["spiffe://cluster.local/ns/default/sa/default".into()],

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -15,7 +15,7 @@
 use crate::config::{ConfigSource, ProxyMode};
 use crate::rbac::Authorization;
 use crate::state::service::{endpoint_uid, Endpoint, Service};
-use crate::state::workload::{gatewayaddress, Workload};
+use crate::state::workload::{gatewayaddress, HealthStatus, Workload};
 use crate::test_helpers::app::TestApp;
 use crate::test_helpers::netns::{Namespace, Resolver};
 use crate::test_helpers::*;
@@ -482,6 +482,7 @@ impl<'a> TestWorkloadBuilder<'a> {
                     service: service_name.clone(),
                     address: Some(ep_network_addr.clone()),
                     port: ports.to_owned(),
+                    status: HealthStatus::Healthy,
                 };
                 let mut svc = self.manager.services.get(&service_name).unwrap().clone();
                 let ep_uid = endpoint_uid(&self.w.workload.uid, Some(&ep_network_addr));

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -260,7 +260,7 @@ impl ProxyStateUpdateMutator {
             .get_by_namespaced_host(&service.namespaced_hostname())
         {
             for (wip, ep) in prev.endpoints.iter() {
-                if service.accepts_endpoint_health(ep.status) {
+                if service.should_include_endpoint(ep.status) {
                     service.endpoints.insert(wip.clone(), ep.clone());
                 }
             }


### PR DESCRIPTION
Istio side: https://github.com/istio/istio/pull/52359

This implements support for `publishNotReadyAddresses`. This is done by inserting a new field into Service.loadbalancer which specifies we should allow unhealthy things.

The implementation is _almost_ trivial, but made more complex by how we reconcile service endpoints. There is a bug I intentionally left, where if you change from publishNotReadyAddresses=false to publishNotReadyAddresses=true, the endpoints are not added. This could be supported, however, the cost is we need to totally change how we many endpoints. IMO, given the field is niche, and changing the field is even nicher, it is safer to not support this. This is tested + commented in the code.