### PR TITLE
Retrying compartmentless containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,7 +1815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3794,11 +3794,13 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.2",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4519,6 +4521,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "url",
+ "uuid",
  "windows",
  "x509-parser",
  "ztunnel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ tracing-core = "0.1"
 tracing-appender = "0.2"
 tokio-util = { version = "0.7", features = ["io-util"] }
 educe = "0.6"
+uuid = "1.17.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -436,7 +436,7 @@ async fn handle_jemalloc_pprof_heapgen(
         .expect("builder with known status code should not fail"))
 }
 
-#[cfg(not(feature = "jemalloc"))]
+#[cfg(all(target_os = "linux", not(feature = "jemalloc")))]
 async fn handle_jemalloc_pprof_heapgen(
     _req: Request<Incoming>,
 ) -> anyhow::Result<Response<Full<Bytes>>> {

--- a/src/inpod.rs
+++ b/src/inpod.rs
@@ -24,6 +24,8 @@ pub enum Error {
     ProtocolError(String),
     #[error("announce error: {0}")]
     AnnounceError(String),
+    #[error("namespace error: {0}")]
+    NamespaceError(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]

--- a/src/inpod/windows.rs
+++ b/src/inpod/windows.rs
@@ -34,8 +34,7 @@ mod workloadmanager;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;
 
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WorkloadData {
     workload_uid: WorkloadUid,
     workload_info: Option<WorkloadInfo>,

--- a/src/inpod/windows/namespace.rs
+++ b/src/inpod/windows/namespace.rs
@@ -1,27 +1,19 @@
-use std::sync::Arc;
 use tracing::warn;
 use windows::Win32::NetworkManagement::IpHelper::{
     GetCurrentThreadCompartmentId, SetCurrentThreadCompartmentId,
 };
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
-pub struct Namespace {
-    pub id: u32,
-    pub guid: String,
+pub struct NetworkNamespace {
+    // On Windows every network namespace is based
+    // on a network compartment ID. This is the reference
+    // we need when we want to create sockets inside
+    // a network namespace or change IP stack configuration.
+    pub compartment_id: u32,
+    pub namespace_guid: String,
 }
 
-#[derive(Clone, Debug)]
-pub struct InpodNamespace {
-    inner: Arc<NetnsInner>,
-}
-
-#[derive(Debug, Eq, PartialEq)]
-struct NetnsInner {
-    current_namespace: u32,
-    workload_namespace: Namespace,
-}
-
-impl InpodNamespace {
+impl NetworkNamespace {
     pub fn current() -> std::io::Result<u32> {
         let curr_namespace = unsafe { GetCurrentThreadCompartmentId() };
         if curr_namespace.0 == 0 {
@@ -32,56 +24,50 @@ impl InpodNamespace {
     }
 
     pub fn capable() -> std::io::Result<()> {
-        // set the netns to our current netns. This is intended to be a no-op,
-        // and meant to be used as a test, so we can fail early if we can't set the netns
-        let curr_namespace = Self::current()?;
-        setns(curr_namespace)
+        // Set the network compartment to the host compartment. This is intended to be a no-op,
+        // and meant to be used as a test, so we can fail early if we can't set the netns.
+        set_compartment(1)
     }
 
-    pub fn new(cur_namespace: u32, workload_namespace: String) -> std::io::Result<Self> {
+    pub fn new(workload_namespace: String) -> std::io::Result<Self> {
         let ns = hcn::get_namespace(&workload_namespace);
         match ns {
             Err(e) => {
                 warn!("Failed to get namespace: {}", e);
                 Err(std::io::Error::last_os_error())
             }
-            Ok(ns) => Ok(InpodNamespace {
-                inner: Arc::new(NetnsInner {
-                    current_namespace: cur_namespace,
-                    workload_namespace: Namespace {
-                        id: ns
-                            .namespace_id
-                            .expect("There must always be a namespace id"),
-                        guid: ns.id,
-                    },
-                }),
+            Ok(ns) => Ok(NetworkNamespace {
+                compartment_id: ns
+                    .namespace_id
+                    // Compartment ID 0 means undefined compartment ID.
+                    // At the moment the JSON serialization ommits the field
+                    // if it is set to 0. This happens when the compartment
+                    // for the container is not yet available.
+                    .unwrap_or(0),
+                namespace_guid: ns.id,
             }),
         }
-    }
-
-    pub fn workload_namespace(&self) -> u32 {
-        self.inner.workload_namespace.id
-    }
-
-    // Useful for logging / debugging
-    pub fn workload_namespace_guid(&self) -> String {
-        self.inner.workload_namespace.guid.clone()
     }
 
     pub fn run<F, T>(&self, f: F) -> std::io::Result<T>
     where
         F: FnOnce() -> T,
     {
-        setns(self.inner.workload_namespace.id)?;
+        set_compartment(self.compartment_id)?;
         let ret = f();
-        setns(self.inner.current_namespace).expect("this must never fail");
+        // The Windows API defines the network compartment ID 1 as the
+        // comapartment backing up the host network namespace.
+        set_compartment(1).expect("failed to switch to host namespace");
         Ok(ret)
     }
 }
 
-// hop into a namespace
-fn setns(namespace: u32) -> std::io::Result<()> {
-    let error = unsafe { SetCurrentThreadCompartmentId(namespace) };
+// Hop into a network compartment
+fn set_compartment(compartment_id: u32) -> std::io::Result<()> {
+    if compartment_id == 0 {
+        return Err(std::io::Error::other("undefined compartment ID"));
+    }
+    let error = unsafe { SetCurrentThreadCompartmentId(compartment_id) };
     if error.0 != 0 {
         return Err(std::io::Error::from_raw_os_error(error.0 as i32));
     }
@@ -90,8 +76,8 @@ fn setns(namespace: u32) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use hcn::schema::HostComputeQuery;
     use hcn::api;
+    use hcn::schema::HostComputeQuery;
     use windows::core::GUID;
 
     use super::*;

--- a/src/inpod/windows/namespace.rs
+++ b/src/inpod/windows/namespace.rs
@@ -82,7 +82,7 @@ mod tests {
 
     use super::*;
 
-    fn new_namespace() -> Namespace {
+    fn new_namespace() -> NetworkNamespace {
         let api_namespace = hcn::schema::HostComputeNamespace::default();
 
         let api_namespace = serde_json::to_string(&api_namespace).unwrap();
@@ -97,9 +97,9 @@ mod tests {
         let api_namespace: hcn::schema::HostComputeNamespace =
             serde_json::from_str(&api_namespace).unwrap();
 
-        Namespace {
-            id: api_namespace.namespace_id.unwrap(),
-            guid: api_namespace.id,
+        NetworkNamespace {
+            compartment_id: api_namespace.namespace_id.unwrap(),
+            namespace_guid: api_namespace.id,
         }
     }
 

--- a/src/inpod/windows/protocol.rs
+++ b/src/inpod/windows/protocol.rs
@@ -1,13 +1,12 @@
 use crate::drain::DrainWatcher;
-use crate::inpod::windows::{WorkloadData, WorkloadMessage, WorkloadUid};
 use crate::inpod::istio::zds::{
-    self, workload_request::Payload, Ack, Version, WorkloadRequest, WorkloadResponse, ZdsHello,
+    self, Ack, Version, WorkloadRequest, WorkloadResponse, ZdsHello, workload_request::Payload,
 };
+use crate::inpod::windows::{WorkloadData, WorkloadMessage, WorkloadUid};
 use prost::Message;
-use tracing::info;
 use std::io::{IoSlice, IoSliceMut};
 use tokio::net::windows::named_pipe::*;
-
+use tracing::info;
 
 pub struct WorkloadStreamProcessor {
     client: NamedPipeClient,

--- a/src/inpod/windows/workloadmanager.rs
+++ b/src/inpod/windows/workloadmanager.rs
@@ -13,22 +13,27 @@
 // limitations under the License.
 
 use crate::drain::DrainWatcher;
+use crate::inpod::windows::{WorkloadData, WorkloadMessage, statemanager};
 use crate::readiness;
-use backoff::{backoff::Backoff, ExponentialBackoff};
+use backoff::{ExponentialBackoff, backoff::Backoff};
+use std::ops::Mul;
 use std::path::PathBuf;
 use std::time::Duration;
-use tokio::time::sleep;
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 use super::statemanager::WorkloadProxyManagerState;
 use crate::inpod::Error;
 
-use crate::inpod::windows::namespace::InpodNamespace;
+use crate::inpod::windows::namespace::NetworkNamespace;
 
 use super::protocol::WorkloadStreamProcessor;
 
 const RETRY_DURATION: Duration = Duration::from_secs(5);
+
+// This is a delay used by pods that don't have a network compartment yet.
+const COMPARTMENTLESS_DELAY: Duration = Duration::from_millis(500);
 
 const CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL: Duration = Duration::from_secs(15);
 
@@ -51,11 +56,26 @@ pub struct WorkloadProxyManager {
     readiness: WorkloadProxyReadinessHandler,
 }
 
+enum EventType {
+    RetryAllPendingWorkloads,
+    RetryWorkload(Duration, WorkloadData),
+}
+
+// As opposed to messages incoming from external sources,
+// these are internal events that are triggered internally
+// from the WorkloadManager itself.
+struct InternalEvent {
+    expiration: tokio::time::Instant,
+    event_type: EventType,
+}
+
 struct WorkloadProxyManagerProcessor<'a> {
     state: &'a mut super::statemanager::WorkloadProxyManagerState,
     readiness: &'a mut WorkloadProxyReadinessHandler,
 
     next_pending_retry: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
+    next_event_timer: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
+    event_queue: Vec<InternalEvent>,
 }
 
 impl WorkloadProxyReadinessHandler {
@@ -106,33 +126,6 @@ impl WorkloadProxyNetworkHandler {
         Ok(Self { uds })
     }
 
-    // OLD CODE USING UNIX STREAM
-    // async fn connect(&self) -> UnixStream {
-    //     let mut backoff = Duration::from_millis(10);
-
-    //     debug!("connecting to server: {:?}", self.uds);
-
-    //     loop {
-    //         match super::packet::connect(&self.uds).await {
-    //             Err(e) => {
-    //                 backoff =
-    //                     std::cmp::min(CONNECTION_FAILURE_RETRY_DELAY_MAX_INTERVAL, backoff * 2);
-    //                 warn!(
-    //                     "failed to connect to the Istio CNI node agent over {:?}, is the node agent healthy? details: {:?}. retrying in {:?}",
-    //                     &self.uds, e, backoff
-    //                 );
-    //                 tokio::time::sleep(backoff).await;
-    //                 continue;
-    //             }
-
-    //             Ok(conn) => {
-    //                 return conn;
-    //             }
-    //         };
-    //     }
-    // }
-
-    // TODO make this work without UnixStream
     async fn connect(&self) -> Result<NamedPipeClient, anyhow::Error> {
         let mut backoff = Duration::from_millis(10);
 
@@ -140,15 +133,18 @@ impl WorkloadProxyNetworkHandler {
 
         loop {
             let client_options = ClientOptions::new()
-            .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Message)
-            .open(&self.uds);
+                .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Message)
+                .open(&self.uds);
             match client_options {
                 Ok(client) => {
                     info!("connected to server: {:?}", self.uds);
                     return Ok(client);
                 }
                 Err(ref e) => {
-                    error!("failed to connect to server: {:?}, error: {:?}", self.uds, e);
+                    error!(
+                        "failed to connect to server: {:?}, error: {:?}",
+                        self.uds, e
+                    );
                     sleep(backoff).await;
                     backoff *= 2;
                 }
@@ -160,7 +156,7 @@ impl WorkloadProxyNetworkHandler {
 impl WorkloadProxyManager {
     pub fn verify_syscalls() -> anyhow::Result<()> {
         // verify that we are capable, so we can fail early if not.
-        InpodNamespace::capable().map_err(|e| anyhow::anyhow!("failed to set netns: {:?}", e))
+        NetworkNamespace::capable().map_err(|e| anyhow::anyhow!("failed to set netns: {:?}", e))
     }
 
     pub fn new(
@@ -272,6 +268,65 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
             state,
             readiness,
             next_pending_retry: None,
+            next_event_timer: None,
+            event_queue: Default::default(),
+        }
+    }
+
+    async fn process_local_events(&mut self) {
+        let now = tokio::time::Instant::now();
+        for i in 0..self.event_queue.len() {
+            let event = &self.event_queue[i];
+            if event.expiration > now {
+                continue;
+            }
+            match &event.event_type {
+                EventType::RetryAllPendingWorkloads => self.retry_proxies().await,
+                EventType::RetryWorkload(previous_timeout, poddata) => {
+                    if let Err(e) = self.state.retry_comparmentless(poddata).await {
+                        // We can't tell the CNI that a node needs to be removed due
+                        // to an unretriable error. So at the moment we always retry,
+                        // always increasing the the timeout by a factor on each attempt.
+                        warn!("error while retyring workload: {}", e);
+                        let new_timeout = previous_timeout.mul(2);
+                        debug!(
+                            "retyring workload {:?} in {} seconds",
+                            poddata,
+                            new_timeout.as_secs()
+                        );
+                        self.enqueue_local_event(
+                            new_timeout,
+                            EventType::RetryWorkload(new_timeout, poddata.clone()),
+                        );
+                    };
+                }
+            }
+        }
+        self.event_queue.retain(|event| event.expiration > now)
+    }
+
+    fn enqueue_local_event(&mut self, delay: Duration, event_type: EventType) {
+        let expiration = tokio::time::Instant::now() + delay;
+        let new_event = InternalEvent {
+            event_type,
+            expiration,
+        };
+        match self
+            .event_queue
+            .binary_search_by_key(&expiration, |event| event.expiration)
+        {
+            Ok(pos) => self.event_queue.insert(pos, new_event),
+            Err(pos) => self.event_queue.insert(pos, new_event),
+        }
+        match self.next_event_timer.take() {
+            Some(_) => {
+                self.next_event_timer = Some(Box::pin(tokio::time::sleep_until(
+                    self.event_queue.first().unwrap().expiration,
+                )))
+            }
+            None => {
+                self.next_event_timer = Some(Box::pin(tokio::time::sleep_until(expiration)));
+            }
         }
     }
 
@@ -284,14 +339,15 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
         // return without completing it.
         futures::pin_mut!(readmsg);
         loop {
-            match self.next_pending_retry.take() {
+            //match self.next_pending_retry.take() {
+            match self.next_event_timer.take() {
                 None => {
                     return readmsg.await;
                 }
                 Some(timer) => {
                     match futures_util::future::select(timer, readmsg).await {
                         futures_util::future::Either::Left((_, readmsg_fut)) => {
-                            self.retry_proxies().await;
+                            self.process_local_events().await;
                             // we have an uncompleted future. It might be in the middle of recvmsg.
                             // to make sure we don't drop messages, we complete the original
                             // future and not start a new one.
@@ -300,7 +356,7 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
                         futures_util::future::Either::Right((res, timer)) => {
                             // we have a message before the timer expired
                             // put the timer back so we will wait for the time remaining next time.
-                            self.next_pending_retry = Some(timer);
+                            self.next_event_timer = Some(timer);
                             return res;
                         }
                     };
@@ -347,13 +403,26 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
             debug!("received message: {:?}", msg);
 
             // send ack:
-            match self.state.process_msg(msg).await {
-                Ok(()) => {
+            match self.state.process_msg(&msg).await {
+                Ok(statemanager::ProxyState::Up) => {
                     self.check_ready();
                     processor
                         .send_ack()
                         .await
                         .map_err(|e| Error::SendAckError(e.to_string()))?;
+                }
+                Ok(statemanager::ProxyState::PendingCompartment) => {
+                    self.check_ready();
+                    processor
+                        .send_ack()
+                        .await
+                        .map_err(|e| Error::SendAckError(e.to_string()))?;
+                    if let WorkloadMessage::AddWorkload(poddata) = msg {
+                        self.enqueue_local_event(
+                            COMPARTMENTLESS_DELAY,
+                            EventType::RetryWorkload(COMPARTMENTLESS_DELAY, poddata),
+                        );
+                    }
                 }
                 Err(Error::ProxyError(uid, e)) => {
                     error!(%uid, "failed to start proxy: {:?}", e);
@@ -382,10 +451,8 @@ impl<'a> WorkloadProxyManagerProcessor<'a> {
     }
 
     fn schedule_retry(&mut self) {
-        if self.next_pending_retry.is_none() {
-            info!("scheduling retry");
-            self.next_pending_retry = Some(Box::pin(tokio::time::sleep(RETRY_DURATION)));
-        }
+        info!("scheduling retry");
+        self.enqueue_local_event(RETRY_DURATION, EventType::RetryAllPendingWorkloads);
     }
     fn check_ready(&mut self) {
         if self.state.ready() {

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -16,7 +16,7 @@ use crate::config;
 use crate::identity::SecretManager;
 use crate::state::{DemandProxyState, WorkloadInfo};
 use std::sync::Arc;
-use tracing::{debug, error};
+use tracing::error;
 
 use crate::dns;
 use crate::drain::DrainWatcher;


### PR DESCRIPTION
### Problem
We have an issue with containerd and Windows' HCS where namespaces for pods don't yet have a compartment ID when the CNI signals ztunnel for a new workload that's just been created. Without that ID we can't create ztunnel proxy sockets inside the pod's network compartment. The compartment ID will only be available after ztunnel signals the CNI that the workload has been assimilated by ztunnel (which can't happen without a compartment ID 🫤).
### What this PR does
This PR mitigates the stated problem with ztunnel replying an ACK to the CNI during the ADD operation, even though the workload proxies haven't been yet instantiated inside ztunnel. After a timeout, ztunnel tries again to add the workflow, and now the HCS API returns a valid compartment ID, which allows the creation of a proxy without any problems.

A more detailed flow looks like:
1. CNI sends an ADD command to ztunnel
2. ztunnel queries HCS and checks if a comapartment ID is available for that pod
2.1 If the compartment ID is available, we create a proxy for the workload and ACK the CNI
2.2 If the compartment ID is not available, we mark the workload as pending inside ztunnel and ACK the CNI.
3. The CNI receives an ACK and the pod creation proceeds.
4. After a timeout, ztunnel tries to add the pending workload again.
### How the PR does it
It introduces a queue of events that runs in the same thread where ZDS commands are processed. These events are managed in a quite simple way at the moment, but can be expanded in the future for more advanced handling of future "internal events", including the current retries of pending workloads.
### Caveats
We'll keep retrying compartmentless workloads even if they're failing in an unretriable way (to be fixed in a different PR). There's no current way to signal CNI after sending an ACK for the ADD command that the workload actually failed to be assimilated by ztunnel.
