### PR TITLE
rbac - include policy name in rejection logs

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -394,7 +394,7 @@ pub fn rbac(c: &mut Criterion) {
         .unwrap();
     c.bench_function("rbac", |b| {
         b.to_async(&rt).iter(|| async {
-            mock_proxy_state.assert_rbac(&rc).await;
+            let _ = mock_proxy_state.assert_rbac(&rc).await;
         })
     });
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -23,6 +23,7 @@ use std::{fmt, io};
 use hickory_proto::error::ProtoError;
 
 use rand::Rng;
+use crate::strng::Strng;
 
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::time::timeout;
@@ -324,6 +325,26 @@ pub struct Addresses {
     pub socks5: Option<SocketAddr>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum AuthorizationRejectionError {
+    NoWorkload,
+    WorkloadMismatch,
+    ExplicitlyDenied(Strng, Strng),
+    NotAllowed,
+}
+impl fmt::Display for AuthorizationRejectionError {
+
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoWorkload => write!(fmt, "workload not found"),
+            Self::WorkloadMismatch => write!(fmt, "workload mismatch"),
+            Self::ExplicitlyDenied(a, b) => write!(fmt, "explicitly denied by: {}/{}", a, b),
+            Self::NotAllowed => write!(fmt, "allow policies exist, but none allowed"),
+        }
+    }
+}
+
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("failed to bind to address {0}: {1}")]
@@ -351,11 +372,14 @@ pub enum Error {
     #[error("connection failed: {0}")]
     ConnectionFailed(io::Error),
 
+    #[error("connection tracking failed")]
+    ConnectionTrackingFailed,
+
     #[error("connection closed due to policy change")]
     AuthorizationPolicyLateRejection,
 
-    #[error("connection closed due to policy rejection")]
-    AuthorizationPolicyRejection,
+    #[error("connection closed due to policy rejection: {0}")]
+    AuthorizationPolicyRejection(AuthorizationRejectionError),
 
     #[error("pool is already connecting")]
     WorkloadHBONEPoolAlreadyConnecting,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -22,8 +22,8 @@ use std::{fmt, io};
 
 use hickory_proto::error::ProtoError;
 
-use rand::Rng;
 use crate::strng::Strng;
+use rand::Rng;
 
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::time::timeout;
@@ -333,7 +333,6 @@ pub enum AuthorizationRejectionError {
     NotAllowed,
 }
 impl fmt::Display for AuthorizationRejectionError {
-
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NoWorkload => write!(fmt, "workload not found"),
@@ -343,7 +342,6 @@ impl fmt::Display for AuthorizationRejectionError {
         }
     }
 }
-
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/src/proxy/connection_manager.rs
+++ b/src/proxy/connection_manager.rs
@@ -312,7 +312,7 @@ impl PolicyWatcher {
                 _ = policies_changed.changed() => {
                     let connections = self.connection_manager.connections();
                     for conn in connections {
-                        if !self.state.assert_rbac(&conn.ctx).await.is_ok() {
+                        if self.state.assert_rbac(&conn.ctx).await.is_err() {
                             self.connection_manager.close(&conn).await;
                             info!("connection {} closed because it's no longer allowed after a policy update", conn.ctx);
                         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1310,7 +1310,7 @@ mod tests {
                     1234,
                 )),
                 dst_network: "".into(),
-                dst: SocketAddr::new(workload.workload_ips[0].clone(), 8080),
+                dst: SocketAddr::new(workload.workload_ips[0], 8080),
             },
             dest_workload_info: Some(Arc::new(get_workloadinfo(state, dest_uid))),
         }

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -966,7 +966,7 @@ mod tests {
 
                     // rbac should reject port 80
                     let rbac_res = state.assert_rbac(&rbac_ctx).await;
-                    assert!(!rbac_res.is_ok());
+                    assert!(rbac_res.is_err());
                     let conn = crate::rbac::Connection{
                         dst: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 81),
                         ..conn

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -966,7 +966,7 @@ mod tests {
 
                     // rbac should reject port 80
                     let rbac_res = state.assert_rbac(&rbac_ctx).await;
-                    assert!(!rbac_res);
+                    assert!(!rbac_res.is_ok());
                     let conn = crate::rbac::Connection{
                         dst: std::net::SocketAddr::new(std::net::Ipv4Addr::new(1, 2, 3, 4).into(), 81),
                         ..conn
@@ -978,7 +978,7 @@ mod tests {
 
                     // but allow port 81
                     let rbac_res = state.assert_rbac(&rbac_ctx).await;
-                    assert!(rbac_res);
+                    assert!(rbac_res.is_ok());
                     return;
                 }
                 req = conn.rx.recv() => {

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -754,7 +754,7 @@ mod namespaced {
             .unwrap()?;
         telemetry::testing::assert_contains(HashMap::from([
             ("scope", "access"),
-            ("error", "connection closed due to policy rejection"),
+            ("error", "connection closed due to policy rejection: allow policies exist, but none allowed"),
         ]));
         Ok(())
     }

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -754,7 +754,10 @@ mod namespaced {
             .unwrap()?;
         telemetry::testing::assert_contains(HashMap::from([
             ("scope", "access"),
-            ("error", "connection closed due to policy rejection: allow policies exist, but none allowed"),
+            (
+                "error",
+                "connection closed due to policy rejection: allow policies exist, but none allowed",
+            ),
         ]));
         Ok(())
     }


### PR DESCRIPTION
- Added policy ns/name to AuthorizationPolicyRejection
- Added to add a new error for ConnectionTrackingFailed case, as we can't use AuthorizationPolicyRejection
- fill in the deny policy in assert_rbac and added tests

Example logs:
`error   access  connection complete     src.addr=10.244.1.6:42020 src.workload="reviews-v1-6584ddcf65-k78wz" src.namespace="default" src.identity="spiffe://cluster.local/ns/default/sa/bookinfo-reviews" dst.addr=10.244.1.9:15008 dst.hbone_addr=10.244.1.9:9080 dst.service="productpage.default.svc.cluster.local" dst.workload="productpage-v1-d5789fdfb-c5w2c" dst.namespace="default" dst.identity="spiffe://cluster.local/ns/default/sa/bookinfo-productpage" direction="inbound" bytes_sent=0 bytes_recv=0 duration="0ms" error="connection closed due to policy rejection: allow policies exist, but none allowed"`
and
`error   access  connection complete     src.addr=10.244.1.6:45208 src.workload="reviews-v1-6584ddcf65-k78wz" src.namespace="default" src.identity="spiffe://cluster.local/ns/default/sa/bookinfo-reviews" dst.addr=10.244.1.9:15008 dst.hbone_addr=10.244.1.9:9080 dst.service="productpage.default.svc.cluster.local" dst.workload="productpage-v1-d5789fdfb-c5w2c" dst.namespace="default" dst.identity="spiffe://cluster.local/ns/default/sa/bookinfo-productpage" direction="inbound" bytes_sent=0 bytes_recv=0 duration="0ms" error="connection closed due to policy rejection: explicitly denied by: default/reviews-denial"`



