### PR TITLE
backport-1.26 - Make csr test stricter and more correct (previously #1432) (#1550)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,27 +114,11 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
- "asn1-rs-derive 0.6.0",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -142,18 +126,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.12",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "synstructure",
 ]
 
 [[package]]
@@ -763,25 +735,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs 0.6.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1844,7 +1802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2228,20 +2186,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs 0.6.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2815,16 +2764,16 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "887a643fa081058097896d87764863994f6c32a1716e76adc479bd283974a825"
 dependencies = [
  "aws-lc-rs",
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser 0.16.0",
+ "x509-parser",
  "yasna",
 ]
 
@@ -4307,34 +4256,16 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs 0.6.2",
- "data-encoding",
- "der-parser 9.0.0",
- "lazy_static",
- "nom",
- "oid-registry 0.7.1",
- "ring",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "data-encoding",
- "der-parser 10.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.8.1",
+ "oid-registry",
  "ring",
  "rusticata-macros",
  "thiserror 2.0.12",
@@ -4510,7 +4441,7 @@ dependencies = [
  "matches",
  "netns-rs",
  "nix 0.29.0",
- "oid-registry 0.8.1",
+ "oid-registry",
  "once_cell",
  "openssl",
  "pin-project-lite",
@@ -4553,6 +4484,6 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "url",
- "x509-parser 0.17.0",
+ "x509-parser",
  "ztunnel",
 ]

--- a/src/tls/csr.rs
+++ b/src/tls/csr.rs
@@ -124,28 +124,44 @@ impl CsrOptions {
 #[cfg(test)]
 mod tests {
     use crate::tls;
+    use itertools::Itertools;
 
     #[test]
     fn test_csr() {
-        use x509_parser::prelude::FromDer;
+        use x509_parser::prelude::*;
         let csr = tls::csr::CsrOptions {
             san: "spiffe://td/ns/ns1/sa/sa1".to_string(),
         }
         .generate()
         .unwrap();
+
         let (_, der) = x509_parser::pem::parse_x509_pem(csr.csr.as_bytes()).unwrap();
 
         let (_, cert) =
             x509_parser::certification_request::X509CertificationRequest::from_der(&der.contents)
                 .unwrap();
         cert.verify_signature().unwrap();
+        let subject = cert.certification_request_info.subject.iter().collect_vec();
+        assert_eq!(subject.len(), 0);
         let attr = cert
             .certification_request_info
             .iter_attributes()
             .next()
             .unwrap();
-        // SAN is encoded in some format I don't understand how to parse; this could be improved.
-        // but make sure it's there in a hacky manner
-        assert!(attr.value.ends_with(b"spiffe://td/ns/ns1/sa/sa1"));
+
+        let ParsedCriAttribute::ExtensionRequest(parsed) = attr.parsed_attribute() else {
+            panic!("not a ExtensionRequest")
+        };
+        let ext = parsed.clone().extensions;
+        assert_eq!(ext.len(), 1);
+        let ext = ext.into_iter().next().unwrap();
+        assert!(ext.critical);
+        let ParsedExtension::SubjectAlternativeName(san) = ext.parsed_extension() else {
+            panic!("not a SubjectAlternativeName")
+        };
+        assert_eq!(
+            &format!("{san:?}"),
+            "SubjectAlternativeName { general_names: [URI(\"spiffe://td/ns/ns1/sa/sa1\")] }"
+        )
     }
 }


### PR DESCRIPTION
* Make csr test stricter and more correct

Part of https://github.com/istio/ztunnel/issues/1431

Fails without https://github.com/rustls/rcgen/pull/311

* update rcgen



* fix merge issue

* format fix



---------