### PR TITLE
admin: allow symbols in jemalloc pprof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9aba4251d95ac86f14c33e688d57a9344bfcff29e9b0c5a063fc66b5facc8a1"
 dependencies = [
  "anyhow",
+ "backtrace",
  "flate2",
  "num",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ duration-str = "0.17"
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
-jemalloc_pprof = { version = "0.8", optional = true }
+jemalloc_pprof = { version = "0.8", optional = true, features = ["symbolize"] }
 tikv-jemallocator = { version = "0.6.0", features = ["profiling", "unprefixed_malloc_on_supported_platforms"], optional = true }
 hashbrown = "0.15"
 hickory-client = "0.25"


### PR DESCRIPTION
Otherwise its pretty useless. Manually tested this makes heap profiles
work
