### PR TITLE
removing CNAME record answer for wildcards

### DIFF
--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -672,7 +672,9 @@ impl Resolver for Store {
 
         // If the service was found by stripping off one of the search domains, create a
         // CNAME record to map to the appropriate canonical name.
-        if let Some(stripped) = service_match.alias.stripped && !service_match.name.is_wildcard(){
+        if let Some(stripped) = service_match.alias.stripped
+            && !service_match.name.is_wildcard()
+        {
             // Create a CNAME record to map from the requested name -> stripped name.
             records.push(cname_record(requested_name.clone(), stripped.clone()));
 
@@ -1294,12 +1296,10 @@ mod tests {
             Case {
                 name: "success: wild card with search domain returns A record correctly",
                 host: "foo.svc.mesh.company.net.ns1.svc.cluster.local.",
-                expect_records: vec![
-                    a(
-                        n("foo.svc.mesh.company.net.ns1.svc.cluster.local."),
-                        ipv4("10.1.2.3"),
-                    ),
-                ],
+                expect_records: vec![a(
+                    n("foo.svc.mesh.company.net.ns1.svc.cluster.local."),
+                    ipv4("10.1.2.3"),
+                )],
                 ..Default::default()
             },
             Case {


### PR DESCRIPTION
This PR removes special treating of wildcards for DNS answers with CNAME record.

When resolving a domain that matches a wildcarded service, for example, resolving www.example.com against service *.example.com, ztunnel would create CNAME records mapping a wildcarded host name to a wildcarded canonical name, which can cause applications to reject the answer. Curl on Ubuntu is an example of application that rejects an authoritative answer with CNAME and A records when the CNAME contains mappings that are not FQDNs.

This should fix #1663 