### PR TITLE
Add xDS and CA headers/metadata support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,9 @@ const ISTIO_META_PREFIX: &str = "ISTIO_META_";
 const DNS_CAPTURE_METADATA: &str = "DNS_CAPTURE";
 const DNS_PROXY_ADDR_METADATA: &str = "DNS_PROXY_ADDR";
 
+const ISTIO_XDS_HEADER_PREFIX: &str = "XDS_HEADER_";
+const ISTIO_CA_HEADER_PREFIX: &str = "CA_HEADER_";
+
 /// Fetch the XDS/CA root cert file path based on below constants
 const XDS_ROOT_CA_ENV: &str = "XDS_ROOT_CA";
 const CA_ROOT_CA_ENV: &str = "CA_ROOT_CA";
@@ -246,6 +249,12 @@ pub struct Config {
     pub packet_mark: Option<u32>,
 
     pub socket_config: SocketConfig,
+
+    // Headers to be added to XDS discovery request
+    pub xds_headers: HashMap<String, String>,
+
+    // Headers to be added to certificate request
+    pub ca_headers: HashMap<String, String>,
 }
 
 #[derive(serde::Serialize, Clone, Copy, Debug)]
@@ -676,6 +685,14 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             }
         }),
         fake_self_inbound: false,
+        xds_headers: env::vars()
+            .filter(|(key, _)| key.starts_with(ISTIO_XDS_HEADER_PREFIX))
+            .map(|(key, val)| (key.trim_start_matches(ISTIO_XDS_HEADER_PREFIX).to_string(), val))
+            .collect(),
+        ca_headers: env::vars()
+            .filter(|(key, _)| key.starts_with(ISTIO_CA_HEADER_PREFIX))
+            .map(|(key, val)| (key.trim_start_matches(ISTIO_CA_HEADER_PREFIX).to_string(), val))
+            .collect(),
     })
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,10 +250,10 @@ pub struct Config {
 
     pub socket_config: SocketConfig,
 
-    // Headers to be added to XDS discovery request
+    // Headers to be added to XDS discovery requests
     pub xds_headers: HashMap<String, String>,
 
-    // Headers to be added to certificate request
+    // Headers to be added to certificate requests
     pub ca_headers: HashMap<String, String>,
 }
 
