### PR TITLE
tls: allow alternative hostname verification for control plane

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,8 @@ const DNS_PROXY_ADDR_METADATA: &str = "DNS_PROXY_ADDR";
 /// Fetch the XDS/CA root cert file path based on below constants
 const XDS_ROOT_CA_ENV: &str = "XDS_ROOT_CA";
 const CA_ROOT_CA_ENV: &str = "CA_ROOT_CA";
+const ALT_XDS_HOSTNAME: &str = "ALT_XDS_HOSTNAME";
+const ALT_CA_HOSTNAME: &str = "ALT_CA_HOSTNAME";
 const DEFAULT_ROOT_CERT_PROVIDER: &str = "./var/run/secrets/istio/root-cert.pem";
 const TOKEN_PROVIDER_ENV: &str = "AUTH_TOKEN";
 const DEFAULT_TOKEN_PROVIDER: &str = "./var/run/secrets/tokens/istio-token";
@@ -186,10 +188,15 @@ pub struct Config {
     pub ca_address: Option<String>,
     /// Root cert for CA TLS verification.
     pub ca_root_cert: RootCert,
+    // Allow custom alternative CA hostname verification
+    pub alt_ca_hostname: Option<String>,
     /// XDS address to use. If unset, XDS will not be used.
     pub xds_address: Option<String>,
     /// Root cert for XDS TLS verification.
     pub xds_root_cert: RootCert,
+    // Allow custom alternative XDS hostname verification
+    pub alt_xds_hostname: Option<String>,
+
     /// TTL for CSR requests
     pub secret_ttl: Duration,
     /// YAML config for local XDS workloads
@@ -545,6 +552,9 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         xds_root_cert,
         ca_address,
         ca_root_cert,
+        alt_xds_hostname: parse(ALT_XDS_HOSTNAME)?,
+        alt_ca_hostname: parse(ALT_CA_HOSTNAME)?,
+
         secret_ttl: match parse::<String>(SECRET_TTL)? {
             Some(ttl) => duration_str::parse(ttl).unwrap_or(DEFAULT_TTL),
             None => DEFAULT_TTL,

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -36,12 +36,13 @@ pub struct CaClient {
 impl CaClient {
     pub async fn new(
         address: String,
+        alt_hostname: Option<String>,
         cert_provider: Box<dyn tls::ControlPlaneClientCertProvider>,
         auth: AuthSource,
         enable_impersonated_identity: bool,
         secret_ttl: i64,
     ) -> Result<CaClient, Error> {
-        let svc = tls::grpc_connector(address, auth, cert_provider.fetch_cert().await?)?;
+        let svc = tls::grpc_connector(address, auth, cert_provider.fetch_cert(alt_hostname).await?)?;
         let client = IstioCertificateServiceClient::new(svc);
         Ok(CaClient {
             client,

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -42,7 +42,8 @@ impl CaClient {
         enable_impersonated_identity: bool,
         secret_ttl: i64,
     ) -> Result<CaClient, Error> {
-        let svc = tls::grpc_connector(address, auth, cert_provider.fetch_cert(alt_hostname).await?)?;
+        let svc =
+            tls::grpc_connector(address, auth, cert_provider.fetch_cert(alt_hostname).await?)?;
         let client = IstioCertificateServiceClient::new(svc);
         Ok(CaClient {
             client,

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -500,6 +500,7 @@ impl SecretManager {
             cfg.ca_address
                 .clone()
                 .expect("ca_address must be set to use CA"),
+            cfg.alt_ca_hostname.clone(),
             Box::new(tls::ControlPlaneAuthentication::RootCert(
                 cfg.ca_root_cert.clone(),
             )),

--- a/src/test_helpers/ca.rs
+++ b/src/test_helpers/ca.rs
@@ -78,6 +78,7 @@ impl CaServer {
         });
         let client = CaClient::new(
             "https://".to_string() + &server_addr.to_string(),
+            None,
             Box::new(tls::ControlPlaneAuthentication::RootCert(root_cert)),
             AuthSource::Token(
                 PathBuf::from(r"src/test_helpers/fake-jwt"),

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -59,6 +59,9 @@ pub enum Error {
 
     #[error("failed to build server verifier: {0}")]
     ServerVerifierBuilderError(#[from] VerifierBuilderError),
+
+    #[error("invalid alt hostname: {0}")]
+    InvalidAltHostname(#[from] rustls::pki_types::InvalidDnsNameError),
 }
 
 impl From<InvalidUri> for Error {

--- a/src/tls/certificate.rs
+++ b/src/tls/certificate.rs
@@ -54,7 +54,7 @@ pub struct WorkloadCertificate {
     pub private_key: PrivateKeyDer<'static>,
 
     /// precomputed roots
-    roots: Arc<RootCertStore>,
+    pub roots: Arc<RootCertStore>,
 }
 
 pub fn identity_from_connection(conn: &server::ServerConnection) -> Option<Identity> {
@@ -106,7 +106,7 @@ pub fn identities(cert: X509Certificate) -> Result<Vec<Identity>, Error> {
 }
 
 impl Certificate {
-    // TOOD: I would love to parse this once, but ran into lifetime issues.
+    // TODO: I would love to parse this once, but ran into lifetime issues.
     fn parsed(&self) -> X509Certificate {
         x509_parser::parse_x509_certificate(&self.der)
             .expect("certificate was already parsed successfully before")

--- a/src/tls/control.rs
+++ b/src/tls/control.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tonic::body::BoxBody;
+use tracing::debug;
 
 async fn root_to_store(root_cert: &RootCert) -> Result<rustls::RootCertStore, Error> {
     let mut roots = rustls::RootCertStore::empty();
@@ -174,6 +175,7 @@ async fn control_plane_client_config(
     let c = ClientConfig::builder_with_provider(provider())
         .with_protocol_versions(crate::tls::TLS_VERSIONS)?;
     if let Some(alt_hostname) = alt_hostname {
+        debug!("using alternate hostname {alt_hostname} for TLS verification");
         Ok(c.dangerous()
             .with_custom_certificate_verifier(Arc::new(AltHostnameVerifier {
                 roots: Arc::new(roots),

--- a/src/tls/control.rs
+++ b/src/tls/control.rs
@@ -20,7 +20,9 @@ use hyper::body::Incoming;
 use hyper::Uri;
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
-use rustls::ClientConfig;
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, SignatureScheme};
 use std::future::Future;
 use std::io::Cursor;
 use std::pin::Pin;
@@ -66,10 +68,10 @@ pub enum ControlPlaneAuthentication {
 
 #[async_trait::async_trait]
 impl ControlPlaneClientCertProvider for ControlPlaneAuthentication {
-    async fn fetch_cert(&self) -> Result<ClientConfig, Error> {
+    async fn fetch_cert(&self, alt_hostname: Option<String>) -> Result<ClientConfig, Error> {
         match self {
             ControlPlaneAuthentication::RootCert(root_cert) => {
-                control_plane_client_config(root_cert).await
+                control_plane_client_config(root_cert, alt_hostname).await
             }
             ControlPlaneAuthentication::ClientBundle(_bundle) => {
                 // TODO: implement this. Its is not currently used so no need.
@@ -79,12 +81,108 @@ impl ControlPlaneClientCertProvider for ControlPlaneAuthentication {
     }
 }
 
-async fn control_plane_client_config(root_cert: &RootCert) -> Result<ClientConfig, Error> {
+#[derive(Debug)]
+struct AltHostnameVerifier {
+    roots: Arc<rustls::RootCertStore>,
+    alt_server_name: ServerName<'static>,
+}
+
+// A custom verifier that allows alternative server names to be accepted.
+// Build our own verifier, inspired by https://github.com/rustls/rustls/blob/ccb79947a4811412ee7dcddcd0f51ea56bccf101/rustls/src/webpki/server_verifier.rs#L239.
+impl ServerCertVerifier for AltHostnameVerifier {
+    /// Will verify the certificate is valid in the following ways:
+    /// - Signed by a  trusted `RootCertStore` CA
+    /// - Not Expired
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        sn: &ServerName,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        let cert = rustls::server::ParsedCertificate::try_from(end_entity)?;
+
+        let algs = provider().signature_verification_algorithms;
+        rustls::client::verify_server_cert_signed_by_trust_anchor(
+            &cert,
+            &self.roots,
+            intermediates,
+            now,
+            algs.all,
+        )?;
+
+        if !ocsp_response.is_empty() {
+            tracing::trace!("Unvalidated OCSP response: {ocsp_response:?}");
+        }
+
+        // First attempt to verify the original server name...
+        if let Err(err) = rustls::client::verify_server_name(&cert, sn) {
+            tracing::debug!(
+                "failed to verify {sn:?} ({err}), attempting alt name {:?}",
+                self.alt_server_name
+            );
+            // That failed, lets try the alternative one
+            rustls::client::verify_server_name(&cert, &self.alt_server_name)?;
+        }
+
+        Ok(ServerCertVerified::assertion())
+    }
+
+    // Rest use the default implementations
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &provider().signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &provider().signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+async fn control_plane_client_config(
+    root_cert: &RootCert,
+    alt_hostname: Option<String>,
+) -> Result<ClientConfig, Error> {
     let roots = root_to_store(root_cert).await?;
-    Ok(ClientConfig::builder_with_provider(provider())
-        .with_protocol_versions(crate::tls::TLS_VERSIONS)?
-        .with_root_certificates(roots)
-        .with_no_client_auth())
+    let c = ClientConfig::builder_with_provider(provider())
+        .with_protocol_versions(crate::tls::TLS_VERSIONS)?;
+    if let Some(alt_hostname) = alt_hostname {
+        Ok(c.dangerous()
+            .with_custom_certificate_verifier(Arc::new(AltHostnameVerifier {
+                roots: Arc::new(roots),
+                alt_server_name: ServerName::try_from(alt_hostname)?,
+            }))
+            .with_no_client_auth())
+    } else {
+        Ok(c.with_root_certificates(roots).with_no_client_auth())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -30,7 +30,7 @@ use tracing::error;
 
 #[async_trait::async_trait]
 pub trait ControlPlaneClientCertProvider: Send + Sync {
-    async fn fetch_cert(&self) -> Result<ClientConfig, Error>;
+    async fn fetch_cert(&self, alt_hostname: Option<String>) -> Result<ClientConfig, Error>;
 }
 
 #[async_trait::async_trait]

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -623,7 +623,7 @@ impl AdsClient {
         let addr = self.config.address.clone();
         let tls_grpc_channel = tls::grpc_connector(
             self.config.address.clone(),
-						self.config.auth.clone(),
+            self.config.auth.clone(),
             self.config
                 .tls_builder
                 .fetch_cert(self.config.alt_hostname.clone())

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -212,6 +212,9 @@ pub struct Config {
     handlers: HashMap<Strng, Box<dyn RawHandler>>,
     initial_requests: Vec<DeltaDiscoveryRequest>,
     on_demand: bool,
+
+    /// alt_hostname provides an alternative accepted SAN for the control plane TLS verification
+    alt_hostname: Option<String>,
 }
 
 pub struct State {
@@ -258,6 +261,7 @@ impl Config {
             initial_requests: Vec::new(),
             on_demand: config.xds_on_demand,
             proxy_metadata: config.proxy_metadata.clone(),
+            alt_hostname: config.alt_xds_hostname.clone(),
         }
     }
 
@@ -619,8 +623,11 @@ impl AdsClient {
         let addr = self.config.address.clone();
         let tls_grpc_channel = tls::grpc_connector(
             self.config.address.clone(),
-            self.config.auth.clone(),
-            self.config.tls_builder.fetch_cert().await?,
+						self.config.auth.clone(),
+            self.config
+                .tls_builder
+                .fetch_cert(self.config.alt_hostname.clone())
+                .await?,
         )?;
 
         let ads_connection = AggregatedDiscoveryServiceClient::new(tls_grpc_channel)


### PR DESCRIPTION
Use cases:
* Connect to control plane in places where we do not have DNS (but
  istiod does not have an IP cert)
* Connect through a passthrough LB
