### PR TITLE
logging: minor tweaks to debugging

### DIFF
--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -405,6 +405,10 @@ impl ServiceStore {
         if let Some(svc) = self.get_by_namespaced_host(&service_name) {
             // We may or may not accept the endpoint based on it's health
             if !svc.should_include_endpoint(ep.status) {
+                trace!(
+                    "service doesn't accept pod with status {:?}, skip",
+                    ep.status
+                );
                 return;
             }
             let mut svc = Arc::unwrap_or_clone(svc);
@@ -473,6 +477,10 @@ impl ServiceStore {
             // First add any staged service endpoints. Due to ordering issues, we may have received
             // the workloads before their associated services.
             if let Some(endpoints) = self.staged_services.remove(&namespaced_hostname) {
+                trace!(
+                    "staged service found, inserting {} endpoints",
+                    endpoints.len()
+                );
                 for (wip, ep) in endpoints {
                     if service.should_include_endpoint(ep.status) {
                         service.endpoints.insert(wip.clone(), ep);

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -685,9 +685,7 @@ impl WorkloadStore {
     pub fn remove(&mut self, uid: &Strng) -> Option<Workload> {
         match self.by_uid.remove(uid) {
             None => {
-                trace!(
-                    "tried to remove workload but it was not found; presumably it was a service"
-                );
+                trace!("tried to remove workload but it was not found");
                 None
             }
             Some(prev) => {


### PR DESCRIPTION
While debugging an issue (which was not a real issue, it turns out), I
was quite confused by the logs. This is mostly around not logging
service xds operations, and doing some confusing `remove` calls (which
handles both svc and workload) when we know its a workload. This just
cleans things upa bit
