### PR TITLE
Support inline XDS config and auth

### DIFF
--- a/src/identity/auth.rs
+++ b/src/identity/auth.rs
@@ -23,7 +23,34 @@ use tonic::{Code, Request, Status};
 pub enum AuthSource {
     // JWT authentication source which contains the token file path and the cluster id.
     Token(PathBuf, String),
+    // JWT authentication source which contains a static token file.
+    // Note that this token is not refreshed, so its lifetime ought to be longer than ztunnel's
+    StaticToken(String, String),
     None,
+}
+
+impl AuthSource {
+    fn read_token(&self) -> io::Result<Option<(Vec<u8>, String)>> {
+        Ok(match self {
+            AuthSource::Token(path, cluster_id) => {
+                let token = load_token(path).map(|mut t| {
+                    let mut bearer: Vec<u8> = b"Bearer ".to_vec();
+                    bearer.append(&mut t);
+                    bearer
+                })?;
+                Some((token, cluster_id.to_string()))
+            }
+            AuthSource::StaticToken(token, cluster_id) => {
+                let token = {
+                    let mut bearer: Vec<u8> = b"Bearer ".to_vec();
+                    bearer.extend_from_slice(token.as_bytes());
+                    bearer
+                };
+                Some((token, cluster_id.to_string()))
+            }
+            AuthSource::None => None,
+        })
+    }
 }
 
 fn load_token(path: &PathBuf) -> io::Result<Vec<u8>> {
@@ -40,29 +67,18 @@ fn load_token(path: &PathBuf) -> io::Result<Vec<u8>> {
 
 impl Interceptor for AuthSource {
     fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
-        match self {
-            AuthSource::Token(path, cluster_id) => {
-                let token = load_token(path)
-                    .map_err(|e| Status::new(Code::Unauthenticated, e.to_string()))
-                    .map(|mut t| {
-                        let mut bearer: Vec<u8> = b"Bearer ".to_vec();
-                        bearer.append(&mut t);
-                        bearer
-                    })
-                    .and_then(|b| {
-                        AsciiMetadataValue::try_from(b)
-                            .map_err(|e| Status::new(Code::Unauthenticated, e.to_string()))
-                    })?;
-
-                request.metadata_mut().insert("authorization", token);
-                if !cluster_id.is_empty() {
-                    let id = AsciiMetadataValue::try_from(cluster_id.as_bytes().to_vec())
-                        .map_err(|e| Status::new(Code::Unauthenticated, e.to_string()))?;
-                    request.metadata_mut().insert("clusterid", id);
-                }
+        if let Some((token, cluster_id)) = self
+            .read_token()
+            .map_err(|e| Status::new(Code::Unauthenticated, e.to_string()))?
+        {
+            let token = AsciiMetadataValue::try_from(token)
+                .map_err(|e| Status::new(Code::Unauthenticated, e.to_string()))?;
+            request.metadata_mut().insert("authorization", token);
+            if !cluster_id.is_empty() {
+                let id = AsciiMetadataValue::try_from(cluster_id.as_bytes().to_vec())
+                    .map_err(|e| Status::new(Code::Unauthenticated, e.to_string()))?;
+                request.metadata_mut().insert("clusterid", id);
             }
-            // When no token based authentication is required, do not load or insert the token.
-            AuthSource::None => {}
         }
         Ok(request)
     }


### PR DESCRIPTION
Having to always use files is troublesome when we want to run in locked down environments that don't have file write access. Nice to be able to set these inline