### PR TITLE
Validate (and do not set in our test) invalid app_tunnnel

### DIFF
--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -333,12 +333,6 @@ mod namespaced {
 
         let waypoint = manager
             .workload_builder("waypoint", DEFAULT_NODE)
-            .mutate_workload(|w| {
-                w.application_tunnel = Some(ApplicationTunnel {
-                    protocol: Protocol::NONE,
-                    port: None,
-                });
-            })
             .register()
             .await?;
         let waypoint_ip = waypoint.ip();


### PR DESCRIPTION
We shouldn't accept this type of config, as it has no meaning. We also
don't need to test it
