### PR TITLE
remove authorization from "by_namespace" when scope change to workload

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -367,7 +367,7 @@ pub fn rbac(c: &mut Criterion) {
     let policies = create_test_policies();
     let mut state = ProxyState::default();
     for p in policies {
-        state.policies.insert(p);
+        state.policies.insert(p.to_key(), p);
     }
 
     let mut registry = Registry::default();

--- a/src/app.rs
+++ b/src/app.rs
@@ -308,7 +308,7 @@ fn init_inpod_proxy_mgr(
     _config: &config::Config,
     _proxy_gen: ProxyFactory,
     _ready: readiness::Ready,
-    _drain_rx: drain::Watch,
+    _drain_rx: drain::DrainWatcher,
 ) -> anyhow::Result<std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + Sync>>> {
     anyhow::bail!("in-pod mode is not supported on non-linux platforms")
 }

--- a/src/state/policy.rs
+++ b/src/state/policy.rs
@@ -56,28 +56,28 @@ impl PolicyStore {
             .collect()
     }
 
-    pub fn insert(&mut self, rbac: Authorization) {
-        let key: Strng = rbac.to_key();
+    pub fn insert(&mut self, xds_name: Strng, rbac: Authorization) {
+        self.remove(xds_name.clone());
         match rbac.scope {
             RbacScope::Global => {
                 self.by_namespace
                     .entry(strng::EMPTY)
                     .or_default()
-                    .insert(key.clone());
+                    .insert(xds_name.clone());
             }
             RbacScope::Namespace => {
                 self.by_namespace
                     .entry(strng::new(&rbac.namespace))
                     .or_default()
-                    .insert(key.clone());
+                    .insert(xds_name.clone());
             }
             RbacScope::WorkloadSelector => {}
         }
-        self.by_key.insert(key, rbac);
+        self.by_key.insert(xds_name.clone(), rbac);
     }
 
-    pub fn remove(&mut self, name: Strng) {
-        let Some(rbac) = self.by_key.remove(&name) else {
+    pub fn remove(&mut self, xds_name: Strng) {
+        let Some(rbac) = self.by_key.remove(&xds_name) else {
             return;
         };
         if let Some(key) = match rbac.scope {
@@ -86,7 +86,7 @@ impl PolicyStore {
             RbacScope::WorkloadSelector => None,
         } {
             if let Some(pl) = self.by_namespace.get_mut(&key) {
-                pl.remove(&name);
+                pl.remove(&xds_name);
                 if pl.is_empty() {
                     self.by_namespace.remove(&key);
                 }
@@ -102,5 +102,44 @@ impl PolicyStore {
     pub fn clear_all_policies(&mut self) {
         self.by_namespace.clear();
         self.by_key.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rbac::{RbacAction, RbacMatch, StringMatch};
+
+    #[test]
+    fn rbac_change_scope() {
+        let mut store = PolicyStore::default();
+        let namespace = "default";
+        let name = "test_policy";
+        let mut xds_name = String::with_capacity(1 + namespace.len() + name.len());
+        xds_name.push_str(namespace);
+        xds_name.push('/');
+        xds_name.push_str(name);
+        let mut policy = Authorization {
+            name: name.into(),
+            namespace: namespace.into(),
+            scope: RbacScope::Namespace,
+            action: RbacAction::Allow,
+            rules: vec![vec![vec![RbacMatch {
+                namespaces: vec![StringMatch::Exact("whatever".into())],
+                ..Default::default()
+            }]]],
+        };
+        let policy_key = policy.to_key();
+        // insert this namespace-scoped policy into policystore then assert it is
+        // exists in by_namespace of policystore
+        store.insert(xds_name.clone().into(), policy.clone());
+        let namespace_policies = store.get_by_namespace(&namespace.into());
+        assert!(namespace_policies.contains(&policy_key));
+        // change policy scope to workload and insert it into policystore again, then
+        // assert it is not exists in by_namespace of policystore anymore
+        policy.scope = RbacScope::WorkloadSelector;
+        store.insert(xds_name.clone().into(), policy.clone());
+        let namespace_policies = store.get_by_namespace(&namespace.into());
+        assert!(!namespace_policies.contains(&policy_key));
     }
 }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -273,19 +273,24 @@ impl ProxyStateUpdateMutator {
     pub fn insert_authorization(
         &self,
         state: &mut ProxyState,
+        xds_name: Strng,
         r: XdsAuthorization,
     ) -> anyhow::Result<()> {
         info!("handling RBAC update {}", r.name);
 
         let rbac = rbac::Authorization::try_from(r)?;
-        trace!("insert policy {}", serde_json::to_string(&rbac)?);
-        state.policies.insert(rbac);
+        trace!(
+            "insert policy {}, {}",
+            xds_name,
+            serde_json::to_string(&rbac)?
+        );
+        state.policies.insert(xds_name, rbac);
         Ok(())
     }
 
-    pub fn remove_authorization(&self, state: &mut ProxyState, name: Strng) {
-        info!("handling RBAC delete {}", name);
-        state.policies.remove(name);
+    pub fn remove_authorization(&self, state: &mut ProxyState, xds_name: Strng) {
+        info!("handling RBAC delete {}", xds_name);
+        state.policies.remove(xds_name);
     }
 }
 
@@ -384,9 +389,9 @@ impl Handler<XdsAuthorization> for ProxyStateUpdater {
         let mut state = self.state.write().unwrap();
         let handle = |res: XdsUpdate<XdsAuthorization>| {
             match res {
-                XdsUpdate::Update(w) => {
-                    self.updater.insert_authorization(&mut state, w.resource)?
-                }
+                XdsUpdate::Update(w) => self
+                    .updater
+                    .insert_authorization(&mut state, w.name, w.resource)?,
                 XdsUpdate::Remove(name) => self.updater.remove_authorization(&mut state, name),
             }
             Ok(())
@@ -505,7 +510,8 @@ impl LocalClient {
             insert_service_endpoints(&w, &services, &mut state.services)?;
         }
         for rbac in r.policies {
-            state.policies.insert(rbac);
+            let xds_name = rbac.to_key();
+            state.policies.insert(xds_name, rbac);
         }
         for svc in r.services {
             state.services.insert(svc);


### PR DESCRIPTION
As described in https://github.com/istio/ztunnel/issues/1247

The root cause of this bug is that Authorization not removed from 'by_namespace' when change to workload scope.