### PR TITLE
[release-1.22] Minimal fix to build on rust 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,3 +144,10 @@ test-case = "3.3"
 oid-registry = "0.7"
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
 ctor = "0.2"
+
+[lints.clippy]
+# This rule makes code more confusing
+assigning_clones = "allow"
+# This doesn't understand `strng` which we use everywhere
+borrow_interior_mutable_const = "allow"
+declare_interior_mutable_const = "allow"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2560,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -2581,9 +2581,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -681,7 +681,7 @@ impl WorkloadStore {
     }
 
     pub fn has_identity(&self, identity: &Identity) -> bool {
-        self.by_identity.get(identity).is_some()
+        self.by_identity.contains_key(identity)
     }
 }
 

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -22,6 +22,7 @@ use prometheus_client::encoding::LabelValueEncoder;
 /// * Cheap cloning (ref counting)
 /// * Efficient storage (8 bytes vs 24 bytes)
 /// * Immutable
+///
 /// This is mostly provided by a library, ArcStr, we just provide a very thin wrapper around it
 /// for some flexibility.
 pub type Strng = ArcStr;


### PR DESCRIPTION
https://github.com/istio/ztunnel/pull/1241 included more fixes, so this
is direct to 1.23

(cherry picked from commit 5ef6eed334fe77e1cdf0a05674ce33a60636e420)
