### PR TITLE
Tidy `DelWorkload` handling in a pre-snapshot context

### DIFF
--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -178,9 +178,9 @@ impl WorkloadProxyManagerState {
                     // make sure we also opportunistically remove here before we
                     // get a snapshot
                     //
-                    // Note that unlike AddWorkload we do *not* need to remove the workload here,
-                    // as it should be auto-dropped subsequently during snapshot reconcile(), when
-                    // we actually get the `SnapshotSent` notification.
+                    // Note that even though AddWorkload starts the workload, we do *not* need
+                    // to stop it here, as it should be auto-dropped subsequently during snapshot
+                    // reconcile(), when we actually get the `SnapshotSent` notification.
                     self.snapshot_names.remove(&workload_uid);
                     // `reconcile()` will drop this workload later, but if the workload never successfully
                     // starts it will stay in the pending queue (which `reconcile()` can't remove it from),

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -203,11 +203,13 @@ impl WorkloadProxyManagerState {
     // reconcile existing state to snaphsot. drains any workloads not in the snapshot
     // this can happen if workloads were removed while we were disconnected.
     fn reconcile(&mut self) {
-        for (_, workload_state) in self
+        for (wl_uid, workload_state) in self
             .workload_states
             .extract_if(|uid, _| !self.snapshot_names.contains(uid))
         {
             self.draining.shutdown_workload(workload_state);
+            // Also clear pending queue if we have something stuck in there for this UID
+            self.pending_workloads.remove(&wl_uid);
         }
         self.snapshot_names.clear();
         self.update_proxy_count_metrics();

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -588,14 +588,14 @@ mod tests {
             .process_msg(WorkloadMessage::DelWorkload(uid(0)))
             .await.unwrap();
 
-        assert!(state.snapshot_names.len() == 0);
+        assert!(state.snapshot_names.is_empty());
 
         state
             .process_msg(WorkloadMessage::WorkloadSnapshotSent)
             .await
             .unwrap();
 
-        assert!(state.snapshot_names.len() == 0);
+        assert!(state.snapshot_names.is_empty());
         assert!(!state.have_pending());
         state.drain().await;
     }

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -581,12 +581,16 @@ mod tests {
             workload_info: workload_info(),
         };
 
-        state.process_msg(WorkloadMessage::AddWorkload(data)).await.unwrap();
+        state
+            .process_msg(WorkloadMessage::AddWorkload(data))
+            .await
+            .unwrap();
         assert!(state.snapshot_names.len() == 1);
 
         state
             .process_msg(WorkloadMessage::DelWorkload(uid(0)))
-            .await.unwrap();
+            .await
+            .unwrap();
 
         assert!(state.snapshot_names.is_empty());
 

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -134,6 +134,7 @@ impl WorkloadProxyManagerState {
                     ));
                 };
                 if !self.snapshot_received {
+                    debug!("got workload add before snapshot");
                     self.snapshot_names.insert(poddata.workload_uid.clone());
                 }
                 let netns =
@@ -172,12 +173,12 @@ impl WorkloadProxyManagerState {
                     "pod delete request, shutting down proxy"
                 );
                 if !self.snapshot_received {
-                    // TODO: consider if this is an error. if not, do this instead:
-                    // self.snapshot_names.remove(&workload_uid)
-                    // self.pending_workloads.remove(&workload_uid)
-                    return Err(Error::ProtocolError(
-                        "pod delete received before snapshot".into(),
-                    ));
+                    debug!("got workload delete before snapshot");
+                    // Since we insert here on AddWorkload before we get a snapshot,
+                    // make sure we also opportunistically remove here before we
+                    // get a snapshot
+                    self.snapshot_names.remove(&workload_uid);
+                    return Ok(());
                 }
                 self.del_workload(&workload_uid);
                 Ok(())

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -177,6 +177,10 @@ impl WorkloadProxyManagerState {
                     // Since we insert here on AddWorkload before we get a snapshot,
                     // make sure we also opportunistically remove here before we
                     // get a snapshot
+                    //
+                    // Note that unlike AddWorkload we do *not* need to remove the workload here,
+                    // as it should be auto-dropped subsequently during snapshot reconcile(), when
+                    // we actually get the `SnapshotSent` notification.
                     self.snapshot_names.remove(&workload_uid);
                     return Ok(());
                 }


### PR DESCRIPTION
Removes a `TODO` here (and also fixes a potential theoretical snapshot state bug, I think)