### PR TITLE
remove invalid test cases from parsing of ZTUNNEL_WORKER_THREADS

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1175,14 +1175,6 @@ pub mod tests {
             env::remove_var(ZTUNNEL_WORKER_THREADS);
             assert_eq!(parse_worker_threads(2).unwrap(), 2);
 
-            // Test invalid percentage
-            env::set_var(ZTUNNEL_WORKER_THREADS, "150%");
-            assert!(parse_worker_threads(2).is_err());
-
-            // Test invalid number
-            env::set_var(ZTUNNEL_WORKER_THREADS, "invalid");
-            assert!(parse_worker_threads(2).is_err());
-
             // Test without CPU limit (should use system CPU count)
             env::remove_var(ZTUNNEL_CPU_LIMIT);
             let system_cpus = num_cpus::get();


### PR DESCRIPTION
Rust tests will run in parallel which can lead to bad interactions with anything making assertions about global state (like env vars). We have other tests which are unwrapping config, meaning it should never be an Error, that can flake if they happen to run while these two test cases are set.

- `env::set_var(ZTUNNEL_WORKER_THREADS, "150%");`
- `env::set_var(ZTUNNEL_WORKER_THREADS, "invalid");`

https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_ztunnel/1572/test_ztunnel/1931621324791222272

For now, we could just eliminate testing as done here.

Alternatively we could add a retry mechanism to tests other tests which deal with config or rework all tests to use some sort of env var isolation crate. (https://crates.io/search?q=env-lock)