### PR TITLE
Reduce stack bloat on inbound

### DIFF
--- a/src/proxy/inbound_passthrough.rs
+++ b/src/proxy/inbound_passthrough.rs
@@ -29,7 +29,7 @@ use crate::proxy::metrics::Reporter;
 use crate::proxy::Error;
 use crate::proxy::{metrics, util, ProxyInputs};
 use crate::state::workload::NetworkAddress;
-use crate::{assertions, copy, rbac, strng};
+use crate::{assertions, copy, handle_connection, rbac, strng};
 use crate::{proxy, socket};
 
 pub(super) struct InboundPassthrough {
@@ -206,7 +206,7 @@ impl InboundPassthrough {
             pi.metrics.clone(),
         ));
 
-        let conn_guard = match pi
+        let mut conn_guard = match pi
             .connection_manager
             .assert_rbac(&pi.state, &rbac_ctx, None)
             .await
@@ -241,7 +241,7 @@ impl InboundPassthrough {
             .await
         };
 
-        let res = conn_guard.handle_connection(send).await;
+        let res = handle_connection!(conn_guard, send);
         result_tracker.record(res);
     }
 }


### PR DESCRIPTION
Builds on https://github.com/istio/ztunnel/pull/1330
First, add new checks. Our inbound flow has 3 nested futures, we only
measured the outer one.

Next, two optimizations. Unfortunately, I dont really understand either
of them...  the stack sizing is a bit of black magic.

1. Drop #instrument for .instrument(). Result is the same but one uses
   500b less?
2. Inline handle_connection, which saves 1kb

Before
```
tracing::instrument::Instrumented<ztunnel::proxy::inbound_passthrough::InboundPassthrough::run::>,2464
tracing::instrument::Instrumented<ztunnel::proxy::outbound::Outbound::run::>,1488
tracing::instrument::Instrumented<ztunnel::proxy::socks5::Socks5::run::>,1808
ztunnel::proxy::h2::server::serve_connection<>>,6440
ztunnel::proxy::inbound::Inbound::run::,1400
ztunnel::proxy::inbound::Inbound::serve_connect::{{closure}},3576
```

After
```
tracing::instrument::Instrumented<ztunnel::proxy::inbound_passthrough::InboundPassthrough::run::>,1672
tracing::instrument::Instrumented<ztunnel::proxy::outbound::Outbound::run::>,1488
tracing::instrument::Instrumented<ztunnel::proxy::socks5::Socks5::run::>,1808
ztunnel::proxy::h2::server::serve_connection<>>6440
ztunnel::proxy::inbound::Inbound::run::,1400
tracing::instrument::Instrumented<ztunnel::proxy::inbound::Inbound::serve_connect::{{closure}}>,2128
```