### PR TITLE
misc refactors around inbound code

### DIFF
--- a/src/baggage.rs
+++ b/src/baggage.rs
@@ -25,6 +25,8 @@ pub struct Baggage {
     pub workload_name: Option<Strng>,
     pub service_name: Option<Strng>,
     pub revision: Option<Strng>,
+    pub region: Option<Strng>,
+    pub zone: Option<Strng>,
 }
 
 pub fn parse_baggage_header(headers: GetAll<HeaderValue>) -> Result<Baggage, ToStrError> {
@@ -49,6 +51,8 @@ pub fn parse_baggage_header(headers: GetAll<HeaderValue>) -> Result<Baggage, ToS
                     | "k8s.job.name" => baggage.workload_name = val,
                     "service.name" => baggage.service_name = val,
                     "service.version" => baggage.revision = val,
+                    "cloud.region" => baggage.region = val,
+                    "cloud.availability_zone" => baggage.zone = val,
                     _ => {}
                 }
             }

--- a/src/baggage.rs
+++ b/src/baggage.rs
@@ -51,6 +51,7 @@ pub fn parse_baggage_header(headers: GetAll<HeaderValue>) -> Result<Baggage, ToS
                     | "k8s.job.name" => baggage.workload_name = val,
                     "service.name" => baggage.service_name = val,
                     "service.version" => baggage.revision = val,
+                    // https://opentelemetry.io/docs/specs/semconv/attributes-registry/cloud/
                     "cloud.region" => baggage.region = val,
                     "cloud.availability_zone" => baggage.zone = val,
                     _ => {}

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -560,7 +560,8 @@ impl Inbound {
                     HboneAddress::SvcHostname(h, port) => {
                         // PROXY cannot currently send to hostnames, so we will need to select an IP to
                         // use instead
-                        let vip = services[0]
+                        // We ensure a service is set above.
+                        let vip = services.first().expect("service must exist")
                             .vips
                             .iter()
                             .max_by_key(|a| match a.network == conn.dst_network {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -798,7 +798,7 @@ mod tests {
     // to workload traffic
     #[test_case(Waypoint::Workload(WAYPOINT_POD_IP, None), WAYPOINT_POD_IP, SERVER_POD_IP, TARGET_PORT, Some((WAYPOINT_POD_IP, TARGET_PORT, None)); "to workload with waypoint referenced by pod")]
     #[test_case(Waypoint::Workload(WAYPOINT_SVC_IP, None), WAYPOINT_POD_IP, SERVER_POD_IP, TARGET_PORT, Some((WAYPOINT_POD_IP, TARGET_PORT, None)); "to workload with waypoint referenced by vip")]
-    #[test_case(Waypoint::Workload(WAYPOINT_SVC_IP, APP_TUNNEL_PROXY), WAYPOINT_POD_IP, SERVER_POD_IP, TARGET_PORT, Some((WAYPOINT_POD_IP, PROXY_PORT, None)); "to workload with app tunnel")]
+    #[test_case(Waypoint::Workload(WAYPOINT_SVC_IP, APP_TUNNEL_PROXY), WAYPOINT_POD_IP, SERVER_POD_IP, TARGET_PORT, Some((WAYPOINT_POD_IP, PROXY_PORT, Some(SERVER_POD_IP))); "to workload with app tunnel")]
     // to service traffic
     #[test_case(Waypoint::Service(WAYPOINT_POD_IP, None), WAYPOINT_POD_IP, SERVER_SVC_IP, TARGET_PORT, Some((WAYPOINT_POD_IP, TARGET_PORT, None)); "to service with waypoint referenced by pod")]
     #[test_case(Waypoint::Service(WAYPOINT_SVC_IP, None), WAYPOINT_POD_IP, SERVER_SVC_IP, TARGET_PORT, Some((WAYPOINT_POD_IP, TARGET_PORT, None)); "to service with waypint referenced by vip")]

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -561,7 +561,9 @@ impl Inbound {
                         // PROXY cannot currently send to hostnames, so we will need to select an IP to
                         // use instead
                         // We ensure a service is set above.
-                        let vip = services.first().expect("service must exist")
+                        let vip = services
+                            .first()
+                            .expect("service must exist")
                             .vips
                             .iter()
                             .max_by_key(|a| match a.network == conn.dst_network {

--- a/src/state.rs
+++ b/src/state.rs
@@ -262,9 +262,9 @@ impl ProxyState {
     /// Find services by hostname.
     pub fn find_service_by_hostname(&self, hostname: &Strng) -> Result<Vec<Arc<Service>>, Error> {
         // Hostnames for services are more common, so lookup service first and fallback to workload.
-        self.services.get_by_host(hostname).ok_or_else(|| {
-            Error::NoHostname(format!("service with hostname {} not found", hostname))
-        })
+        self.services
+            .get_by_host(hostname)
+            .ok_or_else(|| Error::NoHostname(hostname.to_string()))
     }
 
     fn find_upstream(


### PR DESCRIPTION
Some of the initial choses we made have not really held up over the
tweaks we have made over the year. Clean things up a bit. This should
have no meaningful user impact, mostly a refactoring.

* check_from_network_gateway is not right; it is assuming we get the
  identity from the EW GW; in the modern multi-network scheme that is
never true as its forwarded e2e from the client (double hbone). Instead,
change the heuristic to be "if hostname, it is multi-network".
* Instead of trying to create the PROXY protocol handling in the main
  forwarding logic, refactor it into find_inbound_upstream.
