### PR TITLE
tests: improve error messages

### DIFF
--- a/src/test_helpers/namespaced.rs
+++ b/src/test_helpers/namespaced.rs
@@ -47,7 +47,8 @@ macro_rules! setup_netns_test {
         let function_name = function_name
             .strip_suffix("::{{closure}}")
             .unwrap_or_else(|| function_name);
-        ztunnel::test_helpers::linux::WorkloadManager::new(function_name, $mode)?
+        ztunnel::test_helpers::linux::WorkloadManager::new(function_name, $mode)
+            .expect("namespace setup failed")
     }};
 }
 /// initialize_namespace_tests sets up the namespace tests.


### PR DESCRIPTION
Before:
```
thread '<unnamed>' panicked at tests/namespaced.rs:1411:43:
called `Result::unwrap()` on an `Err` value: Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'namespaced::local_captured_inpod' panicked at tests/namespaced.rs:1336:14:
called `Result::unwrap()` on an `Err` value: Any { .. }
```

After:
```
thread 'namespaced::local_captured_inpod' panicked at tests/namespaced.rs:1168:85:
called `Result::unwrap()` on an `Err` value: tcp client

Caused by:
    0: write failed
    1: Connection reset by peer (os error 104)
```

---

Access log change now looks like:

```
thread 'namespaced::local_captured_inpod' panicked at tests/namespaced.rs:1231:13:
Analyzed 40 logs but none matched our criteria. Closest 10 matches:

direction:"outboundx" != "outbound"

bytes_recv:"22" != "11"
bytes_sent:"11" != "22"
direction:"outboundx" != "inbound"

bytes_recv:missing
bytes_sent:missing
direction:missing
dst.identity:missing
dst.workload:missing
message:"connection complete" != "starting server"
scope:"access" != "ztunnel::test_helpers::inpod"
src.identity:missing
src.workload:missing
```

Before it just dumped all the logs
