### PR TITLE
[Direct to 1.23] Future proof LoadBalancerPolicy

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -349,8 +349,7 @@ impl ProxyState {
         });
 
         match svc.load_balancer {
-            None => endpoints.choose(&mut rand::thread_rng()),
-            Some(ref lb) => {
+            Some(ref lb) if lb.mode != LoadBalancerMode::Standard => {
                 let ranks = endpoints
                     .filter_map(|(ep, wl)| {
                         // Load balancer will define N targets we want to match
@@ -394,6 +393,7 @@ impl ProxyState {
                     .map(|(_, ep, wl)| (ep, wl))
                     .choose(&mut rand::thread_rng())
             }
+            _ => endpoints.choose(&mut rand::thread_rng()),
         }
     }
 }

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -59,7 +59,11 @@ pub struct Service {
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub enum LoadBalancerMode {
+    // Do not consider LoadBalancerScopes when picking endpoints
+    Standard,
+    // Only select endpoints matching all LoadBalancerScopes when picking endpoints; otherwise, fail.
     Strict,
+    // Prefer select endpoints matching all LoadBalancerScopes when picking endpoints but allow mismatches
     Failover,
 }
 
@@ -67,10 +71,10 @@ impl From<xds::istio::workload::load_balancing::Mode> for LoadBalancerMode {
     fn from(value: xds::istio::workload::load_balancing::Mode) -> Self {
         match value {
             xds::istio::workload::load_balancing::Mode::Strict => LoadBalancerMode::Strict,
-            xds::istio::workload::load_balancing::Mode::UnspecifiedMode => {
-                LoadBalancerMode::Failover
-            }
             xds::istio::workload::load_balancing::Mode::Failover => LoadBalancerMode::Failover,
+            xds::istio::workload::load_balancing::Mode::UnspecifiedMode => {
+                LoadBalancerMode::Standard
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, the implementation of the LoadBalancer policy is flawed; it
assumes if the message is set, we will use failover. This actually
mostly works since failover against 'no routing preferences' is the same
as no policy, but its wasteful performance and confusing.

This ensures that if LBPolicy is used for new fields (which it will be,
see https://github.com/istio/ztunnel/pull/1231), we do not accidentally
start doing failover routing.
