### PR TITLE
More consistent logging for inpod

### DIFF
--- a/src/inpod.rs
+++ b/src/inpod.rs
@@ -42,8 +42,8 @@ pub mod istio {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("error creating proxy: {0}")]
-    ProxyError(crate::proxy::Error),
+    #[error("error creating proxy {0}: {1}")]
+    ProxyError(String, crate::proxy::Error),
     #[error("error receiving message: {0}")]
     ReceiveMessageError(String),
     #[error("error sending ack: {0}")]


### PR DESCRIPTION
Log UID wherever we can basically. Only other difference is to log the
error before we say we are retrying, instead of after (which makes it
seem like the error is after the retry)
