### PR TITLE
tls: improve failed connection handshake log

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -79,7 +79,7 @@ fn main() -> Result<(), anyhow::Error> {
             for line in String::from_utf8(output.stdout).unwrap().lines() {
                 // Each line looks like `istio.io/pkg/version.buildGitRevision=abc`
                 if let Some((key, value)) = line.split_once('=') {
-                    let key = key.split('.').last().unwrap();
+                    let key = key.split('.').next_back().unwrap();
                     println!("cargo:rustc-env=ZTUNNEL_BUILD_{key}={value}");
                 } else {
                     println!("cargo:warning=invalid build output {line}");

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -86,7 +86,6 @@ impl Inbound {
 
         // Safety: we set nodelay directly in tls_server, so it is safe to convert to a normal listener.
         // Although, that is *after* the TLS handshake; in theory we may get some benefits to setting it earlier.
-        // let mut stream = crate::hyper_util::tls_server(acceptor, self.listener.inner());
 
         let accept = async move |drain: DrainWatcher, force_shutdown: watch::Receiver<()>| {
             loop {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::stream::StreamExt;
 use futures_util::TryFutureExt;
 use http::{Method, Response, StatusCode};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Instant;
+use tls_listener::AsyncTls;
 use tokio::sync::watch;
 
-use tracing::{Instrument, debug, info, info_span, trace_span};
+use tracing::{Instrument, debug, error, info, info_span, trace_span};
 
-use super::{ConnectionResult, Error, HboneAddress, LocalWorkloadInformation, ResponseFlags};
+use super::{ConnectionResult, Error, HboneAddress, LocalWorkloadInformation, ResponseFlags, util};
 use crate::baggage::parse_baggage_header;
 use crate::identity::Identity;
 
@@ -86,19 +86,40 @@ impl Inbound {
 
         // Safety: we set nodelay directly in tls_server, so it is safe to convert to a normal listener.
         // Although, that is *after* the TLS handshake; in theory we may get some benefits to setting it earlier.
-        let mut stream = crate::hyper_util::tls_server(acceptor, self.listener.inner());
+        // let mut stream = crate::hyper_util::tls_server(acceptor, self.listener.inner());
 
         let accept = async move |drain: DrainWatcher, force_shutdown: watch::Receiver<()>| {
-            while let Some(tls) = stream.next().await {
-                let pi = self.pi.clone();
-                let (raw_socket, ssl) = tls.get_ref();
-                let src_identity: Option<Identity> = tls::identity_from_connection(ssl);
-                let dst = to_canonical(raw_socket.local_addr().expect("local_addr available"));
-                let src = to_canonical(raw_socket.peer_addr().expect("peer_addr available"));
+            loop {
+                let (raw_socket, src) = match self.listener.accept().await {
+                    Ok(raw_socket) => raw_socket,
+                    Err(e) => {
+                        if util::is_runtime_shutdown(&e) {
+                            return;
+                        }
+                        error!("Failed TCP handshake {}", e);
+                        continue;
+                    }
+                };
+                let src = to_canonical(src);
+                let start = Instant::now();
                 let drain = drain.clone();
                 let force_shutdown = force_shutdown.clone();
+                let pi = self.pi.clone();
+                let dst = to_canonical(raw_socket.local_addr().expect("local_addr available"));
                 let network = pi.cfg.network.clone();
+                let acceptor = crate::tls::InboundAcceptor::new(acceptor.clone());
                 let serve_client = async move {
+                    let tls = match acceptor.accept(raw_socket).await {
+                        Ok(tls) => tls,
+                        Err(e) => {
+                            metrics::log_early_deny(src, dst, Reporter::destination, e);
+
+                            return Err::<(), _>(proxy::Error::SelfCall);
+                        }
+                    };
+                    debug!(latency=?start.elapsed(), "accepted TLS connection");
+                    let (_, ssl) = tls.get_ref();
+                    let src_identity: Option<Identity> = tls::identity_from_connection(ssl);
                     let conn = Connection {
                         src_identity,
                         src,


### PR DESCRIPTION
```
2025-04-13T01:20:27.118891Z     warn    hyper_util      TLS handshake error: tls handshake error: Custom { kind: InvalidData, error: NoCertificatesPresented }
```

before ^

after v
```
2025-04-13T01:33:51.805055Z     warn    access  connection failed       src.addr=[::1]:36332 dst.addr=[::1]:15008 direction="inbound" error="tls handshake error: Custom { kind: InvalidData, error: NoCertificatesPresented }"
```
