### PR TITLE
Makefile: fix bad `fmt` args

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -40,10 +40,10 @@ license-check:
 
 fix: fix-copyright-banner
 	cargo clippy --fix --allow-staged --allow-dirty $(FEATURES)
-	cargo fmt $(FEATURES)
+	cargo fmt
 
 format:
-	cargo fmt $(FEATURES)
+	cargo fmt
 
 release:
 	./scripts/release.sh


### PR DESCRIPTION
Cargo fmt does not take feature flags. This only works in CI since we
never call these targets with feature flags.
