### PR TITLE
scripts: early exit if command fails in test coverage

### DIFF
--- a/scripts/test-with-coverage.sh
+++ b/scripts/test-with-coverage.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
+set -xe
 
 ARTIFACTS="${ARTIFACTS:-out/coverage}"
 output_dir=$ARTIFACTS/report


### PR DESCRIPTION
Update test coverage script to exit early if any command fails.