### PR TITLE
Add inbound support for svc hostname in authority

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -493,14 +493,11 @@ pub enum Error {
 
 // Custom TLV for proxy protocol for the identity of the source
 const PROXY_PROTOCOL_AUTHORITY_TLV: u8 = 0xD0;
-// Custom TLV for including the svc hostname in the proxy protocol header
-const PROXY_PROTOCOL_SVC_HOSTNAME_TLV: u8 = 0xD1;
 
 pub async fn write_proxy_protocol<T>(
     stream: &mut TcpStream,
     addresses: T,
     src_id: Option<Identity>,
-    hostname_addr: Option<Strng>,
 ) -> io::Result<()>
 where
     T: Into<ppp::v2::Addresses> + std::fmt::Debug,
@@ -518,11 +515,6 @@ where
 
     if let Some(id) = src_id {
         builder = builder.write_tlv(PROXY_PROTOCOL_AUTHORITY_TLV, id.to_string().as_bytes())?;
-    }
-
-    // svc_hostname is None when the hbone_addr does not contain a svc hostname.
-    if let Some(svc_host) = hostname_addr {
-        builder = builder.write_tlv(PROXY_PROTOCOL_SVC_HOSTNAME_TLV, svc_host.as_bytes())?;
     }
 
     let header = builder.build()?;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -851,28 +851,24 @@ impl From<(Strng, u16)> for HboneAddress {
     }
 }
 
