### PR TITLE
Fix incorrect function naming

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -288,7 +288,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
     let ipv6_enabled = parse::<bool>(IPV6_ENABLED)?.unwrap_or(true);
     let ipv6_localhost_enabled = if ipv6_enabled {
         // IPv6 may be generally enabled, but not on localhost. In that case, we do not want to bind on IPv6.
-        crate::proxy::ipv6_disabled_on_localhost().unwrap_or_else(|e| {
+        crate::proxy::ipv6_enabled_on_localhost().unwrap_or_else(|e| {
             warn!(err=?e, "failed to determine if IPv6 was disabled; continuing anyways, but this may fail");
             true
         })

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -101,7 +101,7 @@ impl SocketFactory for DefaultSocketFactory {
     }
 
     fn ipv6_enabled_localhost(&self) -> io::Result<bool> {
-        ipv6_disabled_on_localhost()
+        ipv6_enabled_on_localhost()
     }
 }
 
@@ -705,7 +705,7 @@ fn read_sysctl(key: &str) -> io::Result<String> {
     Ok(data.trim().to_string())
 }
 
-pub fn ipv6_disabled_on_localhost() -> io::Result<bool> {
+pub fn ipv6_enabled_on_localhost() -> io::Result<bool> {
     read_sysctl(IPV6_DISABLED_LO).map(|s| s != "1")
 }
 


### PR DESCRIPTION
The behavior is right, just the naming is off. Its a weird double
negative since we are checking its `!disabled`
