### PR TITLE
Fixes for rust 1.81

### DIFF
--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -399,19 +399,6 @@ pub enum SocksError {
 }
 
 impl SocksError {
-    pub fn into_inner(self) -> Error {
-        match self {
-            SocksError::General(e) => e,
-            SocksError::NotAllowed(e) => e,
-            SocksError::NetworkUnreachable(e) => e,
-            SocksError::HostUnreachable(e) => e,
-            SocksError::ConnectionRefused(e) => e,
-            SocksError::CommandNotSupported(e) => e,
-        }
-    }
-}
-
-impl SocksError {
     pub fn invalid_protocol(reason: String) -> SocksError {
         SocksError::CommandNotSupported(Error::Anyhow(anyhow::anyhow!(reason)))
     }

--- a/src/test_helpers/namespaced.rs
+++ b/src/test_helpers/namespaced.rs
@@ -119,7 +119,6 @@ pub fn initialize_namespace_tests() {
 
     write_to_stderr(&format!("Starting test in {tmp:?}. Debug with `sudo nsenter --mount --net --setuid=0 --preserve-credentials --user -t {pid}`"))
       .expect("write");
-    return;
 }
 
 // write_to_stderr is a small helper to write a message to stderr.

--- a/src/test_helpers/namespaced.rs
+++ b/src/test_helpers/namespaced.rs
@@ -14,9 +14,9 @@
 
 use libc::getpid;
 use nix::unistd::mkdtemp;
-use std::fs;
 use std::fs::File;
 use std::path::PathBuf;
+use std::{fs, io};
 
 #[macro_export]
 macro_rules! function {
@@ -116,5 +116,31 @@ pub fn initialize_namespace_tests() {
     .expect("xtables bindmount");
 
     let pid = unsafe { getpid() };
-    eprintln!("Starting test in {tmp:?}. Debug with `sudo nsenter --mount --net --setuid=0 --preserve-credentials --user -t {pid}`");
+
+    write_to_stderr(&format!("Starting test in {tmp:?}. Debug with `sudo nsenter --mount --net --setuid=0 --preserve-credentials --user -t {pid}`"))
+      .expect("write");
+    return;
+}
+
+// write_to_stderr is a small helper to write a message to stderr.
+// use of `std` in before-main code is not guaranteed to be legal, and does fail in Rust 1.81:
+// https://users.rust-lang.org/t/ld-preload-with-init-array-fatal-runtime-error-thread-set-current-should-only-be-called-once-per-thread/117264/13
+fn write_to_stderr(message: &str) -> io::Result<()> {
+    let c_str = std::ffi::CString::new(message)?;
+    let buf = c_str.as_bytes_with_nul();
+    let count = buf.len() as libc::size_t;
+
+    let result = unsafe {
+        libc::write(
+            libc::STDERR_FILENO,
+            buf.as_ptr() as *const std::ffi::c_void,
+            count,
+        ) as libc::ssize_t
+    };
+
+    if result < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }

--- a/src/test_helpers/tcp.rs
+++ b/src/test_helpers/tcp.rs
@@ -184,10 +184,7 @@ where
             let mut buffer = [0; 512];
             let mut read = 0;
             let header = loop {
-                let n = match rw.read(&mut buffer[read..]).await {
-                    Ok(n) => n,
-                    _ => 0,
-                };
+                let n = rw.read(&mut buffer[read..]).await.unwrap_or_default();
                 read += n;
                 let header = HeaderResult::parse(&buffer[..read]);
                 if n == 0 || header.is_complete() || read >= 512 {


### PR DESCRIPTION
dead code in socks5 caught by new rust I think but not older one.

Other thing is an obscure runtime error ,not sure the change that triggers it but this works around it.