@@ -929,6 +929,9 @@ pub mod tests {
         env::set_var("ISTIO_META_INCLUDE_THIS", "foobar-env");
         env::set_var("NOT_INCLUDE", "not-include");
         env::set_var("ISTIO_META_CLUSTER_ID", "test-cluster");
+        env::set_var("XDS_HEADER_HEADER_FOO", "foo");
+        env::set_var("XDS_HEADER_HEADER_BAR", "bar");
+        env::set_var("CA_HEADER_HEADER_BAZ", "baz");
 
         let pc = construct_proxy_config("", pc_env).unwrap();
         let cfg = construct_config(pc).unwrap();
@@ -942,7 +945,14 @@ pub mod tests {
         );
         assert_eq!(cfg.proxy_metadata["BAR"], "bar");
         assert_eq!(cfg.proxy_metadata["FOOBAR"], "foobar-overwritten");
+        assert_eq!(cfg.proxy_metadata["NO_PREFIX"], "no-prefix");
+        assert_eq!(cfg.proxy_metadata["INCLUDE_THIS"], "foobar-env");
+        assert_eq!(cfg.proxy_metadata.get("NOT_INCLUDE"), None);
+        assert_eq!(cfg.proxy_metadata["CLUSTER_ID"], "test-cluster");
         assert_eq!(cfg.cluster_id, "test-cluster");
+        assert_eq!(cfg.xds_headers["HEADER_FOO"], "foo");
+        assert_eq!(cfg.xds_headers["HEADER_BAR"], "bar");
+        assert_eq!(cfg.ca_headers["HEADER_BAZ"], "baz");
 
         // both (with a field override and metadata override)
         let pc = construct_proxy_config(mesh_config_path, pc_env).unwrap();
@@ -957,5 +967,10 @@ pub mod tests {
         assert_eq!(cfg.proxy_metadata["FOOBAR"], "foobar-overwritten");
         assert_eq!(cfg.proxy_metadata["NO_PREFIX"], "no-prefix");
         assert_eq!(cfg.proxy_metadata["INCLUDE_THIS"], "foobar-env");
+        assert_eq!(cfg.proxy_metadata["CLUSTER_ID"], "test-cluster");
+        assert_eq!(cfg.cluster_id, "test-cluster");
+        assert_eq!(cfg.xds_headers["HEADER_FOO"], "foo");
+        assert_eq!(cfg.xds_headers["HEADER_BAR"], "bar");
+        assert_eq!(cfg.ca_headers["HEADER_BAZ"], "baz");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -380,7 +380,7 @@ fn parse_headers(prefix: &str) -> Result<MetadataVector, Error> {
         match stripped_key {
             Some(stripped_key) => {
                 // attempt to parse the stripped key
-                match AsciiMetadataKey::from_str(&stripped_key) {
+                match AsciiMetadataKey::from_str(stripped_key) {
                     Ok(metadata_key) => {
                         // attempt to parse the value
                         match AsciiMetadataValue::from_str(&value) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1052,7 +1052,7 @@ pub mod tests {
         for (k, v) in header_map {
             let key: AsciiMetadataKey = AsciiMetadataKey::from_str(&k).unwrap();
             let value: AsciiMetadataValue = AsciiMetadataValue::from_str(&v).unwrap();
-            assert_eq!(metadata.vec.contains(&(key, value)), true);
+            assert!(metadata.vec.contains(&(key, value)));
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -687,11 +687,21 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         fake_self_inbound: false,
         xds_headers: env::vars()
             .filter(|(key, _)| key.starts_with(ISTIO_XDS_HEADER_PREFIX))
-            .map(|(key, val)| (key.trim_start_matches(ISTIO_XDS_HEADER_PREFIX).to_string(), val))
+            .map(|(key, val)| {
+                (
+                    key.trim_start_matches(ISTIO_XDS_HEADER_PREFIX).to_string(),
+                    val,
+                )
+            })
             .collect(),
         ca_headers: env::vars()
             .filter(|(key, _)| key.starts_with(ISTIO_CA_HEADER_PREFIX))
-            .map(|(key, val)| (key.trim_start_matches(ISTIO_CA_HEADER_PREFIX).to_string(), val))
+            .map(|(key, val)| {
+                (
+                    key.trim_start_matches(ISTIO_CA_HEADER_PREFIX).to_string(),
+                    val,
+                )
+            })
             .collect(),
     })
 }

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -31,7 +31,7 @@ pub struct CaClient {
     pub client: IstioCertificateServiceClient<TlsGrpcChannel>,
     pub enable_impersonated_identity: bool,
     pub secret_ttl: i64,
-    headers: HashMap<String, String>,
+    ca_headers: HashMap<String, String>,
 }
 
 impl CaClient {
@@ -42,7 +42,7 @@ impl CaClient {
         auth: AuthSource,
         enable_impersonated_identity: bool,
         secret_ttl: i64,
-        headers: HashMap<String, String>,
+        ca_headers: HashMap<String, String>,
     ) -> Result<CaClient, Error> {
         let svc =
             tls::grpc_connector(address, auth, cert_provider.fetch_cert(alt_hostname).await?)?;
@@ -51,7 +51,7 @@ impl CaClient {
             client,
             enable_impersonated_identity,
             secret_ttl,
-            headers,
+            ca_headers,
         })
     }
 }
@@ -84,7 +84,7 @@ impl CaClient {
                 }
             },
         });
-        self.headers.iter().for_each(|(k, v)| {
+        self.ca_headers.iter().for_each(|(k, v)| {
             let key: tonic::metadata::MetadataKey<_> = k.as_str().parse().unwrap();
             let value: tonic::metadata::MetadataValue<_> = v.as_str().parse().unwrap();
             req.metadata_mut().insert(key.clone(), value.clone());

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -88,11 +88,8 @@ impl CaClient {
         self.ca_headers.iter().for_each(|(k, v)| {
             req.metadata_mut().insert(k.clone(), v.clone());
 
-            match v.to_str() {
-                Ok(v_str) => {
-                    debug!("CA header added: {}={}", k, v_str);
-                }
-                _ => {}
+            if let Ok(v_str) = v.to_str() {
+                debug!("CA header added: {}={}", k, v_str);
             }
         });
 

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -17,8 +17,8 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use prost_types::value::Kind;
 use prost_types::Struct;
-use tonic::IntoRequest;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue};
+use tonic::IntoRequest;
 use tracing::{debug, error, instrument, warn};
 
 use crate::identity::auth::AuthSource;

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -507,6 +507,7 @@ impl SecretManager {
             cfg.auth.clone(),
             cfg.proxy_mode == ProxyMode::Shared,
             cfg.secret_ttl.as_secs().try_into().unwrap_or(60 * 60 * 24),
+            cfg.ca_headers.clone(),
         )
         .await?;
         Ok(Self::new_with_client(caclient))

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -507,7 +507,7 @@ impl SecretManager {
             cfg.auth.clone(),
             cfg.proxy_mode == ProxyMode::Shared,
             cfg.secret_ttl.as_secs().try_into().unwrap_or(60 * 60 * 24),
-            cfg.ca_headers.clone(),
+            cfg.ca_headers.vec.clone(),
         )
         .await?;
         Ok(Self::new_with_client(caclient))

--- a/src/test_helpers/ca.rs
+++ b/src/test_helpers/ca.rs
@@ -86,6 +86,7 @@ impl CaServer {
             ),
             true,
             60 * 60 * 24,
+            None,
         )
         .await
         .unwrap();

--- a/src/test_helpers/ca.rs
+++ b/src/test_helpers/ca.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -87,7 +86,7 @@ impl CaServer {
             ),
             true,
             60 * 60 * 24,
-            HashMap::new(),
+            Vec::new(),
         )
         .await
         .unwrap();

--- a/src/test_helpers/ca.rs
+++ b/src/test_helpers/ca.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -86,7 +87,7 @@ impl CaServer {
             ),
             true,
             60 * 60 * 24,
-            None,
+            HashMap::new(),
         )
         .await
         .unwrap();

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -215,6 +215,8 @@ pub struct Config {
 
     /// alt_hostname provides an alternative accepted SAN for the control plane TLS verification
     alt_hostname: Option<String>,
+
+    xds_headers: HashMap<String, String>,
 }
 
 pub struct State {
@@ -262,6 +264,7 @@ impl Config {
             on_demand: config.xds_on_demand,
             proxy_metadata: config.proxy_metadata.clone(),
             alt_hostname: config.alt_xds_hostname.clone(),
+            xds_headers: config.xds_headers.clone(),
         }
     }
 
@@ -628,9 +631,17 @@ impl AdsClient {
                 .await?,
         )?;
 
+        let mut req = tonic::Request::new(outbound);
+        self.config.xds_headers.iter().for_each(|(k,v)| {
+            let key: tonic::metadata::MetadataKey<_> =  k.as_str().parse().unwrap();
+            let value: tonic::metadata::MetadataValue<_> = v.as_str().parse().unwrap();
+            req.metadata_mut().insert(key.clone(), value.clone());
+            debug!("XDS header added: {}={}", k, v);
+        });
+
         let ads_connection = AggregatedDiscoveryServiceClient::new(tls_grpc_channel)
             .max_decoding_message_size(200 * 1024 * 1024)
-            .delta_aggregated_resources(tonic::Request::new(outbound))
+            .delta_aggregated_resources(req)
             .await;
 
         let mut response_stream = ads_connection

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -215,7 +215,6 @@ pub struct Config {
 
     /// alt_hostname provides an alternative accepted SAN for the control plane TLS verification
     alt_hostname: Option<String>,
-
     xds_headers: HashMap<String, String>,
 }
 

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -635,11 +635,8 @@ impl AdsClient {
         self.config.xds_headers.iter().for_each(|(k, v)| {
             req.metadata_mut().insert(k.clone(), v.clone());
 
-            match v.to_str() {
-                Ok(v_str) => {
-                    debug!("XDS header added: {}={}", k, v_str);
-                }
-                _ => {}
+            if let Ok(v_str) = v.to_str() {
+                debug!("XDS header added: {}={}", k, v_str);
             }
         });
 

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -631,8 +631,8 @@ impl AdsClient {
         )?;
 
         let mut req = tonic::Request::new(outbound);
-        self.config.xds_headers.iter().for_each(|(k,v)| {
-            let key: tonic::metadata::MetadataKey<_> =  k.as_str().parse().unwrap();
+        self.config.xds_headers.iter().for_each(|(k, v)| {
+            let key: tonic::metadata::MetadataKey<_> = k.as_str().parse().unwrap();
             let value: tonic::metadata::MetadataValue<_> = v.as_str().parse().unwrap();
             req.metadata_mut().insert(key.clone(), value.clone());
             debug!("XDS header added: {}={}", k, v);


### PR DESCRIPTION
### Summary
This PR make it possible to add additional xDS and CA headers/metadata (fetched from env vars). We could use these headers/metadata for different purposes, such as routing.