### PR TITLE
display protocol in accesslog

### DIFF
--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -60,6 +60,15 @@ pub enum Protocol {
     HBONE,
 }
 
+impl std::fmt::Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TCP => write!(f, "TCP"),
+            Self::HBONE => write!(f, "HBONE"),
+        }
+    }
+}
+
 impl From<xds::istio::workload::TunnelProtocol> for Protocol {
     fn from(value: xds::istio::workload::TunnelProtocol) -> Self {
         match value {


### PR DESCRIPTION
display src/dst protocol in accesslog, which help understand the connection better.

```console
2025-04-01T14:01:02.476412Z	info	access	connection complete	src.addr=10.244.3.9:52462 src.workload="simple-http-waypoint-547d6d7b8b-4xckr" src.protocol=TCP src.namespace="default" src.identity="spiffe://cluster.local/ns/default/sa/simple-http-waypoint" dst.addr=10.244.3.8:15008 dst.hbone_addr=10.244.3.8:8080 dst.service="httpbin.default.svc.cluster.local" dst.workload="httpbin-54845dfb75-4tsvd" dst.protocol=HBONE dst.namespace="default" dst.identity="spiffe://cluster.local/ns/default/sa/httpbin" direction="inbound" bytes_sent=564 bytes_recv=156 duration="5013ms"
```