### PR TITLE
Add transparent network policy support for HBONE connections

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ use crate::{identity, state};
 use {crate::test_helpers::MpscAckReceiver, crate::xds::LocalConfig, tokio::sync::Mutex};
 
 const ENABLE_PROXY: &str = "ENABLE_PROXY";
+const TRANSPARENT_NETWORK_POLICIES: &str = "TRANSPARENT_NETWORK_POLICIES";
 const KUBERNETES_SERVICE_HOST: &str = "KUBERNETES_SERVICE_HOST";
 const NETWORK: &str = "NETWORK";
 const NODE_NAME: &str = "NODE_NAME";
@@ -185,6 +186,8 @@ pub struct Config {
     pub proxy: bool,
     /// If true, a DNS proxy will be used.
     pub dns_proxy: bool,
+    /// If true, the communicatin will be stablished by the original destination port.
+    pub transparent_network_policies: bool,
 
     pub window_size: u32,
     pub connection_window_size: u32,
@@ -705,6 +708,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
 
     validate_config(Config {
         proxy: parse_default(ENABLE_PROXY, true)?,
+        transparent_network_policies: parse_default(TRANSPARENT_NETWORK_POLICIES, false)?,
         // Enable by default; running the server is not an issue, clients still need to opt-in to sending their
         // DNS requests to Ztunnel.
         dns_proxy: pc

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -611,12 +611,17 @@ impl OutboundConnection {
             .selected_workload_ip
             .ok_or(Error::NoValidDestination(Box::new((*us.workload).clone())))?;
 
+        let original_destination = us.workload_socket_addr()
+            .ok_or(Error::NoValidDestination(Box::new((*us.workload).clone())))?;
+
         // only change the port if we're sending HBONE
         let actual_destination = match us.workload.protocol {
-            InboundProtocol::HBONE => SocketAddr::from((selected_workload_ip, self.hbone_port)),
-            InboundProtocol::TCP => us
-                .workload_socket_addr()
-                .ok_or(Error::NoValidDestination(Box::new((*us.workload).clone())))?,
+            InboundProtocol::HBONE => if self.pi.cfg.transparent_network_policies {
+                original_destination
+            } else {
+                SocketAddr::from((selected_workload_ip, self.hbone_port))
+            },
+            InboundProtocol::TCP => original_destination,
         };
         let hbone_target_destination = match us.workload.protocol {
             InboundProtocol::HBONE => Some(HboneAddress::SocketAddr(


### PR DESCRIPTION
## Description

Introduces TRANSPARENT_NETWORK_POLICIES config flag to preserve original destination ports for HBONE protocol connections. When enabled, outbound HBONE traffic uses the original destination port instead of routing all traffic through the standard HBONE port. This allows network policies to operate transparently based on the actual service port, enabling port-level policy enforcement without application awareness.

Defaults to false to maintain backward compatibility.

Requires [this](https://github.com/istio/istio/pull/58285) change also for the rest of the traffic control


## How does it work?

**With our modifications:**
```mermaid
sequenceDiagram
    participant PodA as Pod A<br/>(Client)
    participant ZTA as ZTunnel<br>(listening socket in Pod A netns)
    participant IFPodA as Iface Pod A
    participant Plc as Network Policies<br>(Allow port 8080 for Pod A)
    participant IFPodB as Iface Pod B
    participant ZTB as ZTunnel<br>(listening socket in Pod B netns)
    participant PodB as Pod B<br/>(Server:8080)

    Note over PodA,PodB: Mesh Communication - with microsegmentation
    PodA->>ZTA: Istio redirects all TCP traffic,<br>leaving the pod, to ZTunnel
    ZTA->>IFPodA: Proxing over<br>HBONE protocol<br>(original dst port)
    Note over ZTA,IFPodA: Modified ZTunnel<br>that proxies with<br>original dst port
    IFPodA->>Plc: Flow to Pod B (port 8080)
    Plc->>IFPodB: Traffic Allowed
    Note over IFPodB: Felix makes magic<br>DSCP mark (0x17)<br>(host netns)
    Note over IFPodB: Modified Istio CNI<br>iptables rules<br>redirects to ZTunnel<br>(pod netns)

    IFPodB->>ZTB: ZTunnel receives<br>the connection :15008
    ZTB->>PodB: Ztunnel proxying<br>finishes
```


The key concept is that Felix (part of calico-node) maintains an ipset of pods that have the istio ambient mode label. For traffic that matches tha ipset it's marked with a DSCP rule that drives traffic back to ztunnel inbound

