### PR TITLE
Revert "Validate (and do not set in our test) invalid app_tunnnel"

### DIFF
--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -296,7 +296,7 @@ impl TryFrom<&XdsApplicationTunnel> for ApplicationTunnel {
     type Error = WorkloadError;
 
     fn try_from(value: &XdsApplicationTunnel) -> Result<Self, Self::Error> {
-        let tunnel = ApplicationTunnel {
+        Ok(ApplicationTunnel {
             protocol: application_tunnel::Protocol::from(
                 xds::istio::workload::application_tunnel::Protocol::try_from(value.protocol)?,
             ),
@@ -305,13 +305,7 @@ impl TryFrom<&XdsApplicationTunnel> for ApplicationTunnel {
             } else {
                 Some(value.port as u16)
             },
-        };
-        if tunnel.port.is_none() && tunnel.protocol == application_tunnel::Protocol::NONE {
-            return Err(Self::Error::InvalidConfiguration(
-                "application_tunnel must set port or protocol".to_string(),
-            ));
-        }
-        Ok(tunnel)
+        })
     }
 }
 
@@ -765,8 +759,6 @@ pub enum WorkloadError {
     PrefixParse(#[from] ipnet::PrefixLenError),
     #[error("unknown enum: {0}")]
     EnumParse(String),
-    #[error("invalid configuration: {0}")]
-    InvalidConfiguration(String),
     #[error("nonempty gateway address is missing address")]
     MissingGatewayAddress,
     #[error("decode error: {0}")]

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -396,6 +396,12 @@ mod namespaced {
 
         let waypoint = manager
             .workload_builder("waypoint", DEFAULT_NODE)
+            .mutate_workload(|w| {
+                w.application_tunnel = Some(ApplicationTunnel {
+                    protocol: Protocol::NONE,
+                    port: None,
+                });
+            })
             .register()
             .await?;
         let waypoint_ip = waypoint.ip();


### PR DESCRIPTION
Reverts istio/ztunnel#1304

It seems istiod is actually sending this :facepalm: . We should fix on Istiod side, but give a few releases to reject here (if ever)