### PR TITLE
debugging: add some extra debug logs to introspect HBONE requests

### DIFF
--- a/src/proxy/h2/server.rs
+++ b/src/proxy/h2/server.rs
@@ -19,6 +19,7 @@ use bytes::Bytes;
 use futures_util::FutureExt;
 use http::request::Parts;
 use http::Response;
+use std::fmt::Debug;
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -30,6 +31,14 @@ pub struct H2Request {
     request: Parts,
     recv: h2::RecvStream,
     send: h2::server::SendResponse<Bytes>,
+}
+
+impl Debug for H2Request {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("H2Request")
+            .field("request", &self.request)
+            .finish()
+    }
 }
 
 impl H2Request {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -171,7 +171,7 @@ impl Inbound {
         let src = conn.src;
         let dst = conn.dst;
 
-        debug!(%conn, ?req, "accepted request");
+        debug!(%conn, ?req, "received request");
 
         // In order to ensure we properly handle all errors, we split up serving inbound request into a few
         // phases.

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -171,6 +171,8 @@ impl Inbound {
         let src = conn.src;
         let dst = conn.dst;
 
+        debug!(%conn, ?req, "accepted request");
+
         // In order to ensure we properly handle all errors, we split up serving inbound request into a few
         // phases.
 


### PR DESCRIPTION
Right now we cannot see what is coming in on HBONE. I have >5 times done
a small local build to add this, so seems well worth having for
debugging.
