### PR TITLE
Improvements to Endpoint handling 

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -769,11 +769,11 @@ mod tests {
             .unwrap();
         let resp_str = String::from(std::str::from_utf8(&resp_bytes).unwrap());
 
-        // quick sanity check that our workload is there and keyed properly.
+        // quick sanity check that our workload is there.
         // avoid stronger checks since serialization is not determinstic, and
         // most of the value of this test is ensuring that we can serialize
         // the config dump at all from our internal types
-        assert!(resp_str.contains("defaultnw/127.0.0.2"));
+        assert!(resp_str.contains("127.0.0.2"), "{resp_str}");
         // Check a waypoint
         assert!(resp_str.contains(
             r#"waypoint": {

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -436,7 +436,7 @@ impl Store {
                     service
                         .endpoints
                         .iter()
-                        .filter_map(|(_, ep)| {
+                        .filter_map(|ep| {
                             let Some(wl) = workloads.find_uid(&ep.workload_uid) else {
                                 debug!("failed to fetch workload for {}", ep.workload_uid);
                                 return None;

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -432,18 +432,19 @@ impl Store {
             Address::Service(service) => {
                 if service.vips.is_empty() {
                     // Headless service. Use the endpoint IPs.
+                    let workloads = &self.state.read().workloads;
                     service
                         .endpoints
                         .iter()
-                        .filter_map(|(_, ep)| match &ep.address {
-                            Some(addr) => {
-                                if is_record_type(&addr.address, record_type) {
-                                    Some(addr.address)
-                                } else {
-                                    None
-                                }
-                            }
-                            None => None,
+                        .filter_map(|(_, ep)| {
+                            let Some(wl) = workloads.find_uid(&ep.workload_uid) else {
+                                debug!("failed to fetch workload for {}", ep.workload_uid);
+                                return None;
+                            };
+                            wl.workload_ips
+                                .iter()
+                                .map(|a| *a)
+                                .find(|addr| is_record_type(addr, record_type))
                         })
                         .collect()
                 } else {

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -443,7 +443,7 @@ impl Store {
                             };
                             wl.workload_ips
                                 .iter()
-                                .map(|a| *a)
+                                .copied()
                                 .find(|addr| is_record_type(addr, record_type))
                         })
                         .collect()

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -500,6 +500,7 @@ mod tests {
         sync::{Arc, RwLock},
     };
 
+    use crate::state::service::EndpointSet;
     use crate::{
         rbac::Connection,
         state::{
@@ -507,8 +508,7 @@ mod tests {
             service::{Endpoint, Service},
             workload::{
                 application_tunnel::Protocol as AppProtocol, gatewayaddress::Destination,
-                ApplicationTunnel, GatewayAddress, NamespacedHostname, NetworkAddress, Protocol,
-                Workload,
+                ApplicationTunnel, GatewayAddress, NetworkAddress, Protocol, Workload,
             },
             DemandProxyState,
         },
@@ -588,50 +588,28 @@ mod tests {
         let mut state = state::ProxyState::default();
 
         let services = vec![
-            ("waypoint", WAYPOINT_SVC_IP, WAYPOINT_POD_IP, Waypoint::None),
-            (
-                "server",
-                SERVER_SVC_IP,
-                SERVER_POD_IP,
-                server_waypoint.clone(),
-            ),
+            ("waypoint", WAYPOINT_SVC_IP, Waypoint::None),
+            ("server", SERVER_SVC_IP, server_waypoint.clone()),
         ]
         .into_iter()
-        .map(|(name, vip, ep_ip, waypoint)| {
-            let ep_uid = strng::format!("cluster1//v1/Pod/default/{name}");
-            let ep_addr = Some(NetworkAddress {
-                address: ep_ip.parse().unwrap(),
-                network: strng::EMPTY,
-            });
-            Service {
-                name: name.into(),
-                namespace: "default".into(),
-                hostname: strng::format!("{name}.default.svc.cluster.local"),
-                vips: vec![NetworkAddress {
-                    address: vip.parse().unwrap(),
-                    network: "".into(),
-                }],
-                ports: std::collections::HashMap::new(),
-                endpoints: vec![(
-                    endpoint_uid(&ep_uid, ep_addr.as_ref()),
-                    Endpoint {
-                        workload_uid: ep_uid,
-                        service: NamespacedHostname {
-                            hostname: strng::format!("{name}.default.svc.cluster.local"),
-                            namespace: "default".into(),
-                        },
-                        address: ep_addr,
-                        port: std::collections::HashMap::new(),
-                        status: HealthStatus::Healthy,
-                    },
-                )]
-                .into_iter()
-                .collect(),
-                subject_alt_names: vec![strng::format!("{name}.default.svc.cluster.local")],
-                waypoint: waypoint.service_attached(),
-                load_balancer: None,
-                ip_families: None,
-            }
+        .map(|(name, vip, waypoint)| Service {
+            name: name.into(),
+            namespace: "default".into(),
+            hostname: strng::format!("{name}.default.svc.cluster.local"),
+            vips: vec![NetworkAddress {
+                address: vip.parse().unwrap(),
+                network: "".into(),
+            }],
+            ports: std::collections::HashMap::new(),
+            endpoints: EndpointSet::from_list([Endpoint {
+                workload_uid: strng::format!("cluster1//v1/Pod/default/{name}"),
+                port: std::collections::HashMap::new(),
+                status: HealthStatus::Healthy,
+            }]),
+            subject_alt_names: vec![strng::format!("{name}.default.svc.cluster.local")],
+            waypoint: waypoint.service_attached(),
+            load_balancer: None,
+            ip_families: None,
         });
 
         let workloads = vec![

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -500,12 +500,11 @@ mod tests {
         sync::{Arc, RwLock},
     };
 
-    use crate::state::service::EndpointSet;
     use crate::{
         rbac::Connection,
         state::{
             self,
-            service::{Endpoint, Service},
+            service::{Endpoint, EndpointSet, Service},
             workload::{
                 application_tunnel::Protocol as AppProtocol, gatewayaddress::Destination,
                 ApplicationTunnel, GatewayAddress, NetworkAddress, Protocol, Workload,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -411,7 +411,7 @@ impl Inbound {
             // Validate that the HBONE target references the Waypoint we're connecting to
             Some(match target_waypoint {
                 Address::Service(svc) => {
-                    if !svc.contains_endpoint(&conn_wl, Some(connection_dst)) {
+                    if !svc.contains_endpoint(&conn_wl) {
                         // target points to a different waypoint
                         return Some(None);
                     }
@@ -504,7 +504,7 @@ mod tests {
         rbac::Connection,
         state::{
             self,
-            service::{endpoint_uid, Endpoint, Service},
+            service::{Endpoint, Service},
             workload::{
                 application_tunnel::Protocol as AppProtocol, gatewayaddress::Destination,
                 ApplicationTunnel, GatewayAddress, NamespacedHostname, NetworkAddress, Protocol,

--- a/src/state.rs
+++ b/src/state.rs
@@ -322,7 +322,7 @@ impl ProxyState {
             return None;
         };
 
-        let endpoints = svc.endpoints.values().filter_map(|ep| {
+        let endpoints = svc.endpoints.iter().filter_map(|ep| {
             let Some(wl) = self.workloads.find_uid(&ep.workload_uid) else {
                 debug!("failed to fetch workload for {}", ep.workload_uid);
                 return None;

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -437,7 +437,7 @@ impl ServiceStore {
     }
 
     /// Removes entries for the given endpoint address.
-    pub fn remove_endpoint(&mut self, workload_uid: &Strng, endpoint_uid: &Strng) {
+    pub fn remove_endpoint(&mut self, workload_uid: &Strng) {
         let mut services_to_update = HashSet::new();
         if let Some(prev_services) = self.workload_to_services.remove(workload_uid) {
             for svc in prev_services.iter() {
@@ -445,7 +445,7 @@ impl ServiceStore {
                 self.staged_services
                     .entry(svc.clone())
                     .or_default()
-                    .remove(endpoint_uid);
+                    .remove(workload_uid);
                 if self.staged_services[svc].is_empty() {
                     self.staged_services.remove(svc);
                 }
@@ -458,7 +458,7 @@ impl ServiceStore {
         for svc in &services_to_update {
             if let Some(svc) = self.get_by_namespaced_host(svc) {
                 let mut svc = Arc::unwrap_or_clone(svc);
-                svc.endpoints.remove(endpoint_uid);
+                svc.endpoints.remove(workload_uid);
 
                 // Update the service.
                 self.insert(svc);

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use bytes::Bytes;
+use serde::{Deserializer, Serializer};
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::ops::Deref;
@@ -60,10 +61,27 @@ pub struct Service {
 /// While this is currently not very useful, merely wrapping a HashMap, the intent is to make this future
 /// proofed to future enhancements, such as keeping track of load balancing information the ability
 /// to incrementally update.
-#[derive(Debug, Eq, PartialEq, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Debug, Eq, PartialEq, Clone, Default)]
 pub struct EndpointSet {
     pub inner: HashMap<Strng, Endpoint>,
+}
+
+impl serde::Serialize for EndpointSet {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for EndpointSet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        <HashMap<Strng, Endpoint>>::deserialize(deserializer).map(|inner| EndpointSet { inner })
+    }
 }
 
 impl EndpointSet {

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -472,10 +472,10 @@ impl ServiceStore {
         }
     }
 
-    /// Removes the service for the given host and namespace.
-    pub fn remove(&mut self, namespaced_host: &NamespacedHostname) -> Option<Service> {
+    /// Removes the service for the given host and namespace, and returns whether something was removed
+    pub fn remove(&mut self, namespaced_host: &NamespacedHostname) -> bool {
         match self.by_host.get_mut(&namespaced_host.hostname) {
-            None => None,
+            None => false,
             Some(services) => {
                 // Remove the previous service from the by_host map.
                 let Some(prev) = ({
@@ -495,7 +495,7 @@ impl ServiceStore {
                     prev
                 }) else {
                     // Not found.
-                    return None;
+                    return false;
                 };
 
                 // Remove the entries for the previous service VIPs.
@@ -520,7 +520,7 @@ impl ServiceStore {
                 }
 
                 // Remove successful.
-                Some(prev.deref().clone())
+                true
             }
         }
     }

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arcstr::ArcStr;
 use bytes::Bytes;
-use std::collections::hash_map::Iter;
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::ops::Deref;
@@ -58,41 +56,43 @@ pub struct Service {
     pub ip_families: Option<IpFamily>,
 }
 
+/// EndpointSet is an abstraction over a set of endpoints.
+/// While this is currently not very useful, merely wrapping a HashMap, the intent is to make this future
+/// proofed to future enhancements, such as keeping track of load balancing information the ability
+/// to incrementally update.
 #[derive(Debug, Eq, PartialEq, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EndpointSet {
-    pub endpoints: HashMap<Strng, Endpoint>,
+    pub inner: HashMap<Strng, Endpoint>,
 }
 
 impl EndpointSet {
     pub fn from_list<const N: usize>(eps: [Endpoint; N]) -> EndpointSet {
-        let mut endpoints =  HashMap::with_capacity(eps.len());
+        let mut endpoints = HashMap::with_capacity(eps.len());
         for ep in eps.into_iter() {
             endpoints.insert(ep.workload_uid.clone(), ep);
         }
-        EndpointSet{
-            endpoints
-        }
+        EndpointSet { inner: endpoints }
     }
 
     pub fn insert(&mut self, k: Strng, v: Endpoint) {
-        self.endpoints.insert(k, v);
+        self.inner.insert(k, v);
     }
 
     pub fn contains(&self, key: &Strng) -> bool {
-        self.endpoints.contains_key(key)
+        self.inner.contains_key(key)
     }
 
     pub fn get(&self, key: &Strng) -> Option<&Endpoint> {
-        self.endpoints.get(key)
+        self.inner.get(key)
     }
 
     pub fn remove(&mut self, key: &Strng) {
-        self.endpoints.remove(key);
+        self.inner.remove(key);
     }
 
-    pub fn iter(&self) -> impl Iterator<Item=&Endpoint> {
-        self.endpoints.iter().map(|(_, v)| v)
+    pub fn iter(&self) -> impl Iterator<Item = &Endpoint> {
+        self.inner.values()
     }
 }
 

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -1281,7 +1281,7 @@ mod tests {
                 namespace: "ns".into(),
                 hostname: "svc-allow-unhealthy".into(),
             });
-        assert_eq!(svc.unwrap().endpoints.len(), 2);
+        assert_eq!(svc.unwrap().endpoints.inner.len(), 2);
         let svc = state
             .read()
             .unwrap()
@@ -1290,7 +1290,7 @@ mod tests {
                 namespace: "ns".into(),
                 hostname: "svc-normal".into(),
             });
-        assert_eq!(svc.unwrap().endpoints.len(), 1);
+        assert_eq!(svc.unwrap().endpoints.inner.len(), 1);
     }
 
     #[test]
@@ -1403,7 +1403,7 @@ mod tests {
                     hostname: host.into(),
                 });
             assert_eq!(
-                s.unwrap().endpoints.len(),
+                s.unwrap().endpoints.inner.len(),
                 want,
                 "host {host} wanted {want}"
             );

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -263,16 +263,8 @@ fn test_custom_svc(
     hostname: &str,
     vip: &str,
     workload_name: &str,
-    endpoint: &str,
     echo_port: u16,
 ) -> anyhow::Result<Service> {
-    let addr = match endpoint.is_empty() {
-        true => None,
-        false => Some(NetworkAddress {
-            network: strng::EMPTY,
-            address: endpoint.parse()?,
-        }),
-    };
     Ok(Service {
         name: name.into(),
         namespace: TEST_SERVICE_NAMESPACE.into(),
@@ -286,11 +278,6 @@ fn test_custom_svc(
             format!("cluster1//v1/Pod/default/{}", workload_name).into(),
             Endpoint {
                 workload_uid: format!("cluster1//v1/Pod/default/{}", workload_name).into(),
-                service: NamespacedHostname {
-                    namespace: TEST_SERVICE_NAMESPACE.into(),
-                    hostname: hostname.into(),
-                },
-                address: addr,
                 port: HashMap::from([(80u16, echo_port)]),
                 status: HealthStatus::Healthy,
             },
@@ -312,7 +299,6 @@ pub fn local_xds_config(
         TEST_SERVICE_HOST,
         TEST_VIP,
         "local-hbone",
-        TEST_WORKLOAD_HBONE,
         echo_port,
     )?;
     let dns_svc = test_custom_svc(
@@ -320,7 +306,6 @@ pub fn local_xds_config(
         TEST_SERVICE_DNS_HBONE_HOST,
         TEST_VIP_DNS,
         "local-tcp-via-dns",
-        "",
         echo_port,
     )?;
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -14,7 +14,7 @@
 
 use crate::config::ConfigSource;
 use crate::config::{self, RootCert};
-use crate::state::service::{Endpoint, Service};
+use crate::state::service::{Endpoint, EndpointSet, Service};
 use crate::state::workload::Protocol::{HBONE, TCP};
 use crate::state::workload::{
     gatewayaddress, GatewayAddress, NamespacedHostname, NetworkAddress, Workload,
@@ -179,7 +179,7 @@ pub fn mock_default_service() -> Service {
     let vips = vec![vip1];
     let mut ports = HashMap::new();
     ports.insert(8080, 80);
-    let endpoints = HashMap::new();
+    let endpoints = EndpointSet::from_list([]);
     Service {
         name: "".into(),
         namespace: "default".into(),
@@ -274,14 +274,11 @@ fn test_custom_svc(
             address: vip.parse()?,
         }],
         ports: HashMap::from([(80u16, echo_port)]),
-        endpoints: HashMap::from([(
-            format!("cluster1//v1/Pod/default/{}", workload_name).into(),
-            Endpoint {
-                workload_uid: format!("cluster1//v1/Pod/default/{}", workload_name).into(),
-                port: HashMap::from([(80u16, echo_port)]),
-                status: HealthStatus::Healthy,
-            },
-        )]),
+        endpoints: EndpointSet::from_list([Endpoint {
+            workload_uid: format!("cluster1//v1/Pod/default/{}", workload_name).into(),
+            port: HashMap::from([(80u16, echo_port)]),
+            status: HealthStatus::Healthy,
+        }]),
         subject_alt_names: vec!["spiffe://cluster.local/ns/default/sa/default".into()],
         waypoint: None,
         load_balancer: None,

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -14,7 +14,7 @@
 
 use crate::config::{ConfigSource, ProxyMode};
 use crate::rbac::Authorization;
-use crate::state::service::{endpoint_uid, Endpoint, Service};
+use crate::state::service::{Endpoint, Service};
 use crate::state::workload::{gatewayaddress, HealthStatus, Workload};
 use crate::test_helpers::app::TestApp;
 use crate::test_helpers::netns::{Namespace, Resolver};

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -495,23 +495,14 @@ impl<'a> TestWorkloadBuilder<'a> {
         for (service, ports) in &self.w.services {
             let service_name = service.parse::<NamespacedHostname>()?;
 
-            for wip in self.w.workload.workload_ips.iter() {
-                let ep_network_addr = NetworkAddress {
-                    network: strng::EMPTY,
-                    address: *wip,
-                };
-
-                let ep = Endpoint {
-                    workload_uid: self.w.workload.uid.as_str().into(),
-                    service: service_name.clone(),
-                    address: Some(ep_network_addr.clone()),
-                    port: ports.to_owned(),
-                    status: HealthStatus::Healthy,
-                };
-                let mut svc = self.manager.services.get(&service_name).unwrap().clone();
-                let ep_uid = endpoint_uid(&self.w.workload.uid, Some(&ep_network_addr));
-                svc.endpoints.insert(ep_uid, ep.clone());
-            }
+            let ep = Endpoint {
+                workload_uid: self.w.workload.uid.as_str().into(),
+                port: ports.to_owned(),
+                status: HealthStatus::Healthy,
+            };
+            let mut svc = self.manager.services.get(&service_name).unwrap().clone();
+            svc.endpoints
+                .insert(self.w.workload.uid.clone(), ep.clone());
         }
 
         info!("registered {}", &self.w.workload.uid);

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -354,25 +354,11 @@ fn insert_service_endpoints(
             }
         };
 
-        // Create service endpoints for all the workload IPs.
-        for wip in &workload.workload_ips {
-            services_state.insert_endpoint(Endpoint {
-                workload_uid: workload.uid.clone(),
-                service: namespaced_host.clone(),
-                address: Some(network_addr(workload.network.clone(), *wip)),
-                port: ports.into(),
-                status: workload.status,
-            })
-        }
-        if workload.workload_ips.is_empty() {
-            services_state.insert_endpoint(Endpoint {
-                workload_uid: workload.uid.clone(),
-                service: namespaced_host.clone(),
-                address: None,
-                port: ports.into(),
-                status: workload.status,
-            })
-        }
+        services_state.insert_endpoint(namespaced_host, Endpoint {
+            workload_uid: workload.uid.clone(),
+            port: ports.into(),
+            status: workload.status,
+        })
     }
     Ok(())
 }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -228,7 +228,7 @@ impl ProxyStateUpdateMutator {
             trace!("not a service, not attempting to delete as such",);
             return;
         }
-        if state.services.remove(&name).is_none() && !for_insert {
+        if !state.services.remove(&name) && !for_insert {
             warn!("tried to remove service, but it was not found");
         }
     }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -37,7 +37,7 @@ use crate::cert_fetcher::{CertFetcher, NoCertFetcher};
 use crate::config::ConfigSource;
 use crate::rbac::Authorization;
 use crate::state::service::{Endpoint, Service, ServiceStore};
-use crate::state::workload::{network_addr, NamespacedHostname, Workload};
+use crate::state::workload::{NamespacedHostname, Workload};
 use crate::state::ProxyState;
 use crate::strng::Strng;
 use crate::{rbac, strng};
@@ -251,7 +251,9 @@ impl ProxyStateUpdateMutator {
         {
             for ep in prev.endpoints.iter() {
                 if service.should_include_endpoint(ep.status) {
-                    service.endpoints.insert(ep.workload_uid.clone(), ep.clone());
+                    service
+                        .endpoints
+                        .insert(ep.workload_uid.clone(), ep.clone());
                 }
             }
         }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -183,7 +183,7 @@ impl ProxyStateUpdateMutator {
         // remove workload by UID; if xds_name is a service then this will no-op
         if let Some(prev) = state.workloads.remove(&strng::new(xds_name)) {
             // Also remove service endpoints for the workload.
-            state.services.remove_endpoint(&prev.uid, &prev.uid);
+            state.services.remove_endpoint(&prev.uid);
 
             // This is a real removal (not a removal before insertion), and nothing else references the cert
             // Clear it out


### PR DESCRIPTION
Part of https://github.com/istio/ztunnel/issues/1268

This doesn't solve the problem -- we don't fix the primary performance issues. However, this sets us up for success by refactoring the data structures.

* A new EndpointSet is a collection of endpoints. For now this is just a wrapper around a hashmap, but the intent is we could swap it out with something that allows updates, or maybe add some things like load tracking for better LB.
* Drop address from Endpoint (and Service). Instead, an Endpoint just points to a workload (and its a part of a Service, so no need to point to the service). This also means for dual stack we only need 1 endpoint per Pod instead of 2.
* Trivial optimization to avoid cloning a Service when we always immediately drop it.