### PR TITLE
Cleanup inpod test server

### DIFF
--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -399,19 +399,6 @@ pub enum SocksError {
 }
 
 impl SocksError {
-    pub fn into_inner(self) -> Error {
-        match self {
-            SocksError::General(e) => e,
-            SocksError::NotAllowed(e) => e,
-            SocksError::NetworkUnreachable(e) => e,
-            SocksError::HostUnreachable(e) => e,
-            SocksError::ConnectionRefused(e) => e,
-            SocksError::CommandNotSupported(e) => e,
-        }
-    }
-}
-
-impl SocksError {
     pub fn invalid_protocol(reason: String) -> SocksError {
         SocksError::CommandNotSupported(Error::Anyhow(anyhow::anyhow!(reason)))
     }


### PR DESCRIPTION
Basically this just avoids blocking the async runtime, so we don't need
to do our own abnormal workarounds for that. Also cleans up the message
type to be more idiomatic.
