### PR TITLE
xds: support overlapping IP addresses

### DIFF
--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -788,7 +788,7 @@ impl WorkloadStore {
 
     /// Finds the workload by address, as an arc.
     pub fn find_address(&self, addr: &NetworkAddress) -> Option<Arc<Workload>> {
-        dbg!(dbg!(self.by_addr.get(addr)).map(WorkloadByAddr::get))
+        self.by_addr.get(addr).map(WorkloadByAddr::get)
     }
 
     /// Finds the workload by workload information, as an arc.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/54528

The original design was to dedupe IPs in the control plane. however,
this approach was flawed. While it may be possible to handle this in
the control plane properly, it would be quite challenging. Instead, we
will allow multiple in Ztunnel itself. In the unlikely event of a
conflciting IP, we will store all matches and pick the best one for the
situation.

Note we only lookup by IP in a few cases:
* On inbound, to get peer metadata *for telemetry*
* lookup_is_destination_this_waypoint for some niche cases
* Sending directly to a Pod IP, instead of to a service

Note that without this PR, if you have 2 objects with the same IP, the
last one updated will 'win'. If you remove one, it may remove any info
about the IP entirely.
