### PR TITLE
tls: better error on TLS handshake failures

### DIFF
--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -15,7 +15,6 @@
 use super::Error;
 
 use crate::identity::{self, Identity};
-use crate::state::workload::NetworkAddress;
 
 use std::fmt::Debug;
 
@@ -71,20 +70,16 @@ pub(super) fn provider() -> Arc<CryptoProvider> {
 pub enum TlsError {
     #[error("tls handshake error: {0:?}")]
     Handshake(std::io::Error),
-    #[error("certificate lookup error: {0} is not a known destination")]
-    CertificateLookup(NetworkAddress),
     #[error("signing error: {0}")]
     SigningError(#[from] identity::Error),
-    #[error("san verification error: remote did not present the expected SAN ({0:?}), got {1:?}")]
+    #[error(
+        "identity verification error: peer did not present the expected SAN ({0:?}), got {1:?}"
+    )]
     SanError(Vec<Identity>, Vec<Identity>),
     #[error(
-        "san verification error: remote did not present the expected trustdomain ({0}), got {1:?}"
+        "identity verification error: peer did not present the expected trustdomain ({0}), got {1:?}"
     )]
     SanTrustDomainError(String, Vec<Identity>),
-    #[error("failed getting ex data")]
-    ExDataError,
-    #[error("failed getting peer cert")]
-    PeerCertError,
     #[error("ssl error: {0}")]
     SslError(#[from] Error),
 }

--- a/src/tls/workload.rs
+++ b/src/tls/workload.rs
@@ -205,7 +205,10 @@ impl IdentityVerifier {
         }
         debug!("identity mismatch {id:?} != {:?}", self.identity);
         Err(rustls::Error::InvalidCertificate(
-            rustls::CertificateError::ApplicationVerificationFailure,
+            rustls::CertificateError::Other(rustls::OtherError(Arc::new(TlsError::SanError(
+                self.identity.clone(),
+                id,
+            )))),
         ))
     }
 }


### PR DESCRIPTION
Before: `error="io error: invalid peer certificate: ApplicationVerificationFailure"`
After: `error="io error: invalid peer certificate: Other(OtherError(SanError([], [Spiffe { trust_domain: \"\", namespace: \"default\", service_account: \"default\" }])))"`

Error still is a bit wonky, rustls doesn't give us much flexibility. But at least this lets a developer to understand what is going on