### PR TITLE
retain valid certs on fetch failures

### DIFF
--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -226,13 +226,13 @@ pub mod mock {
             let not_after = not_before + self.cfg.cert_lifetime;
 
             let mut state = self.state.write().await;
+            state.fetches.push(id.to_owned());
             if state.error {
                 return Err(Error::Spiffe("injected test error".into()));
             }
             let certs = state
                 .cert_gen
                 .new_certs(&id.to_owned().into(), not_before, not_after);
-            state.fetches.push(id.to_owned());
             Ok(certs)
         }
 


### PR DESCRIPTION
Retain existing valid certificates when new fetch attempts fail, improving service reliability during CA outages. Implements backoff scheduling that respects certificate expiry times.
This PR addresses istio [issue#56452](https://github.com/istio/istio/issues/56452)