### PR TITLE
remove git tag

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -22,7 +22,6 @@ use crate::tls::CRYPTO_PROVIDER;
 const BUILD_VERSION: &str = env!("ZTUNNEL_BUILD_buildVersion");
 const BUILD_GIT_REVISION: &str = env!("ZTUNNEL_BUILD_buildGitRevision");
 const BUILD_STATUS: &str = env!("ZTUNNEL_BUILD_buildStatus");
-const BUILD_TAG: &str = env!("ZTUNNEL_BUILD_buildTag");
 const BUILD_RUST_VERSION: &str = env!("ZTUNNEL_BUILD_RUSTC_VERSION");
 const BUILD_RUST_PROFILE: &str = env!("ZTUNNEL_BUILD_PROFILE_NAME");
 
@@ -34,7 +33,6 @@ pub struct BuildInfo {
     rust_version: String,
     build_profile: String,
     build_status: String,
-    git_tag: String,
     pub istio_version: String,
     crypto_provider: String,
 }
@@ -47,7 +45,6 @@ impl BuildInfo {
             rust_version: BUILD_RUST_VERSION.to_string(),
             build_profile: BUILD_RUST_PROFILE.to_string(),
             build_status: BUILD_STATUS.to_string(),
-            git_tag: BUILD_TAG.to_string(),
             istio_version: env::var("ISTIO_META_ISTIO_VERSION")
                 .unwrap_or_else(|_| "unknown".to_string()),
             crypto_provider: CRYPTO_PROVIDER.to_string(),
@@ -59,13 +56,12 @@ impl Display for BuildInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "version.BuildInfo{{Version:\"{}\", GitRevision:\"{}\", RustVersion:\"{}\", BuildProfile:\"{}\", BuildStatus:\"{}\", GitTag:\"{}\", IstioVersion:\"{}\", CryptoProvider:\"{}\"}}",
+            "version.BuildInfo{{Version:\"{}\", GitRevision:\"{}\", RustVersion:\"{}\", BuildProfile:\"{}\", BuildStatus:\"{}\", IstioVersion:\"{}\", CryptoProvider:\"{}\"}}",
             self.version,
             self.git_revision,
             self.rust_version,
             self.build_profile,
             self.build_status,
-            self.git_tag,
             self.istio_version,
             self.crypto_provider,
         )


### PR DESCRIPTION
fixes: https://github.com/istio/ztunnel/issues/1548

As mentioned in https://github.com/istio/ztunnel/issues/1548, would be better to remove it, reduce misunderstanding.

Sample output on `1.25.3`:
```console
2025-05-21T02:10:52.141911Z	info	ztunnel	version: version.BuildInfo{Version:"0f1f8c1ab27dbb5810654c6cf14e7d51f931ba8f", GitRevision:"0f1f8c1ab27dbb5810654c6cf14e7d51f931ba8f", RustVersion:"1.84.0", BuildProfile:"release", BuildStatus:"Clean", GitTag:"1.25.2-3-g0f1f8c1", IstioVersion:"1.25.3"}
```