### PR TITLE
Don't create V6 binds if global V6 flag is off

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -703,10 +703,18 @@ impl Address {
         }
     }
 
-    // with_ipv6 overrides the IPv6 setting for the address
+    // with_ipv6 unconditionally overrides the IPv6 setting for the address
     pub fn with_ipv6(self, ipv6: bool) -> Self {
         match self {
             Address::Localhost(_, port) => Address::Localhost(ipv6, port),
+            x => x,
+        }
+    }
+
+    // maybe_downgrade_ipv6 updates the V6 setting, ONLY if the address was already V6
+    pub fn maybe_downgrade_ipv6(self, updated_v6: bool) -> Self {
+        match self {
+            Address::Localhost(true, port) => Address::Localhost(updated_v6, port),
             x => x,
         }
     }

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -94,16 +94,10 @@ impl Server {
         // This is to ensure globally-enabled V6 support doesn't try to create V6 addresses in pods
         // that do not support it, and also ensure globally-disabled V6 support doesn't create V6 address
         // even if that's turned off.
-        let local_address = if let config::Address::Localhost(v6_global_enable, _) = address {
-            if v6_global_enable {
-                address.with_ipv6(socket_factory.ipv6_enabled_localhost().unwrap_or_else(|e| {
-                    warn!(err=?e, "failed to determine if IPv6 was disabled; continuing anyways, but this may fail");
-                    true
-                }))
-            } else {
-                address
-            }
-        };
+        let local_address = address.maybe_downgrade_ipv6(socket_factory.ipv6_enabled_localhost().unwrap_or_else(|e| {
+            warn!(err=?e, "failed to determine if IPv6 was disabled; continuing anyways, but this may fail");
+            true
+        }));
         // Create the DNS server, backed by ztunnel data structures.
         let mut store = Store::new(
             domain,


### PR DESCRIPTION
Existing code handles the case where V6 is globally enabled but not enabled in the local pod context.

It does not handle the case where V6 is globally _disabled_ but is enabled in the local pod context, which is a tad surprising.

Only the DNS handler is affected by this.