-/*
 impl TryFrom<&http::Uri> for HboneAddress {
-    type Error = InboundError;
+    type Error = Error;
 
     fn try_from(value: &http::Uri) -> Result<Self, Self::Error> {
         match value.to_string().parse::<SocketAddr>() {
             Ok(addr) => Ok(HboneAddress::SocketAddr(addr)),
             Err(_) => {
-                let hbone_host = value.host().ok_or_else(|| InboundError(
-                    Error::NoValidAuthority(value.to_string()),
-                    StatusCode::BAD_REQUEST
-                ))?;
-                let hbone_port = value.port_u16().ok_or_else(|| InboundError(
-                    Error::NoValidAuthority(value.to_string()),
-                    StatusCode::BAD_REQUEST
-                ))?;
+                let hbone_host = value
+                    .host()
+                    .ok_or_else(|| Error::NoValidAuthority(value.to_string()))?;
+                let hbone_port = value
+                    .port_u16()
+                    .ok_or_else(|| Error::NoValidAuthority(value.to_string()))?;
                 Ok(HboneAddress::SvcHostname(hbone_host.into(), hbone_port))
             }
         }
     }
 }
-*/
 
 #[cfg(test)]
 mod tests {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -485,12 +485,16 @@ pub enum Error {
     DnsEmpty,
 }
 
+// Custom TLV for proxy protocol for the identity of the source
 const PROXY_PROTOCOL_AUTHORITY_TLV: u8 = 0xD0;
+//TODO(jaellio) - Create our own TLV 0
+const PROXY_PROTOCOL_SVC_HOSTNAME_TLV: u8 = 0xD1;
 
 pub async fn write_proxy_protocol<T>(
     stream: &mut TcpStream,
     addresses: T,
     src_id: Option<Identity>,
+    svc_hostname: Option<String>,
 ) -> io::Result<()>
 where
     T: Into<ppp::v2::Addresses> + std::fmt::Debug,
@@ -504,6 +508,13 @@ where
 
     if let Some(id) = src_id {
         builder = builder.write_tlv(PROXY_PROTOCOL_AUTHORITY_TLV, id.to_string().as_bytes())?;
+    }
+
+    if let Some(svc_hostname) = svc_hostname {
+        builder = builder.write_tlv(
+            PROXY_PROTOCOL_SVC_HOSTNAME_TLV,
+            svc_hostname.as_bytes(),
+        )?;
     }
 
     let header = builder.build()?;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -516,10 +516,7 @@ where
 
     // svc_hostname is None when the hbone_addr does not contain a svc hostname.
     if let Some(svc_host) = svc_hostname {
-        builder = builder.write_tlv(
-            PROXY_PROTOCOL_SVC_HOSTNAME_TLV,
-            svc_host.as_bytes(),
-        )?;
+        builder = builder.write_tlv(PROXY_PROTOCOL_SVC_HOSTNAME_TLV, svc_host.as_bytes())?;
     }
 
     let header = builder.build()?;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -494,7 +494,7 @@ pub async fn write_proxy_protocol<T>(
     stream: &mut TcpStream,
     addresses: T,
     src_id: Option<Identity>,
-    svc_hostname: Option<String>,
+    svc_hostname: Option<Strng>,
 ) -> io::Result<()>
 where
     T: Into<ppp::v2::Addresses> + std::fmt::Debug,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -452,6 +452,9 @@ pub enum Error {
     #[error("no valid authority pseudo header: {0}")]
     NoValidAuthority(String),
 
+    #[error("no valid service port in authority header: {0}")]
+    NoValidSerivePort(String, u16),
+
     #[error("no valid routing destination for workload: {0}")]
     NoValidDestination(Box<Workload>),
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -500,7 +500,7 @@ pub async fn write_proxy_protocol<T>(
     stream: &mut TcpStream,
     addresses: T,
     src_id: Option<Identity>,
-    svc_hostname: Option<Strng>,
+    hostname_addr: Option<Strng>,
 ) -> io::Result<()>
 where
     T: Into<ppp::v2::Addresses> + std::fmt::Debug,
@@ -521,7 +521,7 @@ where
     }
 
     // svc_hostname is None when the hbone_addr does not contain a svc hostname.
-    if let Some(svc_host) = svc_hostname {
+    if let Some(svc_host) = hostname_addr {
         builder = builder.write_tlv(PROXY_PROTOCOL_SVC_HOSTNAME_TLV, svc_host.as_bytes())?;
     }
 
@@ -826,6 +826,13 @@ impl HboneAddress {
         match self {
             HboneAddress::SocketAddr(_) => None,
             HboneAddress::SvcHostname(s, _) => Some(s.into()),
+        }
+    }
+
+    pub fn hostname_addr(&self) -> Option<Strng> {
+        match self {
+            HboneAddress::SocketAddr(_) => None,
+            HboneAddress::SvcHostname(_, _) => Some(Strng::from(self.to_string())),
         }
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -449,11 +449,17 @@ pub enum Error {
     #[error("no service or workload for hostname: {0}")]
     NoHostname(String),
 
+    #[error("no endpoints for workload: {0}")]
+    NoWorkloadEndpoints(String),
+
     #[error("no valid authority pseudo header: {0}")]
     NoValidAuthority(String),
 
     #[error("no valid service port in authority header: {0}")]
     NoValidSerivePort(String, u16),
+
+    #[error("no valid target port for workload: {0}")]
+    NoValidTargetPort(String, u16),
 
     #[error("no valid routing destination for workload: {0}")]
     NoValidDestination(Box<Workload>),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -446,6 +446,12 @@ pub enum Error {
     #[error("unknown waypoint: {0}")]
     UnknownWaypoint(String),
 
+    #[error("no service or workload for hostname: {0}")]
+    NoHostname(String),
+
+    #[error("no valid authority pseudo header: {0}")]
+    NoValidAuthority(String),
+
     #[error("no valid routing destination for workload: {0}")]
     NoValidDestination(Box<Workload>),
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -801,7 +801,7 @@ pub fn parse_forwarded_host(input: &str) -> Option<String> {
         .filter(|host| !host.is_empty())
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum HboneAddress {
     SocketAddr(SocketAddr),
     SvcHostname(Strng, u16),
@@ -858,10 +858,10 @@ impl From<(Strng, u16)> for HboneAddress {
     }
 }
 
-impl TryFrom<&http::Uri> for HboneAddress {
+impl TryFrom<http::Uri> for HboneAddress {
     type Error = Error;
 
-    fn try_from(value: &http::Uri) -> Result<Self, Self::Error> {
+    fn try_from(value: http::Uri) -> Result<Self, Self::Error> {
         match value.to_string().parse::<SocketAddr>() {
             Ok(addr) => Ok(HboneAddress::SocketAddr(addr)),
             Err(_) => {

--- a/src/proxy/h2/server.rs
+++ b/src/proxy/h2/server.rs
@@ -42,16 +42,6 @@ impl Debug for H2Request {
 }
 
 impl H2Request {
-    /// The request's method
-    pub fn method(&self) -> &http::Method {
-        &self.request.method
-    }
-
-    /// The request's URI
-    pub fn uri(&self) -> &http::Uri {
-        &self.request.uri
-    }
-
     /// The request's headers
     pub fn headers(&self) -> &http::HeaderMap<http::HeaderValue> {
         &self.request.headers
@@ -78,6 +68,10 @@ impl H2Request {
         };
         let h2 = crate::proxy::h2::H2Stream { read, write };
         Ok(h2)
+    }
+
+    pub fn get_request(&self) -> &Parts {
+        &self.request
     }
 }
 

--- a/src/proxy/h2/server.rs
+++ b/src/proxy/h2/server.rs
@@ -42,11 +42,6 @@ impl Debug for H2Request {
 }
 
 impl H2Request {
-    /// The request's headers
-    pub fn headers(&self) -> &http::HeaderMap<http::HeaderValue> {
-        &self.request.headers
-    }
-
     pub fn send_error(mut self, resp: Response<()>) -> Result<(), Error> {
         let _ = self.send.send_response(resp, true)?;
         Ok(())
@@ -72,6 +67,30 @@ impl H2Request {
 
     pub fn get_request(&self) -> &Parts {
         &self.request
+    }
+
+    pub fn headers(&self) -> &http::HeaderMap<http::HeaderValue> {
+        self.request.headers()
+    }
+}
+
+pub trait RequestParts {
+    fn uri(&self) -> &http::Uri;
+    fn method(&self) -> &http::Method;
+    fn headers(&self) -> &http::HeaderMap<http::HeaderValue>;
+}
+
+impl RequestParts for Parts {
+    fn uri(&self) -> &http::Uri {
+        &self.uri
+    }
+
+    fn method(&self) -> &http::Method {
+        &self.method
+    }
+
+    fn headers(&self) -> &http::HeaderMap<http::HeaderValue> {
+        &self.headers
     }
 }
 

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -485,7 +485,7 @@ impl Inbound {
                 }
             })
             .cloned()
-            .ok_or_else(|| Error::NoResolvedAddresses(hbone_host.to_string()))
+            .ok_or_else(|| Error::NoHostname(hbone_host.to_string()))
     }
 
     /// validate_destination ensures the destination is an allowed request.

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -496,7 +496,7 @@ impl Inbound {
         state: &DemandProxyState,
         local_workload: &Workload,
         hbone_host: Strng,
-    ) -> Result<Service, Error> {
+    ) -> Result<Arc<Service>, Error> {
         // Validate a service exists for the hostname
         // TODO(jaellio): Currently returns an error is no service is found. Workload lookup is not supported.
         let services = state.read().find_service_by_hostname(&hbone_host)?;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -803,7 +803,7 @@ mod tests {
                     HboneAddress::SvcHostname(_, _) => {
                         match format!("{}:{}", protocol_addr.unwrap(), TARGET_PORT).parse::<SocketAddr>() {
                             Ok(addr) => assert_eq!(go_protocol_addr, Some(addr)),
-                            Err(_) => assert!(false, "failed to parse protocol addr"),
+                            Err(_) => panic!("failed to parse protocol addr provided in test case"),
                         };
                     }
                 };
@@ -813,32 +813,6 @@ mod tests {
             }
         }
     }
-
-    // TODO(jaellio): Should we want SERVER_SVC_IP or SERVER_POD_IP?
-    /*#[test_case(Waypoint::None, SERVER_POD_HOSTNAME, Some((SERVER_SVC_IP, TARGET_PORT)); "to workload no waypoint")]
-    fn test_convert_hostname_to_ip<'a>(
-        target_waypoint: Waypoint<'a>,
-        hbone_dst: &str,
-        want: Option<(&str, u16)>,
-    ) {
-        let state = test_state(target_waypoint).expect("state setup");
-        let res = Inbound::convert_hostname_to_ip(hbone_dst, TARGET_PORT, &state);
-
-        match want {
-            Some((ip, port)) => {
-                match res {
-                    Ok(got_addr) => assert_eq!(got_addr, SocketAddr::new(ip.parse().unwrap(), port)),
-                    Err(e) => assert!(false, "expected Ok, but got Err: {:?}", e),
-                }
-            }
-            None => {
-                match res {
-                    Ok(_) => assert!(false, "expected Err, but got Ok"),
-                    Err(_) => assert!(true, "failed to convert hostname in uri to ip"), // Expected error, test passes
-                }
-            }
-        }
-    }*/
 
     fn test_state(server_waypoint: Waypoint) -> anyhow::Result<state::DemandProxyState> {
         let mut state = state::ProxyState::new(None);

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -442,13 +442,11 @@ impl Inbound {
             return Err(Error::SelfCall);
         }
 
-        // TODO(jaellio): This is when IP address for the connection and the HBONE address 
         if conn.dst.ip() == hbone_addr.ip() {
             // Normal case: both are aligned. This is allowed (we really only need the HBONE address for the port.)
-            // HBONE address contains the original port, so we need that to update the port from 15008.
+            // TODO(jaellio): note - HBONE address contains the original port, so we need that to update the port from 15008.
             return Ok(());
         }
-        
         if local_workload.application_tunnel.is_some() {
             // In the case they have their own tunnel, they will get the HBONE target address in the PROXY
             // header, and their application can decide what to do with it; we don't validate this.
@@ -469,7 +467,6 @@ impl Inbound {
         let lookup_is_destination_this_waypoint = || -> Option<bool> {
             let state = state.read();
 
-            // TODO(jaellio): Allow HBONE address to be a hostname. We have to respect rules about
             // hostname scoping. Can we use the client's namespace here to do that?
             let hbone_target = state.find_address(hbone_dst)?;
 
@@ -541,7 +538,7 @@ impl Inbound {
 
         (upstream_addr, inbound_protocol, services)
     }
-    }
+}
 
 struct InboundRequest {
     for_host: Option<String>,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -684,7 +684,6 @@ mod tests {
     use crate::state::workload::HealthStatus;
     use crate::state::WorkloadInfo;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-    use http::request::Request;
     use http::{Method, Uri};
     use prometheus_client::registry::Registry;
     use test_case::test_case;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -351,7 +351,13 @@ impl Inbound {
                 .vips
                 .iter()
                 .max_by_key(|a| match a.network == conn.dst_network {
-                    true => 1,
+                    true => {
+                        // Defer to IPv4 if present
+                        match a.address.is_ipv4() {
+                            true => 2,
+                            false => 1,
+                        }
+                    }
                     false => 0,
                 })
                 .ok_or_else(|| {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -378,15 +378,17 @@ impl Inbound {
                                     )
                                 })?;
                         // Get the target port from the endpoint
-                        dest_port = *endpoint.port.get(&hbone_addr.port()).ok_or_else(|| {
-                            InboundError(
+                        if let Some(port) = endpoint.port.get(&hbone_addr.port()) {
+                            dest_port = *port;
+                        } else {
+                            return Err(InboundError(
                                 Error::NoValidTargetPort(
                                     hbone_addr.svc_hostname().unwrap().to_string(),
                                     hbone_addr.port(),
                                 ),
                                 StatusCode::BAD_REQUEST,
-                            )
-                        })?;
+                            ));
+                        }
                     } else {
                         dest_port = *port;
                     }

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -30,7 +30,9 @@ use crate::config::Config;
 use crate::drain::DrainWatcher;
 use crate::proxy::h2::server::{H2Request, RequestParts};
 use crate::proxy::metrics::{ConnectionOpen, Reporter};
-use crate::proxy::{BAGGAGE_HEADER, HboneAddress, ProxyInputs, TRACEPARENT_HEADER, TraceParent, metrics};
+use crate::proxy::{
+    BAGGAGE_HEADER, HboneAddress, ProxyInputs, TRACEPARENT_HEADER, TraceParent, metrics,
+};
 use crate::rbac::Connection;
 use crate::socket::to_canonical;
 use crate::state::service::Service;
@@ -657,7 +659,7 @@ fn build_response(status: StatusCode) -> Response<()> {
 #[cfg(test)]
 mod tests {
     use super::{Inbound, ProxyInputs};
-    use crate::{config, proxy::inbound::HboneAddress, proxy::ConnectionManager, strng};
+    use crate::{config, proxy::ConnectionManager, proxy::inbound::HboneAddress, strng};
 
     use crate::{
         rbac::Connection,
@@ -678,11 +680,11 @@ mod tests {
     };
 
     use crate::identity::manager::mock::new_secret_manager;
-    use crate::proxy::h2::server::RequestParts;
     use crate::proxy::DefaultSocketFactory;
     use crate::proxy::LocalWorkloadInformation;
-    use crate::state::workload::HealthStatus;
+    use crate::proxy::h2::server::RequestParts;
     use crate::state::WorkloadInfo;
+    use crate::state::workload::HealthStatus;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
     use http::{Method, Uri};
     use prometheus_client::registry::Registry;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -791,7 +791,6 @@ mod tests {
 
     // Regular zTunnel workload traffic inbound
     #[test_case(Waypoint::None, SERVER_POD_IP, SERVER_POD_IP, Some((SERVER_POD_IP, TARGET_PORT, None)); "to workload no waypoint")]
-    #[test_case(Waypoint::None, SERVER_SVC_IP, SERVER_POD_HOSTNAME, Some((SERVER_POD_IP, TARGET_PORT, Some(SERVER_SVC_IP))); "to workload no waypoint fail")]
     // Svc hostname
     #[test_case(Waypoint::None, SERVER_POD_IP, SERVER_POD_HOSTNAME, Some((SERVER_POD_IP, TARGET_PORT, Some(SERVER_SVC_IP))); "svc hostname to workload no waypoint")]
     // Sandwiched Waypoint Cases

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -790,7 +790,7 @@ mod tests {
             if let Ok(addr) = format!("{hbone_dst}:{TARGET_PORT}").parse::<SocketAddr>() {
                 HboneAddress::SocketAddr(addr)
             } else {
-                HboneAddress::SvcHostname(hbone_dst.into(), 80)
+                HboneAddress::SvcHostname(hbone_dst.into(), SERVER_PORT)
             };
 
         let validate_destination =

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -73,10 +73,10 @@ impl HboneAddress {
         }
     }
 
-    pub fn svc_hostname(&self) -> Option<String> {
+    pub fn svc_hostname(&self) -> Option<Strng> {
         match self {
             HboneAddress::SocketAddr(_) => None,
-            HboneAddress::SvcHostname(s, _) => Some(s.to_string()),
+            HboneAddress::SvcHostname(s, _) => Some(s.into()),
         }
     }
 }
@@ -312,7 +312,7 @@ impl Inbound {
                         }
                     };
                     // TODO(jaellio): Also include port?
-                    let svc_hostname: Option<String> = ri.hbone_addr.svc_hostname();
+                    let svc_hostname: Option<Strng> = ri.hbone_addr.svc_hostname();
                     super::write_proxy_protocol(&mut stream, (src, protocol_addr), src_identity, svc_hostname)
                         .instrument(trace_span!("proxy protocol"))
                         .await?;

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -500,7 +500,7 @@ impl Inbound {
                 }
                 let namespaced_name = &NamespacedHostname {
                     namespace: namespace.into(),
-                    hostname: hbone_host.into(),
+                    hostname: hbone_host,
                 };
                 let addr = match state.read().find_hostname(namespaced_name){
                     Some(addr) => addr,
@@ -515,7 +515,7 @@ impl Inbound {
                             return Err(Error::NoResolvedAddresses(local_workload.to_string()));
                         }
                         // TODO(jaellio): Intelligently select the VIP
-                        let svc_address = svc.vips[0].address.clone();
+                        let svc_address = svc.vips[0].address;
                         let svc_socket_addr = format!("{}:{}", svc_address, hbone_port)
                             .parse::<SocketAddr>()
                             .map_err(|e| Error::ConnectAddress(e.to_string()))?;

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -36,6 +36,7 @@ use crate::state::service::ServiceDescription;
 use crate::state::workload::Workload;
 use crate::strng::{RichStrng, Strng};
 
+#[derive(Debug)]
 pub struct Metrics {
     pub connection_opens: Family<CommonTrafficLabels, Counter>,
     pub connection_close: Family<CommonTrafficLabels, Counter>,
@@ -339,6 +340,7 @@ impl Metrics {
     }
 }
 
+#[derive(Debug)]
 /// ConnectionResult abstracts recording a metric and emitting an access log upon a connection completion
 pub struct ConnectionResult {
     // Src address and name

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -29,6 +29,7 @@ use tracing::event;
 use tracing_core::field::Value;
 
 use crate::identity::Identity;
+use crate::proxy::inbound::HboneAddress;
 use crate::metrics::DefaultedUnknown;
 use crate::proxy;
 
@@ -345,7 +346,7 @@ pub struct ConnectionResult {
     src: (SocketAddr, Option<RichStrng>),
     // Dst address and name
     dst: (SocketAddr, Option<RichStrng>),
-    hbone_target: Option<SocketAddr>,
+    hbone_target: Option<HboneAddress>,
     start: Instant,
 
     // TODO: storing CommonTrafficLabels adds ~600 bytes retained throughout a connection life time.
@@ -427,7 +428,7 @@ impl ConnectionResult {
         dst: SocketAddr,
         // If using hbone, the inner HBONE address
         // That is, dst is the L4 address, while is the :authority.
-        hbone_target: Option<SocketAddr>,
+        hbone_target: Option<HboneAddress>,
         start: Instant,
         conn: ConnectionOpen,
         metrics: Arc<Metrics>,
@@ -456,7 +457,7 @@ impl ConnectionResult {
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(to_value_owned),
 
             dst.addr = %dst.0,
-            dst.hbone_addr = hbone_target.map(display),
+            dst.hbone_addr = hbone_target.as_ref().map(display),
             dst.service = tl.destination_service.to_value(),
             dst.workload = dst.1.as_deref().map(to_value),
             dst.namespace = tl.destination_workload_namespace.to_value(),
@@ -550,7 +551,7 @@ impl ConnectionResult {
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(to_value_owned),
 
             dst.addr = %self.dst.0,
-            dst.hbone_addr = self.hbone_target.map(display),
+            dst.hbone_addr = self.hbone_target.as_ref().map(display),
             dst.service = tl.destination_service.to_value(),
             dst.workload = self.dst.1.as_deref().map(to_value),
             dst.namespace = tl.destination_workload_namespace.to_value(),

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -30,8 +30,7 @@ use tracing_core::field::Value;
 
 use crate::identity::Identity;
 use crate::metrics::DefaultedUnknown;
-use crate::proxy;
-use crate::proxy::inbound::HboneAddress;
+use crate::proxy::{self, HboneAddress};
 
 use crate::state::service::ServiceDescription;
 use crate::state::workload::Workload;

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -29,9 +29,9 @@ use tracing::event;
 use tracing_core::field::Value;
 
 use crate::identity::Identity;
-use crate::proxy::inbound::HboneAddress;
 use crate::metrics::DefaultedUnknown;
 use crate::proxy;
+use crate::proxy::inbound::HboneAddress;
 
 use crate::state::service::ServiceDescription;
 use crate::state::workload::Workload;

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -27,7 +27,9 @@ use tracing::{Instrument, debug, error, info, info_span, trace_span};
 use crate::identity::Identity;
 
 use crate::proxy::metrics::Reporter;
-use crate::proxy::{BAGGAGE_HEADER, Error, HboneAddress, ProxyInputs, TRACEPARENT_HEADER, TraceParent, util};
+use crate::proxy::{
+    BAGGAGE_HEADER, Error, HboneAddress, ProxyInputs, TRACEPARENT_HEADER, TraceParent, util,
+};
 use crate::proxy::{ConnectionOpen, ConnectionResult, DerivedWorkload, metrics};
 
 use crate::drain::DrainWatcher;

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -27,8 +27,13 @@ use tracing::{Instrument, debug, error, info, info_span, trace_span};
 use crate::identity::Identity;
 
 use crate::proxy::metrics::Reporter;
+<<<<<<< HEAD
 use crate::proxy::{BAGGAGE_HEADER, Error, ProxyInputs, TRACEPARENT_HEADER, TraceParent, util};
 use crate::proxy::{ConnectionOpen, ConnectionResult, DerivedWorkload, metrics};
+=======
+use crate::proxy::{BAGGAGE_HEADER, Error, HboneAddress, ProxyInputs, TRACEPARENT_HEADER, TraceParent, util};
+use crate::proxy::{ConnectionOpen, ConnectionResult, DerivedWorkload, metrics, pool};
+>>>>>>> b9bda55 (Move HboneAddress to proxy)
 
 use crate::drain::DrainWatcher;
 use crate::drain::run_with_drain;
@@ -37,8 +42,6 @@ use crate::state::ServiceResolutionMode;
 use crate::state::service::ServiceDescription;
 use crate::state::workload::{NetworkAddress, Protocol, Workload, address::Address};
 use crate::{assertions, copy, proxy, socket};
-
-use super::inbound::HboneAddress;
 
 pub struct Outbound {
     pi: Arc<ProxyInputs>,

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -185,10 +185,7 @@ impl OutboundConnection {
         );
 
         let metrics = self.pi.metrics.clone();
-        let hbone_target = match req.hbone_target_destination {
-            Some(hbone_target) => Some(HboneAddress::SocketAddr(hbone_target)),
-            None => None,
-        };
+        let hbone_target = req.hbone_target_destination.map(HboneAddress::SocketAddr);
         let result_tracker = Box::new(ConnectionResult::new(
             source_addr,
             req.actual_destination,

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -38,6 +38,8 @@ use crate::state::service::ServiceDescription;
 use crate::state::workload::{NetworkAddress, Protocol, Workload, address::Address};
 use crate::{assertions, copy, proxy, socket};
 
+use super::inbound::HboneAddress;
+
 pub struct Outbound {
     pi: Arc<ProxyInputs>,
     drain: DrainWatcher,
@@ -183,7 +185,10 @@ impl OutboundConnection {
         );
 
         let metrics = self.pi.metrics.clone();
-        let hbone_target = req.hbone_target_destination;
+        let hbone_target = match req.hbone_target_destination {
+            Some(hbone_target) => Some(HboneAddress::SocketAddr(hbone_target)),
+            None => None,
+        };
         let result_tracker = Box::new(ConnectionResult::new(
             source_addr,
             req.actual_destination,

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -27,13 +27,8 @@ use tracing::{Instrument, debug, error, info, info_span, trace_span};
 use crate::identity::Identity;
 
 use crate::proxy::metrics::Reporter;
-<<<<<<< HEAD
-use crate::proxy::{BAGGAGE_HEADER, Error, ProxyInputs, TRACEPARENT_HEADER, TraceParent, util};
-use crate::proxy::{ConnectionOpen, ConnectionResult, DerivedWorkload, metrics};
-=======
 use crate::proxy::{BAGGAGE_HEADER, Error, HboneAddress, ProxyInputs, TRACEPARENT_HEADER, TraceParent, util};
-use crate::proxy::{ConnectionOpen, ConnectionResult, DerivedWorkload, metrics, pool};
->>>>>>> b9bda55 (Move HboneAddress to proxy)
+use crate::proxy::{ConnectionOpen, ConnectionResult, DerivedWorkload, metrics};
 
 use crate::drain::DrainWatcher;
 use crate::drain::run_with_drain;

--- a/src/state.rs
+++ b/src/state.rs
@@ -259,6 +259,14 @@ impl ProxyState {
             })
     }
 
+    /// Find services by hostname.
+    pub fn find_service_by_hostname(&self, hostname: &Strng) -> Result<Vec<Service>, Error> {
+        // Hostnames for services are more common, so lookup service first and fallback to workload.
+        self.services.get_by_host(hostname).ok_or_else(|| {
+            Error::NoHostname(format!("service with hostname {} not found", hostname))
+        })
+    }
+
     fn find_upstream(
         &self,
         network: Strng,

--- a/src/state.rs
+++ b/src/state.rs
@@ -260,7 +260,7 @@ impl ProxyState {
     }
 
     /// Find services by hostname.
-    pub fn find_service_by_hostname(&self, hostname: &Strng) -> Result<Vec<Service>, Error> {
+    pub fn find_service_by_hostname(&self, hostname: &Strng) -> Result<Vec<Arc<Service>>, Error> {
         // Hostnames for services are more common, so lookup service first and fallback to workload.
         self.services.get_by_host(hostname).ok_or_else(|| {
             Error::NoHostname(format!("service with hostname {} not found", hostname))

--- a/src/test_helpers/namespaced.rs
+++ b/src/test_helpers/namespaced.rs
@@ -34,12 +34,13 @@ macro_rules! function {
 /// and automatically setups up a namespace based on the test name (to avoid conflicts).
 #[macro_export]
 macro_rules! setup_netns_test {
-    ($mode:expr) => {{
+    ($mode:expr) => {{ setup_netns_test!($mode, ztunnel::function!()) }};
+    ($mode:expr, $function:expr) => {{
         if unsafe { libc::getuid() } != 0 {
             panic!("CI tests should run as root; this is supposed to happen automatically?");
         }
         ztunnel::test_helpers::helpers::initialize_telemetry();
-        let function_name = ztunnel::function!()
+        let function_name = $function
             .strip_prefix(module_path!())
             .unwrap()
             .strip_prefix("::")

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -886,7 +886,16 @@ mod namespaced {
     }
 
     #[tokio::test]
-    async fn test_svc_hostname() -> anyhow::Result<()> {
+    async fn test_svc_hostname_port() -> anyhow::Result<()> {
+        test_svc_hostname(8080u16).await
+    }
+
+    #[tokio::test]
+    async fn test_svc_hostname_named_port() -> anyhow::Result<()> {
+        test_svc_hostname(0u16).await
+    }
+
+    async fn test_svc_hostname(svc_target_port: u16) -> anyhow::Result<()> {
         let mut manager = setup_netns_test!(Shared);
         let zt = manager.deploy_ztunnel(DEFAULT_NODE).await?;
         manager
@@ -895,7 +904,7 @@ mod namespaced {
                 network: strng::EMPTY,
                 address: TEST_VIP.parse::<IpAddr>()?,
             }])
-            .ports(HashMap::from([(80u16, 8080u16)]))
+            .ports(HashMap::from([(80u16, svc_target_port)]))
             .register()
             .await?;
         let server = manager

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -895,7 +895,7 @@ mod namespaced {
                 network: strng::EMPTY,
                 address: TEST_VIP.parse::<IpAddr>()?,
             }])
-            .ports(HashMap::from([(80u16, 80u16)]))
+            .ports(HashMap::from([(80u16, 8080u16)]))
             .register()
             .await?;
         let server = manager
@@ -921,7 +921,7 @@ mod namespaced {
                     hyper::client::conn::http2::Builder::new(ztunnel::hyper_util::TokioExecutor);
 
                 let request = hyper::Request::builder()
-                    .uri(format!("{SERVER_HOSTNAME}:{SERVER_PORT}"))
+                    .uri(format!("{SERVER_HOSTNAME}:80"))
                     .method(Method::CONNECT)
                     .version(hyper::Version::HTTP_2)
                     .body(Empty::<Bytes>::new())

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -890,7 +890,7 @@ mod namespaced {
         let mut manager = setup_netns_test!(Shared);
         let zt = manager.deploy_ztunnel(DEFAULT_NODE).await?;
         manager
-            .service_builder("service")
+            .service_builder("server")
             .addresses(vec![NetworkAddress {
                 network: strng::EMPTY,
                 address: TEST_VIP.parse::<IpAddr>()?,

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -900,7 +900,11 @@ mod namespaced {
             .await?;
         let server = manager
             .workload_builder("server", DEFAULT_NODE)
-            .service("default/service.default.svc.cluster.local", 80, SERVER_PORT)
+            .service(
+                format!("default/{SERVER_HOSTNAME}").as_str(),
+                80,
+                SERVER_PORT,
+            )
             .register()
             .await?;
         let client = manager
@@ -917,7 +921,7 @@ mod namespaced {
                     hyper::client::conn::http2::Builder::new(ztunnel::hyper_util::TokioExecutor);
 
                 let request = hyper::Request::builder()
-                    .uri(format!("service.default.svc.cluster.local:{}", SERVER_PORT))
+                    .uri(format!("{SERVER_HOSTNAME}:{SERVER_PORT}"))
                     .method(Method::CONNECT)
                     .version(hyper::Version::HTTP_2)
                     .body(Empty::<Bytes>::new())
@@ -1145,6 +1149,7 @@ mod namespaced {
     const TEST_VIP: &str = "10.10.0.1";
 
     const SERVER_PORT: u16 = 8080;
+    const SERVER_HOSTNAME: &str = "server.default.svc.cluster.local";
     const PROXY_PROTOCOL_PORT: u16 = 15088;
 
     const DEFAULT_NODE: &str = "node";

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -887,16 +887,16 @@ mod namespaced {
 
     #[tokio::test]
     async fn test_svc_hostname_port() -> anyhow::Result<()> {
-        test_svc_hostname(8080u16).await
+        test_svc_hostname(8080u16, ztunnel::function!()).await
     }
 
     #[tokio::test]
     async fn test_svc_hostname_named_port() -> anyhow::Result<()> {
-        test_svc_hostname(0u16).await
+        test_svc_hostname(0u16, ztunnel::function!()).await
     }
 
-    async fn test_svc_hostname(svc_target_port: u16) -> anyhow::Result<()> {
-        let mut manager = setup_netns_test!(Shared);
+    async fn test_svc_hostname(svc_target_port: u16, function_name: &str) -> anyhow::Result<()> {
+        let mut manager = setup_netns_test!(Shared, function_name);
         let zt = manager.deploy_ztunnel(DEFAULT_NODE).await?;
         manager
             .service_builder("server")


### PR DESCRIPTION
Main changes:
- hbone_address supports hostname or ip when reading from the authority header
- when a hostname is included in the authority pseudo header in is included as header in the proxy protocol. The hbone address included in the address header is set to the destination service vip
- hostname is validated by looking up the respective service and verifying the destination pod ip is a member of that service. 

Todo:
- [x] refactor hbone address validation to improve testability
- [x] update error types
- [x] confirm if port should also be included with hostname in custom protocol type
- [x] intelligently select service vip for proxy protocol address header
- [ ] strictly validate hostname fqdn