### PR TITLE
send PROXY to localhost by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -752,7 +752,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         xds_headers: parse_headers(ISTIO_XDS_HEADER_PREFIX)?,
         ca_headers: parse_headers(ISTIO_CA_HEADER_PREFIX)?,
 
-        localhost_app_tunnel: parse_default(LOCALHOST_APP_TUNNEL, false)?,
+        localhost_app_tunnel: parse_default(LOCALHOST_APP_TUNNEL, true)?,
     })
 }
 


### PR DESCRIPTION
fast follow for #1501 tested against a waypoint _not_ listening on localhost

waypoints would need the env var to only listen on localhost for newer ztunnels