### PR TITLE
[1.25] Add support for OpenSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "1f5aac023c3ba13725de1604aff621a9dbf9a4f3af1ea6fb712bca91ad729a8e"
 dependencies = [
  "bitflags 2.6.0",
  "boring-sys",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -286,7 +286,7 @@ dependencies = [
  "aead",
  "boring",
  "boring-sys",
- "foreign-types",
+ "foreign-types 0.5.0",
 ]
 
 [[package]]
@@ -299,7 +299,7 @@ dependencies = [
  "boring-additions",
  "boring-sys",
  "boring-sys-additions",
- "foreign-types",
+ "foreign-types 0.5.0",
  "lazy_static",
  "once_cell",
  "rustls",
@@ -875,12 +875,21 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -893,6 +902,12 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2016,6 +2031,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
+name = "openssl"
+version = "0.10.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2061,18 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -2152,6 +2194,12 @@ dependencies = [
  "thread_local",
  "tokio",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -2659,6 +2707,20 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-openssl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6baac2596417ed1ac329842cc9ab22d90fbbc3c59612ecd74d783b1df26523"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "rustls",
+ "rustls-webpki",
 ]
 
 [[package]]
@@ -3448,6 +3510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3943,6 +4011,7 @@ dependencies = [
  "nix 0.29.0",
  "oid-registry",
  "once_cell",
+ "openssl",
  "pin-project-lite",
  "pingora-pool",
  "ppp",
@@ -3958,6 +4027,7 @@ dependencies = [
  "rustc_version",
  "rustls",
  "rustls-native-certs",
+ "rustls-openssl",
  "rustls-pemfile",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ default = ["tls-ring"]
 jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
 tls-boring = ["dep:boring", "dep:boring-sys", "boring-rustls-provider/fips-only"]
 tls-ring = ["dep:ring", "rustls/ring", "tokio-rustls/ring", "hyper-rustls/ring", "dep:rcgen"]
+tls-openssl = ["dep:rustls-openssl", "dep:openssl" ]
 testing = ["dep:rcgen", "rcgen/x509-parser"] # Enables utilities supporting tests.
 
 [lib]
@@ -36,6 +37,10 @@ boring-sys = { version = "4", optional = true }
 
 # Enabled with 'tls-ring'
 ring = { version = "0.17", optional = true }
+
+# Enabled with 'tls-openssl'
+rustls-openssl = { version = "0.2", optional = true }
+openssl = { version = "0.10", optional = true }
 
 anyhow = "1.0"
 async-stream = "0.3"

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -3,6 +3,8 @@ include common/Makefile.common.mk
 FEATURES ?=
 ifeq ($(TLS_MODE), boring)
 	FEATURES:=--no-default-features -F tls-boring
+else ifeq ($(TLS_MODE), openssl)
+	FEATURES:=--no-default-features -F tls-openssl
 endif
 
 test:
@@ -21,6 +23,7 @@ inpodserver:
 # Test that all important features build
 check-features:
 	cargo check --no-default-features -F tls-boring
+	cargo check --no-default-features -F tls-openssl
 	cargo check -F jemalloc
 	(cd fuzz; RUSTFLAGS="--cfg fuzzing" cargo check)
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Ztunnel's TLS is built on [rustls](https://github.com/rustls/rustls).
 
 Rustls has support for plugging in various crypto providers to meet various needs (compliance, performance, etc).
 
-| Name                                          | How To Enable                                  |
-|-----------------------------------------------|------------------------------------------------|
-| [ring](https://github.com/briansmith/ring/)   | Default (or `--features tls-ring`)             |
-| [boring](https://github.com/cloudflare/boring) | `--features tls-boring --no-default-features` |
+| Name                                               | How To Enable                                  |
+|----------------------------------------------------|------------------------------------------------|
+| [ring](https://github.com/briansmith/ring/)        | Default (or `--features tls-ring`)             |
+| [boring](https://github.com/cloudflare/boring)     | `--features tls-boring --no-default-features`  |
+| [openssl](https://github.com/tofay/rustls-openssl) | `--features tls-openssl --no-default-features` |
 
 In all options, only TLS 1.3 with cipher suites `TLS13_AES_256_GCM_SHA384` and `TLS13_AES_128_GCM_SHA256` is used.
 

--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,7 @@ targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-unknown-linux-gnu" },
 ]
-features = ["tls-boring", "tls-ring"]
+features = ["tls-boring", "tls-ring", "tls-openssl" ]
 
 [advisories]
 version = 2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,6 +31,8 @@ if [[ "$TLS_MODE" == "boring" ]]; then
     sed -i 's/x86_64/arm64/g' .cargo/config.toml
   fi
   cargo build --release --no-default-features -F tls-boring
+elif [[ "$TLS_MODE" == "openssl" ]]; then
+  cargo build --release --no-default-features -F tls-openssl
 else
   cargo build --release
 fi

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -53,6 +53,10 @@ pub enum Error {
     #[cfg(feature = "tls-boring")]
     SslError(#[from] boring::error::ErrorStack),
 
+    #[error("invalid operation: {0:?}")]
+    #[cfg(feature = "tls-openssl")]
+    SslError(#[from] openssl::error::ErrorStack),
+
     #[error("invalid certificate generation: {0:?}")]
     #[cfg(feature = "tls-ring")]
     RcgenError(Arc<rcgen::Error>),

--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -66,6 +66,18 @@ pub(super) fn provider() -> Arc<CryptoProvider> {
     })
 }
 
+#[cfg(feature = "tls-openssl")]
+pub(super) fn provider() -> Arc<CryptoProvider> {
+    Arc::new(CryptoProvider {
+        // Limit to only the subset of ciphers that are FIPS compatible
+        cipher_suites: vec![
+            rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
+            rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        ],
+        ..rustls_openssl::default_provider()
+    })
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum TlsError {
     #[error("tls handshake error: {0:?}")]


### PR DESCRIPTION
Back port of #1436 

Add support for using OpenSSL as an alternative crypto provider, implemented using the [rustls-openssl](https://crates.io/crates/rustls-openssl) and [openssl](https://crates.io/crates/openssl) crates, and guarded by a new feature called `tls-openssl`.