### PR TITLE
Fix markdown link formatting for aws-lc

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Rustls has support for plugging in various crypto providers to meet various need
 
 | Name                                               | How To Enable                                  |
 |----------------------------------------------------|------------------------------------------------|
-| [aws-lc]https://github.com/aws/aws-lc-rs)          | Default (or `--features tls-aws-lc`)           |
+| [aws-lc](https://github.com/aws/aws-lc-rs)         | Default (or `--features tls-aws-lc`)           |
 | [ring](https://github.com/briansmith/ring/)        | `--features tls-ring --no-default-features`    |
 | [boring](https://github.com/cloudflare/boring)     | `--features tls-boring --no-default-features`  |
 | [openssl](https://github.com/tofay/rustls-openssl) | `--features tls-openssl --no-default-features` |


### PR DESCRIPTION
This PR fixes a small typo in the markdown formatting of the aws-lc link in the dependencies table.

The current format :
```md
[aws-lc]https://github.com/aws/aws-lc-rs
```
is rendered incorrectly. It should be :
```md
[aws-lc](https://github.com/aws/aws-lc-rs)
```

I noticed this small issue while attending the Istio contributor workshop at **KubeCon EU 2025 Contribfest** and thought it would be a good opportunity to submit my first PR to the project 😊