### PR TITLE
fix function typo noticed in test

### DIFF
--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -381,7 +381,7 @@ impl WorkloadProxyManagerState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::inpod::test_helpers::{self, create_proxy_confilct, new_netns, uid};
+    use crate::inpod::test_helpers::{self, create_proxy_conflict, new_netns, uid};
     use crate::inpod::WorkloadData;
 
     use crate::inpod::istio::zds;
@@ -471,7 +471,7 @@ mod tests {
         let mut state = fixture.state;
         let ns = new_netns();
         // to make the proxy fail, bind to its ports in its netns
-        let sock = create_proxy_confilct(&ns);
+        let sock = create_proxy_conflict(&ns);
 
         let data = WorkloadData {
             netns: ns,
@@ -506,7 +506,7 @@ mod tests {
         let ns1 = new_netns();
         let ns2 = new_netns();
         // to make the proxy fail, bind to its ports in its netns
-        let _sock = create_proxy_confilct(&ns1);
+        let _sock = create_proxy_conflict(&ns1);
 
         // Add the pod in netns1
         let ret = state
@@ -542,7 +542,7 @@ mod tests {
 
         let ns = new_netns();
         // to make the proxy fail, bind to its ports in its netns
-        let _sock = create_proxy_confilct(&ns);
+        let _sock = create_proxy_conflict(&ns);
 
         let data = WorkloadData {
             netns: ns,

--- a/src/inpod/test_helpers.rs
+++ b/src/inpod/test_helpers.rs
@@ -226,7 +226,7 @@ pub async fn send_workload_del(s: &mut UnixStream, uid: super::WorkloadUid) {
     .expect("failed to sendmsg");
 }
 
-pub fn create_proxy_confilct(ns: &std::os::fd::OwnedFd) -> std::os::fd::OwnedFd {
+pub fn create_proxy_conflict(ns: &std::os::fd::OwnedFd) -> std::os::fd::OwnedFd {
     let inpodns = InpodNetns::new(
         Arc::new(crate::inpod::netns::InpodNetns::current().unwrap()),
         ns.try_clone().unwrap(),

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -387,7 +387,7 @@ pub(crate) mod tests {
     use super::*;
 
     use crate::inpod::test_helpers::{
-        self, create_proxy_confilct, new_netns, read_hello, read_msg, send_snap_sent,
+        self, create_proxy_conflict, new_netns, read_hello, read_msg, send_snap_sent,
         send_workload_added, send_workload_del, uid,
     };
 
@@ -505,7 +505,7 @@ pub(crate) mod tests {
         let mut state = f.state;
 
         let podns = new_netns();
-        let socket = create_proxy_confilct(&podns);
+        let socket = create_proxy_conflict(&podns);
 
         let server = tokio::spawn(async move {
             read_hello(&mut s2).await;


### PR DESCRIPTION
Small drive-by PR to update a helper function typo/nit in a test that I noticed the other day.