### PR TITLE
respect IPV6 setting for DNS server

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -309,6 +309,8 @@ pub struct Config {
     pub ztunnel_identity: Option<identity::Identity>,
 
     pub ztunnel_workload: Option<state::WorkloadInfo>,
+
+    pub ipv6_enabled: bool,
 }
 
 #[derive(serde::Serialize, Clone, Copy, Debug)]
@@ -862,6 +864,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         localhost_app_tunnel: parse_default(LOCALHOST_APP_TUNNEL, true)?,
         ztunnel_identity,
         ztunnel_workload,
+        ipv6_enabled,
     })
 }
 

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -113,6 +113,7 @@ impl ProxyFactory {
                 socket_factory.as_ref(),
                 local_workload_information.as_fetcher(),
                 self.config.prefered_service_namespace.clone(),
+                self.config.ipv6_enabled,
             )
             .await?;
             resolver = Some(server.resolver());

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -299,6 +299,7 @@ pub async fn run_dns(responses: HashMap<Name, Vec<IpAddr>>) -> anyhow::Result<Te
             state.clone(),
         ),
         Some("prefered-namespace".to_string()),
+        true, // ipv6_enabled for tests
     )
     .await?;
 


### PR DESCRIPTION
Currently the IPV6_ENABLED flag only affects zTunnel -> upstream DNS instead of making it so we don't include IPv6 addresses in our internal DNS server's responses. This patch respects that flag in our DNS server.