### PR TITLE
Prevent `Error` enum from being huge

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -39,7 +39,7 @@ pub enum Error {
     #[error("failed to create CSR: {0}")]
     Signing(Arc<tls::Error>),
     #[error("signing gRPC error ({}): {}", .0.code(), .0.message())]
-    SigningRequest(#[from] tonic::Status),
+    SigningRequest(#[from] Box<tonic::Status>),
     #[error("failed to process string: {0}")]
     Utf8(#[from] Utf8Error),
     #[error("did not find expected SAN: {0}")]

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -83,7 +83,8 @@ impl CaClient {
             .client
             .clone()
             .create_certificate(req)
-            .await?
+            .await
+            .map_err(Box::new)?
             .into_inner();
         let leaf = resp
             .cert_chain


### PR DESCRIPTION
This one case makes the whole enum big, which ends up bloating some call
stacks. Clippy has a lint for this I  think, but we must be under the
threshold.

Before
```
tracing::instrument::Instrumented<ztunnel::proxy::inbound_passthrough::InboundPassthrough::run::{{closure}}::{{closure}}::{{closure}}::{{closure}}>,2784
tracing::instrument::Instrumented<ztunnel::proxy::outbound::Outbound::run::{{closure}}::{{closure}}::{{closure}}::{{closure}}>,1648
tracing::instrument::Instrumented<ztunnel::proxy::socks5::Socks5::run::{{closure}}::{{closure}}::{{closure}}::{{closure}}>,1968
ztunnel::proxy::inbound::Inbound::run::{{closure}}::{{closure}}::{{closure}}::{{closure}},1400
```

After
```
tracing::instrument::Instrumented<ztunnel::proxy::inbound_passthrough::InboundPassthrough::run::{{closure}}::{{closure}}::{{closure}}::{{closure}}>,2464
tracing::instrument::Instrumented<ztunnel::proxy::outbound::Outbound::run::{{closure}}::{{closure}}::{{closure}}::{{closure}}>,1488
tracing::instrument::Instrumented<ztunnel::proxy::socks5::Socks5::run::{{closure}}::{{closure}}::{{closure}}::{{closure}}>,1808
ztunnel::proxy::inbound::Inbound::run::{{closure}}::{{closure}}::{{closure}}::{{closure}},1400
```
