### PR TITLE
Add default TCP keepalives

### DIFF
--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -1305,7 +1305,7 @@ mod tests {
         let (state, local_workload) = state();
         let forwarder = forwarder();
         let (_signal, drain) = drain::new();
-        let factory = crate::proxy::DefaultSocketFactory;
+        let factory = crate::proxy::DefaultSocketFactory::default();
         let proxy = Server::new(
             domain,
             config::Address::Localhost(false, 0),
@@ -1391,7 +1391,7 @@ mod tests {
             .unwrap(),
         );
         let (_signal, drain) = drain::new();
-        let factory = crate::proxy::DefaultSocketFactory;
+        let factory = crate::proxy::DefaultSocketFactory::default();
         let server = Server::new(
             domain,
             config::Address::Localhost(false, 0),
@@ -1473,7 +1473,7 @@ mod tests {
         });
         let domain = "cluster.local".to_string();
         let (_signal, drain) = drain::new();
-        let factory = crate::proxy::DefaultSocketFactory;
+        let factory = crate::proxy::DefaultSocketFactory::default();
         let server = Server::new(
             domain,
             config::Address::Localhost(false, 0),
@@ -1514,7 +1514,7 @@ mod tests {
         let f = SystemForwarder::from_parts(
             true,
             "cluster.local".to_string(),
-            Arc::new(DefaultSocketFactory),
+            Arc::new(DefaultSocketFactory::default()),
             opts,
             None,
             search,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -24,7 +24,7 @@ use hickory_proto::error::ProtoError;
 
 use crate::strng::Strng;
 use rand::Rng;
-
+use socket2::TcpKeepalive;
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::time::timeout;
 use tracing::{debug, trace, warn, Instrument};
@@ -71,12 +71,32 @@ pub trait SocketFactory {
 }
 
 #[derive(Clone, Copy, Default)]
-pub struct DefaultSocketFactory;
+pub struct DefaultSocketFactory(pub config::SocketConfig);
 
 impl SocketFactory for DefaultSocketFactory {
     fn new_tcp_v4(&self) -> std::io::Result<TcpSocket> {
         TcpSocket::new_v4().and_then(|s| {
             s.set_nodelay(true)?;
+            let cfg = self.0;
+            if cfg.keepalive_enabled {
+                let ka = TcpKeepalive::new()
+                    .with_time(cfg.keepalive_time)
+                    .with_retries(cfg.keepalive_retries)
+                    .with_interval(cfg.keepalive_interval);
+                tracing::trace!(
+                    "set keepalive: {:?}",
+                    socket2::SockRef::from(&s).set_tcp_keepalive(&ka)
+                );
+            }
+            if cfg.user_timeout_enabled {
+                // https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/
+                // TCP_USER_TIMEOUT = TCP_KEEPIDLE + TCP_KEEPINTVL * TCP_KEEPCNT.
+                let ut = cfg.keepalive_time + cfg.keepalive_retries * cfg.keepalive_interval;
+                tracing::trace!(
+                    "set user timeout: {:?}",
+                    socket2::SockRef::from(&s).set_tcp_user_timeout(Some(ut))
+                );
+            }
             Ok(s)
         })
     }
@@ -105,33 +125,36 @@ impl SocketFactory for DefaultSocketFactory {
     }
 }
 
-pub struct MarkSocketFactory(pub u32);
+pub struct MarkSocketFactory {
+    pub inner: DefaultSocketFactory,
+    pub mark: u32,
+}
 
 impl SocketFactory for MarkSocketFactory {
     fn new_tcp_v4(&self) -> io::Result<TcpSocket> {
-        DefaultSocketFactory.new_tcp_v4().and_then(|s| {
-            socket::set_mark(&s, self.0)?;
+        self.inner.new_tcp_v4().and_then(|s| {
+            socket::set_mark(&s, self.mark)?;
             Ok(s)
         })
     }
 
     fn new_tcp_v6(&self) -> io::Result<TcpSocket> {
-        DefaultSocketFactory.new_tcp_v6().and_then(|s| {
-            socket::set_mark(&s, self.0)?;
+        self.inner.new_tcp_v6().and_then(|s| {
+            socket::set_mark(&s, self.mark)?;
             Ok(s)
         })
     }
 
     fn tcp_bind(&self, addr: SocketAddr) -> io::Result<socket::Listener> {
-        DefaultSocketFactory.tcp_bind(addr)
+        self.inner.tcp_bind(addr)
     }
 
     fn udp_bind(&self, addr: SocketAddr) -> io::Result<tokio::net::UdpSocket> {
-        DefaultSocketFactory.udp_bind(addr)
+        self.inner.udp_bind(addr)
     }
 
     fn ipv6_enabled_localhost(&self) -> io::Result<bool> {
-        DefaultSocketFactory.ipv6_enabled_localhost()
+        self.inner.ipv6_enabled_localhost()
     }
 }
 

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -548,7 +548,7 @@ mod tests {
         }
         let state = new_proxy_state(&workloads, &services, &[]);
 
-        let sock_fact = std::sync::Arc::new(crate::proxy::DefaultSocketFactory);
+        let sock_fact = std::sync::Arc::new(crate::proxy::DefaultSocketFactory::default());
 
         let wi = WorkloadInfo {
             name: "source-workload".to_string(),

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -1000,7 +1000,7 @@ mod test {
             pool_unused_release_timeout: idle,
             ..crate::config::parse_config().unwrap()
         };
-        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory);
+        let sock_fact = Arc::new(crate::proxy::DefaultSocketFactory::default());
 
         let mut state = ProxyState::new(None);
         let wl = Arc::new(workload::Workload {

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -70,11 +70,12 @@ impl ProxyFactory {
         &self,
         proxy_workload_info: WorkloadInfo,
     ) -> Result<ProxyResult, Error> {
+        let base = crate::proxy::DefaultSocketFactory(self.config.socket_config);
         let factory: Arc<dyn crate::proxy::SocketFactory + Send + Sync> =
             if let Some(mark) = self.config.packet_mark {
-                Arc::new(crate::proxy::MarkSocketFactory(mark))
+                Arc::new(crate::proxy::MarkSocketFactory { inner: base, mark })
             } else {
-                Arc::new(crate::proxy::DefaultSocketFactory)
+                Arc::new(base)
             };
         self.new_proxies_from_factory(None, proxy_workload_info, factory)
             .await

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -16,7 +16,7 @@ use crate::config::Address;
 use crate::dns::resolver::{Answer, Resolver};
 use crate::dns::Metrics;
 use crate::drain::DrainTrigger;
-use crate::proxy::{DefaultSocketFactory, Error};
+use crate::proxy::Error;
 use crate::state::workload::Workload;
 use crate::state::WorkloadInfo;
 use crate::test_helpers::new_proxy_state;
@@ -253,7 +253,7 @@ pub async fn run_dns(responses: HashMap<Name, Vec<IpAddr>>) -> anyhow::Result<Te
         Arc::new(Metrics::new(istio_registry))
     };
     let (signal, drain) = drain::new();
-    let factory = crate::proxy::DefaultSocketFactory {};
+    let factory = crate::proxy::DefaultSocketFactory::default();
 
     let state = new_proxy_state(
         &[XdsWorkload {
@@ -299,7 +299,7 @@ pub async fn run_dns(responses: HashMap<Name, Vec<IpAddr>>) -> anyhow::Result<Te
     let cfg = internal_resolver_config(tcp, udp);
     let opts = ResolverOpts::default();
     let resolver = Arc::new(
-        dns::forwarder::Forwarder::new(cfg, Arc::new(DefaultSocketFactory), opts)
+        dns::forwarder::Forwarder::new(cfg, Arc::new(factory), opts)
             .map_err(|e| Error::Generic(Box::new(e)))?,
     );
     Ok(TestDnsServer {


### PR DESCRIPTION
Our goal with keepalives is to stop things from dropping our connection prematurely.
So we want this to be a short enough interval to achieve that goal, without causing
excessive pings.

Note that keepalives are not hop-by-hop. So without setting keepalives in Ztunnel,
an application may rely on keepalives which are now only going to the local Ztunnel.
This results in hitting timeout's and unexpected behavior. This only impacts TCP keepalives;
application level keepalives work fine.

Some popular services, like Google LBs have a 10 minute timeout, so we will aim to be
well below that.

Other systems' defaults:
* Go: 15s/15s, 9 retries
* Linux: 2hr delay, 75s interval, 9 retries (note: its off by default, though)
* Envoy: no default
* Linkerd2: 10s delay (then hitting Linux level settings for the rest)

Note that because keepalives are a property of the socket (which has two ends), not the connection,
we cannot somehow read what the peer set and forward it (which would be neat).

Below shows why Ztunnel breaks existing applications:
![image](https://github.com/user-attachments/assets/10e5714e-162c-4399-a3ed-6506742936d7)

There have been >4 reports on slack that I think this will fix. One user tried out a pre-release and said it resolved their issues. Impacted users will see logs like `bytes_recv=7589 duration="1721673ms" error="receive: io error: Connection timed out (os error 110)"` (note the 'connection timed out' but >0 bytes).


This defaults to ON by default.

