### PR TITLE
Serialize SA match as camelCase

### DIFF
--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -283,6 +283,7 @@ impl StringMatch {
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ServiceAccountMatch {
     namespace: Strng,
     service_account: Strng,


### PR DESCRIPTION
Not sure a good way to make sure we don't miss these. Obviously we could
add a test for the individual field but that only helps after we
notice...
