### PR TITLE
build: support compilation on Windows using MSVC

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,12 @@ target-dir = "out/rust"
 [env]
 BORING_BSSL_FIPS_PATH = { value = "vendor/boringssl-fips/linux_x86_64", force = true, relative = true }
 BORING_BSSL_FIPS_INCLUDE_PATH = { value = "vendor/boringssl-fips/include/", force = true, relative = true }
+
+# When targeting MSVC, link statically to MSVCRT in order to create a portable binary.
+#
+# Otherwise, to be able to use ztunnel binary on Windows a user would need to explicitly install
+# C Runtime (CRT) libraries as part of the "Microsoft Visual C++ Redistributable".
+#
+# See https://github.com/rust-lang/rfcs/blob/master/text/1721-crt-static.md
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/build.rs
+++ b/build.rs
@@ -74,7 +74,9 @@ fn main() -> Result<(), anyhow::Error> {
         .nth_back(3)
         .unwrap();
 
-    match Command::new("common/scripts/report_build_info.sh").output() {
+    // When building on Windows, e.g. in Git Bash or in MinGW's MSYS environment,
+    // we have to explicitly specify "bash" as a program.
+    match Command::new("bash").arg("common/scripts/report_build_info.sh").output() {
         Ok(output) => {
             for line in String::from_utf8(output.stdout).unwrap().lines() {
                 // Each line looks like `istio.io/pkg/version.buildGitRevision=abc`

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 
 extern crate core;
 
+#[cfg(unix)]
 use nix::sys::resource::{Resource, getrlimit, setrlimit};
 use std::sync::Arc;
 use tracing::{info, warn};

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -113,13 +113,15 @@ impl DefaultSocketFactory {
         if cfg.keepalive_enabled {
             let ka = TcpKeepalive::new()
                 .with_time(cfg.keepalive_time)
-                .with_retries(cfg.keepalive_retries)
                 .with_interval(cfg.keepalive_interval);
+            #[cfg(unix)]
+            let ka = ka.with_retries(cfg.keepalive_retries);
             tracing::trace!(
                 "set keepalive: {:?}",
                 socket2::SockRef::from(&s).set_tcp_keepalive(&ka)
             );
         }
+        #[cfg(target_os = "linux")]
         if cfg.user_timeout_enabled {
             // https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/
             // TCP_USER_TIMEOUT = TCP_KEEPIDLE + TCP_KEEPINTVL * TCP_KEEPCNT.


### PR DESCRIPTION
## Summary

* add support for `ztunnel` compilation on Windows using MSVC
* fix compilation errors in main sources
* statically link `ztunnel.exe`