### PR TITLE
Bump prom_client to 0.23, fix a few build errors triggered by same

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "92f2b0cae6fd19ec4f2b6ded3f39ffcce7a8c8490b34aa406c27e2c855bdc97d"
 dependencies = [
  "dtoa",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ log = "0.4"
 nix = { version = "0.29", features = ["socket", "sched", "uio", "fs", "ioctl", "user", "net", "mount"] }
 once_cell = "1.19"
 ppp = "2.2"
-prometheus-client = { version = "0.22" }
+prometheus-client = { version = "0.23" }
 prometheus-parse = "0.2"
 prost = "0.13"
 prost-types = "0.13"
@@ -102,7 +102,7 @@ flurry = "0.5"
 h2 = "0.4"
 http = "1.2"
 split-iter = "0.1"
-arcstr = { version = "1.1", features = ["serde"] }
+arcstr = { version = "1.2", features = ["serde"] }
 tracing-core = "0.1"
 tracing-appender = "0.2"
 tokio-util = { version = "0.7", features = ["io-util"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1853,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "92f2b0cae6fd19ec4f2b6ded3f39ffcce7a8c8490b34aa406c27e2c855bdc97d"
 dependencies = [
  "dtoa",
  "itoa",

--- a/src/inpod/metrics.rs
+++ b/src/inpod/metrics.rs
@@ -13,16 +13,15 @@
 // limitations under the License.
 
 use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
 
 #[derive(Default)]
 pub struct Metrics {
-    pub(super) active_proxy_count: Family<(), Gauge>,
-    pub(super) pending_proxy_count: Family<(), Gauge>,
-    pub(super) proxies_started: Family<(), Counter>,
-    pub(super) proxies_stopped: Family<(), Counter>,
+    pub(super) active_proxy_count: Gauge,
+    pub(super) pending_proxy_count: Gauge,
+    pub(super) proxies_started: Counter,
+    pub(super) proxies_stopped: Counter,
 }
 
 impl Metrics {

--- a/src/inpod/statemanager.rs
+++ b/src/inpod/statemanager.rs
@@ -299,13 +299,13 @@ impl WorkloadProxyManagerState {
         let metrics = self.metrics.clone();
         let admin_handler = self.admin_handler.clone();
 
-        metrics.proxies_started.get_or_create(&()).inc();
+        metrics.proxies_started.inc();
         if let Some(proxy) = proxies.proxy {
             tokio::spawn(
                 async move {
                     proxy.run().await;
                     debug!("proxy for workload {:?} exited", uid);
-                    metrics.proxies_stopped.get_or_create(&()).inc();
+                    metrics.proxies_stopped.inc();
                     admin_handler.proxy_down(&uid);
                 }
                 .instrument(tracing::info_span!("proxy", wl=%format!("{}/{}", workload_info.namespace, workload_info.name))),
@@ -369,11 +369,9 @@ impl WorkloadProxyManagerState {
     fn update_proxy_count_metrics(&self) {
         self.metrics
             .active_proxy_count
-            .get_or_create(&())
             .set(self.workload_states.len().try_into().unwrap_or(-1));
         self.metrics
             .pending_proxy_count
-            .get_or_create(&())
             .set(self.pending_workloads.len().try_into().unwrap_or(-1));
     }
 }
@@ -492,7 +490,7 @@ mod tests {
         state.retry_pending().await;
         assert!(!state.have_pending());
         state.drain().await;
-        assert_eq!(m.proxies_started.get_or_create(&()).get(), 1);
+        assert_eq!(m.proxies_started.get(), 1);
     }
 
     #[tokio::test]
@@ -532,7 +530,7 @@ mod tests {
         state.retry_pending().await;
         assert!(!state.have_pending());
         state.drain().await;
-        assert_eq!(m.proxies_started.get_or_create(&()).get(), 1);
+        assert_eq!(m.proxies_started.get(), 1);
     }
 
     #[tokio::test]
@@ -630,7 +628,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(m.proxies_started.get_or_create(&()).get(), 1);
+        assert_eq!(m.proxies_started.get(), 1);
 
         state.drain().await;
     }
@@ -659,8 +657,8 @@ mod tests {
         state.process_msg(add2).await.unwrap();
         state.drain().await;
 
-        assert_eq!(m.proxies_started.get_or_create(&()).get(), 2);
-        assert_eq!(m.active_proxy_count.get_or_create(&()).get(), 1);
+        assert_eq!(m.proxies_started.get(), 2);
+        assert_eq!(m.active_proxy_count.get(), 1);
     }
 
     #[tokio::test]

--- a/src/inpod/workloadmanager.rs
+++ b/src/inpod/workloadmanager.rs
@@ -565,7 +565,7 @@ pub(crate) mod tests {
         assert_end_stream(res);
 
         assert_eq!(state.workload_states().len(), 0);
-        assert_eq!(m.active_proxy_count.get_or_create(&()).get(), 0);
+        assert_eq!(m.active_proxy_count.get(), 0);
         assert!(readiness.ready.pending().is_empty());
 
         state.drain().await;
@@ -608,7 +608,7 @@ pub(crate) mod tests {
             .map(crate::inpod::WorkloadUid::from)
             .collect();
         assert_eq!(key_set, expected_key_set);
-        assert_eq!(m.active_proxy_count.get_or_create(&()).get(), 2);
+        assert_eq!(m.active_proxy_count.get(), 2);
 
         // second connection - don't send the one of the proxies here, to see ztunnel reconciles and removes it:
         let (s1, mut s2) = UnixStream::pair().unwrap();
@@ -631,7 +631,7 @@ pub(crate) mod tests {
         // only second workload should remain
         assert_eq!(state.workload_states().len(), 1);
         assert_eq!(state.workload_states().keys().next(), Some(&uid(1)));
-        assert_eq!(m.active_proxy_count.get_or_create(&()).get(), 1);
+        assert_eq!(m.active_proxy_count.get(), 1);
         assert!(readiness.ready.pending().is_empty());
 
         state.drain().await;

--- a/src/strng.rs
+++ b/src/strng.rs
@@ -42,7 +42,10 @@ pub struct RichStrng(Strng);
 
 impl prometheus_client::encoding::EncodeLabelValue for RichStrng {
     fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), Error> {
-        prometheus_client::encoding::EncodeLabelValue::encode(&self.0.as_ref(), encoder)
+        prometheus_client::encoding::EncodeLabelValue::encode(
+            &<ArcStr as AsRef<str>>::as_ref(&self.0),
+            encoder,
+        )
     }
 }
 


### PR DESCRIPTION
- Bump prom_client to 0.23
- bump arcstr to 1.2
- fix `strng` trait bound
- Don't wrap `inpod` gauges/counters in a Family if we aren't using labels at all (also `&()` for label no longer satisfies trait bounds anyway as of 0.23)