### PR TITLE
show crypto provider in ztunnel version

### DIFF
--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -40,6 +40,15 @@ pub trait ServerCertProvider: Send + Sync + Clone {
 
 pub(super) static TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
 
+#[cfg(feature = "tls-aws-lc")]
+pub static CRYPTO_PROVIDER: &str = "tls-aws-lc";
+#[cfg(feature = "tls-ring")]
+pub static CRYPTO_PROVIDER: &str = "tls-ring";
+#[cfg(feature = "tls-boring")]
+pub static CRYPTO_PROVIDER: &str = "tls-boring";
+#[cfg(feature = "tls-openssl")]
+pub static CRYPTO_PROVIDER: &str = "tls-openssl";
+
 // Ztunnel use `rustls` with pluggable crypto modules.
 // All crypto MUST be done via the below providers.
 //

--- a/src/version.rs
+++ b/src/version.rs
@@ -34,10 +34,16 @@ pub struct BuildInfo {
     build_status: String,
     git_tag: String,
     pub istio_version: String,
+    crypto_provider: String,
 }
 
 impl BuildInfo {
     pub fn new() -> Self {
+        #[cfg(feature = "tls-ring")]
+        let crypto_provider = "tls-ring".to_string();
+        #[cfg(feature = "tls-boring")]
+        let crypto_provider = "tls-boring".to_string();
+
         BuildInfo {
             version: BUILD_VERSION.to_string(),
             git_revision: BUILD_GIT_REVISION.to_string(),
@@ -47,6 +53,7 @@ impl BuildInfo {
             git_tag: BUILD_TAG.to_string(),
             istio_version: env::var("ISTIO_META_ISTIO_VERSION")
                 .unwrap_or_else(|_| "unknown".to_string()),
+            crypto_provider,
         }
     }
 }
@@ -55,14 +62,15 @@ impl Display for BuildInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "version.BuildInfo{{Version:\"{}\", GitRevision:\"{}\", RustVersion:\"{}\", BuildProfile:\"{}\", BuildStatus:\"{}\", GitTag:\"{}\", IstioVersion:\"{}\"}}",
+            "version.BuildInfo{{Version:\"{}\", GitRevision:\"{}\", RustVersion:\"{}\", BuildProfile:\"{}\", BuildStatus:\"{}\", GitTag:\"{}\", IstioVersion:\"{}\", CryptoProvider:\"{}\"}}",
             self.version,
             self.git_revision,
             self.rust_version,
             self.build_profile,
             self.build_status,
             self.git_tag,
-            self.istio_version
+            self.istio_version,
+            self.crypto_provider,
         )
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -39,10 +39,14 @@ pub struct BuildInfo {
 
 impl BuildInfo {
     pub fn new() -> Self {
+        #[cfg(feature = "tls-aws-lc")]
+        let crypto_provider = "tls-aws-lc".to_string();
         #[cfg(feature = "tls-ring")]
         let crypto_provider = "tls-ring".to_string();
         #[cfg(feature = "tls-boring")]
         let crypto_provider = "tls-boring".to_string();
+        #[cfg(feature = "tls-openssl")]
+        let crypto_provider = "tls-openssl".to_string();
 
         BuildInfo {
             version: BUILD_VERSION.to_string(),

--- a/src/version.rs
+++ b/src/version.rs
@@ -17,6 +17,8 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::string::String;
 
+use crate::tls::CRYPTO_PROVIDER;
+
 const BUILD_VERSION: &str = env!("ZTUNNEL_BUILD_buildVersion");
 const BUILD_GIT_REVISION: &str = env!("ZTUNNEL_BUILD_buildGitRevision");
 const BUILD_STATUS: &str = env!("ZTUNNEL_BUILD_buildStatus");
@@ -39,15 +41,6 @@ pub struct BuildInfo {
 
 impl BuildInfo {
     pub fn new() -> Self {
-        #[cfg(feature = "tls-aws-lc")]
-        let crypto_provider = "tls-aws-lc".to_string();
-        #[cfg(feature = "tls-ring")]
-        let crypto_provider = "tls-ring".to_string();
-        #[cfg(feature = "tls-boring")]
-        let crypto_provider = "tls-boring".to_string();
-        #[cfg(feature = "tls-openssl")]
-        let crypto_provider = "tls-openssl".to_string();
-
         BuildInfo {
             version: BUILD_VERSION.to_string(),
             git_revision: BUILD_GIT_REVISION.to_string(),
@@ -57,7 +50,7 @@ impl BuildInfo {
             git_tag: BUILD_TAG.to_string(),
             istio_version: env::var("ISTIO_META_ISTIO_VERSION")
                 .unwrap_or_else(|_| "unknown".to_string()),
-            crypto_provider,
+            crypto_provider: CRYPTO_PROVIDER.to_string(),
         }
     }
 }


### PR DESCRIPTION
It would be nice if ztunnel showed the crypto provider in version.

Envoy does a similar thing, where the output looks like

```
envoy  version: 739644f84930a8c0d416319aea97f58c2222f7ef/1.32.2-dev/Modified/RELEASE/BoringSSL
```

or


```
envoy  version: 739644f84930a8c0d416319aea97f58c2222f7ef/1.32.2-dev/Modified/RELEASE/BoringSSL-FIPS
```