### PR TITLE
Improve XDS error diagnostics

### DIFF
--- a/src/xds.rs
+++ b/src/xds.rs
@@ -55,6 +55,13 @@ impl<'a> fmt::Display for DisplayStatus<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let s = &self.0;
         write!(f, "status: {:?}, message: {:?}", s.code(), s.message())?;
+
+        if s.message().to_string().contains("authentication failure") {
+            write!(
+                f,
+                " (hint: check the control plane logs for more information)"
+            )?;
+        }
         if !s.details().is_empty() {
             if let Ok(st) = std::str::from_utf8(s.details()) {
                 write!(f, ", details: {st}")?;
@@ -62,6 +69,10 @@ impl<'a> fmt::Display for DisplayStatus<'a> {
         }
         if let Some(src) = s.source().and_then(|s| s.source()) {
             write!(f, ", source: {src}")?;
+            // Error is not public to explicitly match on, so do a fuzzy match
+            if format!("{src}").contains("Temporary failure in name resolution") {
+                write!(f, " (hint: is the DNS server reachable?)")?;
+            }
         }
         Ok(())
     }
@@ -71,8 +82,8 @@ impl<'a> fmt::Display for DisplayStatus<'a> {
 pub enum Error {
     #[error("gRPC error {}", DisplayStatus(.0))]
     GrpcStatus(#[from] tonic::Status),
-    #[error("gRPC connection error:{}", DisplayStatus(.0))]
-    Connection(#[source] tonic::Status),
+    #[error("gRPC connection error connecting to {0}: {}", DisplayStatus(.1))]
+    Connection(String, #[source] tonic::Status),
     /// Attempted to send on a MPSC channel which has been canceled
     #[error(transparent)]
     RequestFailure(#[from] Box<mpsc::error::SendError<DeltaDiscoveryRequest>>),


### PR DESCRIPTION
Based on user feedback.

Before/after

dns outage
```
2024-07-29T17:10:59.111431Z     warn    xds::client:xds{id=14}  XDS client connection error: gRPC connection error:status: Unknown, message: "client error (Connect)", source: dns error: failed to lookup address information: Temporary failure in name resolution, retrying in 15s
2024-07-29T17:22:14.958433Z     warn    xds::client:xds{id=3}   XDS client connection error: gRPC connection error connecting to https://istiod.istio-system.svc:15012: status: Unknown, message: "client error (Connect)", source: dns error: failed to lookup address information: Temporary failure in name resolution (hint: is the DNS server reachable?), retrying in 80ms
```

wrong dns name
```
2024-07-29T17:22:47.910253Z     warn    xds::client:xds{id=10}  XDS client connection error: gRPC connection error:status: Unknown, message: "client error (Connect)", source: dns error: failed to lookup address information: Name or service not known, retrying in 10.24s
2024-07-29T17:22:47.910253Z     warn    xds::client:xds{id=10}  XDS client connection error: gRPC connection error connecting to https://istiodx.istio-system.svc:15012: status: Unknown, message: "client error (Connect)", source: dns error: failed to lookup address information: Name or service not known, retrying in 10.24s
```

Bad auth (ztunnel)
```
2024-07-29T17:25:29.137815Z     warn    xds::client:xds{id=11}  XDS client connection error: gRPC connection error connecting to https://istiod.istio-system.svc:15012: status: Unauthenticated, message: "authentication failure", retrying in 15s
2024-07-29T17:35:00.273104Z     warn    xds::client:xds{id=9}   XDS client connection error: gRPC connection error connecting to https://istiod.istio-system.svc:15012: status: Unauthenticated, message: "authentication failure" (hint: check the control plane logs for more information), retrying in 5.12s
```
