### PR TITLE
inbound: unconditionally log errors

### DIFF
--- a/src/proxy/h2/server.rs
+++ b/src/proxy/h2/server.rs
@@ -81,7 +81,7 @@ pub async fn serve_connection<F, Fut>(
 ) -> Result<(), Error>
 where
     F: Fn(H2Request) -> Fut,
-    Fut: Future + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
 {
     let mut builder = h2::server::Builder::new();
     let mut conn = builder

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -66,6 +66,8 @@ pub enum ResponseFlags {
     None,
     // connection denied due to policy
     AuthorizationPolicyDenied,
+    // connection denied because we could not establish an upstream connection
+    ConnectionFailure,
 }
 
 impl EncodeLabelValue for ResponseFlags {
@@ -73,6 +75,7 @@ impl EncodeLabelValue for ResponseFlags {
         match self {
             ResponseFlags::None => writer.write_str("-"),
             ResponseFlags::AuthorizationPolicyDenied => writer.write_str("DENY"),
+            ResponseFlags::ConnectionFailure => writer.write_str("CONNECT"),
         }
     }
 }


### PR DESCRIPTION
Previously, our error logging was built on an assumption that we would
always remember to log errors and return HTTP responses. This is not
great, we should enforce this in the type system -- we are only one `?`
away from broken error handling, which we do have one currently
(`local_workload_information`).

This builds into the type system enforcing we cannot accidentally mask
errors.

Instead of `serve_connect` returning an error (which goes to /dev/null),
we have it return nothing -- this should make it harder to insert any
new code in the wrong place that doesn't handle errors. Additionally, we
split up the function into 3 phases:
* Before we have full metrics context
* After we have full metrics context
* After we already sent a 200 back

This way we can use `?` ergonomically + safely, and consolidate where we
log/return error responses into a small set of places
