### PR TITLE
PROXY Protocol: send to localhost

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,8 @@ const CERT_SYSTEM: &str = "SYSTEM";
 const PROXY_MODE_DEDICATED: &str = "dedicated";
 const PROXY_MODE_SHARED: &str = "shared";
 
+const LOCALHOST_APP_TUNNEL: &str = "LOCALHOST_APP_TUNNEL";
+
 #[derive(serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum RootCert {
     File(PathBuf),
@@ -288,6 +290,9 @@ pub struct Config {
 
     // Headers to be added to certificate requests
     pub ca_headers: MetadataVector,
+
+    // If true, when AppTunnel is set for
+    pub localhost_app_tunnel: bool,
 }
 
 #[derive(serde::Serialize, Clone, Copy, Debug)]
@@ -746,6 +751,8 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         fake_self_inbound: false,
         xds_headers: parse_headers(ISTIO_XDS_HEADER_PREFIX)?,
         ca_headers: parse_headers(ISTIO_CA_HEADER_PREFIX)?,
+
+        localhost_app_tunnel: parse_default(LOCALHOST_APP_TUNNEL, false)?,
     })
 }
 

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -155,6 +155,15 @@ pub mod application_tunnel {
         PROXY,
     }
 
+    impl Protocol {
+        pub fn supports_localhost_send(&self) -> bool {
+            match self {
+                Protocol::NONE => false,
+                Protocol::PROXY => true,
+            }
+        }
+    }
+
     impl From<XdsProtocol> for Protocol {
         fn from(value: XdsProtocol) -> Self {
             match value {

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -163,6 +163,7 @@ impl WorkloadManager {
             } else {
                 Some(true)
             },
+            localhost_app_tunnel: true,
             ..config::parse_config().unwrap()
         };
         let (tx, rx) = std::sync::mpsc::sync_channel(0);


### PR DESCRIPTION
For "sandwich" it's probably desirable to have the sandwiched proxy bind listeners to localhost to prevent things other than the zTunnel from reaching it. 

This PR make it so that any inbound request that would use PROXY will send to localhost. There is an env var to turn this behavior on; long term it should be on by default, forcing sandwich implementations to follow this pattern. 

* In this mode we also bind the `src` address coming from zTunnel to be localhost
* I'm currently guessing between `::1` and `127.0.0.1` based on the IP family of the actual destination address. Maybe this can be the `::ffff:127.0.0.1` or the guess should be based on the ip family of `orig_src`? 
* Currently I don't see the need for a per-proxy/workload setting here but we can revisit that in the future.  

I've tested this alongside an envoy bound like

```
      "listener": {
       "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
       "name": "proxy_protocol_inbound",
       "address": {
        "socket_address": {
         "address": "::ffff:127.0.0.1",
         "port_value": 15088,
         "ipv4_compat": true
        }
       },
```