### PR TITLE
Update ztunnel profiling doc

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -5,43 +5,43 @@
 1. Port-forward admin port (15000):
 
 ```sh
-k port-forward -n istio-system ztunnel-qkvdj 15000:15000
+kubectl port-forward -n istio-system ztunnel-qkvdj 15000:15000
 ```
 
-1. Either open `localhost:15000` in a browser for help, or just `curl` the CPU profile:
+2. Either open `localhost:15000` in a browser for help, or just `curl` the CPU profile:
 
 ```sh
 curl localhost:15000/debug/pprof/profile > profile.prof
 ```
 
-1. Observe in your tooling of choice, such as [flamegraph](https://flamegraph.com/)
+3. Observe in your tooling of choice, such as [flamegraph](https://flamegraph.com/)
 
 ## Memory
 
 1. Build `ztunnel` with the `jemalloc` feature (disabled by default, see `Cargo.toml`)
 
-1. Port-forward admin port (15000):
+2. Port-forward admin port (15000):
 
 ```sh
-k port-forward -n istio-system ztunnel-qkvdj 15000:15000
+kubectl port-forward -n istio-system ztunnel-qkvdj 15000:15000
 ```
 
-1. Either open `localhost:15000` in a browser for help, or just `curl` the memory profile:
+3. Either open `localhost:15000` in a browser for help, or just `curl` the memory profile:
 
 ```sh
 curl localhost:15000/debug/pprof/heap > mem.pb.gz
 ```
 
-1. If working remotely, copy container binaries to local path for symbol resolution:
+4. Copy container binaries to local path for symbol resolution:
 
 ```sh
 # ztunnel main binary
-kubectl cp kube-system/ztunnel-qkvdj:/usr/local/bin/ztunnel ../../ztunnel-libs-pprof/ztunnel
+kubectl cp istio-system/ztunnel-qkvdj:/usr/local/bin/ztunnel ../../ztunnel-libs-pprof/ztunnel
 # stdlibs (optional)
-kubectl cp kube-system/ztunnel-qkvdj:/usr/lib/$BINARY_COMPILED_ARCH/ ../../ztunnel-libs-pprof/
+kubectl cp istio-system/ztunnel-qkvdj:/usr/lib/$BINARY_COMPILED_ARCH/ ../../ztunnel-libs-pprof/
 ```
 
-1. Observe in your tooling of choice, such as golang's `pprof`:
+5. Observe in your tooling of choice, such as golang's `pprof`:
 
 ```sh
 PPROF_BINARY_PATH=../../ztunnel-libs-pprof pprof -http=:8080 mem.pb.gz

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -8,31 +8,31 @@
 kubectl port-forward -n istio-system ztunnel-qkvdj 15000:15000
 ```
 
-2. Either open `localhost:15000` in a browser for help, or just `curl` the CPU profile:
+1. Either open `localhost:15000` in a browser for help, or just `curl` the CPU profile:
 
 ```sh
 curl localhost:15000/debug/pprof/profile > profile.prof
 ```
 
-3. Observe in your tooling of choice, such as [flamegraph](https://flamegraph.com/)
+1. Observe in your tooling of choice, such as [flamegraph](https://flamegraph.com/)
 
 ## Memory
 
 1. Build `ztunnel` with the `jemalloc` feature (disabled by default, see `Cargo.toml`)
 
-2. Port-forward admin port (15000):
+1. Port-forward admin port (15000):
 
 ```sh
 kubectl port-forward -n istio-system ztunnel-qkvdj 15000:15000
 ```
 
-3. Either open `localhost:15000` in a browser for help, or just `curl` the memory profile:
+1. Either open `localhost:15000` in a browser for help, or just `curl` the memory profile:
 
 ```sh
 curl localhost:15000/debug/pprof/heap > mem.pb.gz
 ```
 
-4. Copy container binaries to local path for symbol resolution:
+1. Copy container binaries to local path for symbol resolution:
 
 ```sh
 # ztunnel main binary
@@ -41,7 +41,7 @@ kubectl cp istio-system/ztunnel-qkvdj:/usr/local/bin/ztunnel ../../ztunnel-libs-
 kubectl cp istio-system/ztunnel-qkvdj:/usr/lib/$BINARY_COMPILED_ARCH/ ../../ztunnel-libs-pprof/
 ```
 
-5. Observe in your tooling of choice, such as golang's `pprof`:
+1. Observe in your tooling of choice, such as golang's `pprof`:
 
 ```sh
 PPROF_BINARY_PATH=../../ztunnel-libs-pprof pprof -http=:8080 mem.pb.gz


### PR DESCRIPTION
Minor edits:
- Put istio-system instead of kube-system in the `kubectl cp` command for consistency
- kubectl instead of k alias