### PR TITLE
metrics: add src/dst locality information to labels

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -439,12 +439,14 @@ fn build_forwarded(remote_addr: SocketAddr, server: &Option<ServiceDescription>)
 }
 
 fn baggage(r: &Request, cluster: String) -> String {
-    format!("k8s.cluster.name={cluster},k8s.namespace.name={namespace},k8s.{workload_type}.name={workload_name},service.name={name},service.version={version}",
+    format!("k8s.cluster.name={cluster},k8s.namespace.name={namespace},k8s.{workload_type}.name={workload_name},service.name={name},service.version={version},cloud.region={region},cloud.availability_zone={zone}",
             namespace = r.source.namespace,
             workload_type = r.source.workload_type,
             workload_name = r.source.workload_name,
             name = r.source.canonical_name,
             version = r.source.canonical_revision,
+            region = r.source.locality.region,
+            zone = r.source.locality.zone,
     )
 }
 


### PR DESCRIPTION
Understanding cross-zone/cross-region traffic is one of the most
critical pieces of observing a cluster, for a cost, reliability, and
latency standpoint. Lots of work has been done in this space from
standalone tools (https://github.com/polarsignals/kubezonnet/) to
enterprise upsells (I *think* Buoyant enterprise has this but not in
OSS?); we can provide this exact data trivially.
