### PR TITLE
Provide Spire Workload Attestation Support to ztunnel

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -1,0 +1,135 @@
+name: Image CI Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-binary:
+    name: Build Binary (${{ matrix.arch }}, ${{ matrix.tls_mode }})
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        tls_mode:
+          - aws-lc
+          - boring
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+          - tls_mode: aws-lc
+            image_suffix: ""
+          - tls_mode: boring
+            image_suffix: "-fips"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        with:
+          toolchain: "1.90"
+
+      - name: Cache Cargo Registry
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            out/rust
+          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ matrix.tls_mode }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ matrix.tls_mode }}-
+
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev cmake
+
+      # BoringSSL FIPS vendored path is hardcoded to x86_64; fix for arm64
+      - name: Fix BoringSSL FIPS Path for arm64
+        if: matrix.tls_mode == 'boring' && matrix.arch == 'arm64'
+        run: sed -i 's/x86_64/arm64/g' .cargo/config.toml
+
+      - name: Build Release Binary
+        run: TLS_MODE=${{ matrix.tls_mode }} make build-release
+        env:
+          RUSTFLAGS: "-D warnings"
+
+      - name: Upload Binary
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ztunnel-${{ matrix.arch }}${{ matrix.image_suffix }}
+          path: out/rust/release/ztunnel
+
+  build-image:
+    name: Build and Push CI Image (ztunnel-ci${{ matrix.tag_suffix }})
+    needs: build-binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        include:
+          - tls_mode: aws-lc
+            image_suffix: ""
+            tag_suffix: ""
+          - tls_mode: boring
+            image_suffix: "-fips"
+            tag_suffix: "-fips"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Download amd64 Binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ztunnel-amd64${{ matrix.image_suffix }}
+          path: out/docker/amd64/
+
+      - name: Download arm64 Binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ztunnel-arm64${{ matrix.image_suffix }}
+          path: out/docker/arm64/
+
+      - name: Prepare Build Context
+        run: |
+          chmod +x out/docker/amd64/ztunnel out/docker/arm64/ztunnel
+          cp Dockerfile out/docker/Dockerfile
+
+      - name: Compute Image Tag
+        id: meta
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Login to Quay.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME_CI }}
+          password: ${{ secrets.QUAY_PASSWORD_CI }}
+
+      - name: Build and Push CI Image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: out/docker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/${{ vars.QUAY_ORGANIZATION_DEV }}/ztunnel-ci:${{ steps.meta.outputs.sha }}${{ matrix.tag_suffix }}
+          build-args: BASE_IMAGE=gcr.io/distroless/cc-debian12:nonroot

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -1,0 +1,183 @@
+name: Image Release Build
+
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-binary:
+    name: Build Binary (${{ matrix.arch }}, ${{ matrix.tls_mode }})
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        tls_mode:
+          - aws-lc
+          - boring
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+          - tls_mode: aws-lc
+            image_suffix: ""
+          - tls_mode: boring
+            image_suffix: "-fips"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        with:
+          toolchain: "1.90"
+
+      - name: Cache Cargo Registry
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            out/rust
+          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ matrix.tls_mode }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ matrix.tls_mode }}-
+
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev cmake
+
+      # BoringSSL FIPS vendored path is hardcoded to x86_64; fix for arm64
+      - name: Fix BoringSSL FIPS Path for arm64
+        if: matrix.tls_mode == 'boring' && matrix.arch == 'arm64'
+        run: sed -i 's/x86_64/arm64/g' .cargo/config.toml
+
+      - name: Build Release Binary
+        run: TLS_MODE=${{ matrix.tls_mode }} make build-release
+        env:
+          RUSTFLAGS: "-D warnings"
+
+      - name: Upload Binary
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ztunnel-${{ matrix.arch }}${{ matrix.image_suffix }}
+          path: out/rust/release/ztunnel
+
+  build-image:
+    name: Build and Push Release Image (ztunnel${{ matrix.tag_suffix }})
+    needs: build-binary
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        include:
+          - tls_mode: aws-lc
+            image_suffix: ""
+            tag_suffix: ""
+          - tls_mode: boring
+            image_suffix: "-fips"
+            tag_suffix: "-fips"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Download amd64 Binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ztunnel-amd64${{ matrix.image_suffix }}
+          path: out/docker/amd64/
+
+      - name: Download arm64 Binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ztunnel-arm64${{ matrix.image_suffix }}
+          path: out/docker/arm64/
+
+      - name: Prepare Build Context
+        run: |
+          chmod +x out/docker/amd64/ztunnel out/docker/arm64/ztunnel
+          cp Dockerfile out/docker/Dockerfile
+
+      - name: Login to Quay.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RELEASE_USERNAME }}
+          password: ${{ secrets.QUAY_RELEASE_PASSWORD }}
+
+      - name: Build and Push Release Image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: out/docker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/${{ vars.QUAY_ORGANIZATION }}/ztunnel:${{ github.ref_name }}${{ matrix.tag_suffix }}
+          build-args: BASE_IMAGE=gcr.io/distroless/cc-debian12:nonroot
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-binary, build-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download All Binaries
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: artifacts/
+
+      - name: Prepare Binary Assets
+        run: |
+          mkdir -p release-assets
+          for dir in artifacts/ztunnel-*; do
+            name=$(basename "$dir")
+            cp "$dir/ztunnel" "release-assets/${name}"
+            chmod +x "release-assets/${name}"
+          done
+
+      - name: Login to Quay.io
+        run: skopeo login -u "${{ secrets.QUAY_RELEASE_USERNAME }}" -p "${{ secrets.QUAY_RELEASE_PASSWORD }}" quay.io
+
+      - name: Export Container Images
+        run: |
+          TAG="${{ github.ref_name }}"
+          REGISTRY="quay.io/${{ vars.QUAY_ORGANIZATION }}"
+
+          for variant in "" "-fips"; do
+            for arch in amd64 arm64; do
+              skopeo copy --override-arch "${arch}" \
+                "docker://${REGISTRY}/ztunnel:${TAG}${variant}" \
+                "docker-archive:release-assets/ztunnel-image-${arch}${variant}.tar:${REGISTRY}/ztunnel:${TAG}${variant}"
+              gzip "release-assets/ztunnel-image-${arch}${variant}.tar"
+            done
+          done
+
+      - name: List Release Assets
+        run: ls -la release-assets/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            release-assets/*

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -131,6 +131,7 @@ jobs:
     name: Create GitHub Release
     needs: [build-binary, build-image]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:
@@ -143,6 +144,7 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: artifacts/
+          pattern: ztunnel-*
 
       - name: Prepare Binary Assets
         run: |

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -24,11 +24,10 @@ jobs:
           sudo apt-get install -y protobuf-compiler libprotobuf-dev
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
           toolchain: "1.90"
           components: rustfmt
-          override: true
 
       - name: Cache Cargo Registry
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -58,10 +57,9 @@ jobs:
           sudo apt-get install -y protobuf-compiler libprotobuf-dev
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
           toolchain: "1.90"
-          override: true
 
       - name: Cache Cargo Registry
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -1,0 +1,81 @@
+name: Rust Related Checks
+
+on:
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  lint:
+    name: Lint and Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+        with:
+          toolchain: "1.90"
+          components: rustfmt
+          override: true
+
+      - name: Cache Cargo Registry
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check Formatting
+        run: cargo fmt --all -- --check
+
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+        with:
+          toolchain: "1.90"
+          override: true
+
+      - name: Cache Cargo Registry
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build
+
+      - name: Run Tests
+        run: sudo -E env "PATH=$PATH" cargo test --benches --tests --bins

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,12 +1390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hickory-client"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,21 +1612,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "hyperlocal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
-dependencies = [
- "hex",
- "http-body-util",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -2751,9 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -2761,15 +2740,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -4961,7 +4940,6 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "hyperlocal",
  "ipnet",
  "itertools 0.14.0",
  "jemalloc_pprof",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,7 +127,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -130,7 +139,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
  "synstructure",
 ]
 
@@ -142,7 +151,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -164,7 +173,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -175,7 +184,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -192,25 +201,68 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.0"
+version = "1.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932a7d9d28b0d2ea34c6b3779d35e3dd6f6345317c34e73438c4f1f29144151"
+checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.33.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1826f2e4cfc2cd19ee53c42fbf68e2f81ec21108e0b7ecf6a71cf062137360fc"
+checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -219,7 +271,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "instant",
  "rand 0.8.5",
 ]
@@ -261,14 +313,12 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -285,9 +335,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "boring"
-version = "4.19.0"
+version = "4.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbe9eda68fc7fbfb395aace52dfc37075928536ec2f149abce54dbd40e38d5"
+checksum = "2c7c065a1115b820c26020b3dba8e33592b1ddd9ff811819928b75a49d6c89e1"
 dependencies = [
  "bitflags 2.10.0",
  "boring-sys",
@@ -324,11 +374,10 @@ dependencies = [
 
 [[package]]
 name = "boring-sys"
-version = "4.19.0"
+version = "4.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c9f08dc17fab4192e5e6b0920e6c06eb9e3e4ab98b9cff00368dfe6d1e30c9"
+checksum = "cf413a89e6c07a57fa74c047c78d1d54afe7a65aa33dab328554bca9ca431a28"
 dependencies = [
- "autocfg",
  "bindgen",
  "cmake",
  "fs_extra",
@@ -345,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -372,9 +421,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.46"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -405,9 +454,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -456,18 +505,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -475,15 +524,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -509,7 +558,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -678,10 +727,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
-name = "data-encoding"
-version = "2.9.0"
+name = "darling"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "debugid"
@@ -725,6 +809,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,14 +853,20 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.10"
+name = "downcast"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dtor"
@@ -777,7 +898,7 @@ dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "winnow",
 ]
@@ -791,7 +912,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -815,7 +936,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -835,7 +956,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -855,7 +976,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -891,21 +1012,20 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "findshlibs"
@@ -927,9 +1047,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -986,7 +1106,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -1009,6 +1129,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fs_extra"
@@ -1091,7 +1217,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -1147,13 +1273,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1166,6 +1294,18 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1182,9 +1322,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1223,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hdrhistogram"
@@ -1250,6 +1390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hickory-client"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,7 +1409,7 @@ dependencies = [
  "once_cell",
  "radix_trie",
  "rand 0.9.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1287,7 +1433,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1311,7 +1457,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1333,7 +1479,7 @@ dependencies = [
  "ipnet",
  "prefix-trie",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-util",
@@ -1351,12 +1497,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1436,10 +1581,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-util"
-version = "0.1.18"
+name = "hyper-timeout"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1456,9 +1614,25 @@ dependencies = [
  "socket2 0.6.1",
  "system-configuration",
  "tokio",
+ "tower-layer",
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1533,9 +1707,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1547,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -1565,6 +1739,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1589,12 +1769,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1696,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jemalloc_pprof"
@@ -1729,12 +1909,27 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1774,9 +1969,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
@@ -1819,14 +2014,13 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.5"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
+checksum = "92488bc8a0f99ee9f23577bdd06526d49657df8bd70504c61f812337cdad01ab"
 dependencies = [
  "libc",
  "neli",
- "thiserror 2.0.17",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1840,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -1882,6 +2076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +2115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -1954,10 +2160,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "moka"
-version = "0.12.11"
+name = "mockall"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -1965,7 +2197,6 @@ dependencies = [
  "equivalent",
  "parking_lot",
  "portable-atomic",
- "rustc_version",
  "smallvec",
  "tagptr",
  "uuid",
@@ -1979,27 +2210,31 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "neli"
-version = "0.6.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
+checksum = "e23bebbf3e157c402c4d5ee113233e5e0610cc27453b2f07eefce649c7365dcc"
 dependencies = [
+ "bitflags 2.10.0",
  "byteorder",
+ "derive_builder",
+ "getset",
  "libc",
  "log",
  "neli-proc-macros",
+ "parking_lot",
 ]
 
 [[package]]
 name = "neli-proc-macros"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
+checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
 dependencies = [
  "either",
  "proc-macro2",
  "quote",
  "serde",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2256,14 +2491,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -2324,11 +2559,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -2349,7 +2585,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -2393,6 +2629,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "potential_utf"
@@ -2477,7 +2723,7 @@ dependencies = [
  "spin",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2504,6 +2750,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prefix-trie"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,14 +2792,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2552,7 +2846,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -2579,31 +2873,30 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.14.1",
+ "prost 0.14.3",
  "prost-types",
  "regex",
- "syn 2.0.110",
+ "syn",
  "tempfile",
 ]
 
@@ -2617,29 +2910,29 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.1",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -2695,9 +2988,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -2749,7 +3042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2779,7 +3072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2797,14 +3090,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -2840,9 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fae430c6b28f1ad601274e78b7dffa0546de0b73b4cd32f46723c0c2a16f7a5"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "aws-lc-rs",
  "pem",
@@ -2902,9 +3195,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -2914,17 +3207,17 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rust_decimal"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -2932,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -2975,9 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
@@ -2988,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3004,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3039,23 +3332,23 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3066,9 +3359,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -3156,20 +3449,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3202,18 +3495,31 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -3248,12 +3554,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "spiffe"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d35944014fb3bf691b337f2ffa5de777baea3d7283ac55c113302f6f895ee25a"
+dependencies = [
+ "arc-swap",
+ "hyper-util",
+ "jsonwebtoken",
+ "log",
+ "pkcs8",
+ "prost 0.14.3",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "url",
+ "x509-parser 0.18.0",
+ "zeroize",
+]
+
+[[package]]
 name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spire-api"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae4da72415662c3d4abe3840b7b8623e0ec693886fa3e813aa81eac75ca301"
+dependencies = [
+ "hyper-util",
+ "prost 0.14.3",
+ "spiffe",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tower",
 ]
 
 [[package]]
@@ -3278,6 +3629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,9 +3642,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.16.3"
+version = "12.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03f433c9befeea460a01d750e698aa86caf86dcfbd77d552885cd6c89d52f50"
+checksum = "520cf51c674f8b93d533f80832babe413214bb766b6d7cb74ee99ad2971f8467"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3297,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.16.3"
+version = "12.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d359ef6192db1760a34321ec4f089245ede4342c27e59be99642f12a859de8"
+checksum = "9f0de2ee0ffa2641e17ba715ad51d48b9259778176517979cb38b6aa86fa7425"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -3308,20 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3342,7 +3688,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -3374,16 +3720,22 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-case"
@@ -3403,7 +3755,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -3414,7 +3766,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
  "test-case-core",
 ]
 
@@ -3439,11 +3791,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3454,18 +3806,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -3585,25 +3937,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls-listener"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41256c16d6fc2b3021545f20bf77a73200b18bd54040ac656dddfca6205bfa"
+checksum = "1461056cc1ef47003f7ee16e4cef3741068d4c7f6b627bfce49b7c00c120a530"
 dependencies = [
  "futures-util",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.0",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3620,7 +3972,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -3635,9 +3987,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3646,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3664,15 +4016,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
+ "socket2 0.6.1",
  "sync_wrapper",
+ "tokio",
  "tokio-stream",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3687,7 +4047,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -3697,7 +4057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
- "prost 0.14.1",
+ "prost 0.14.3",
  "tonic",
 ]
 
@@ -3712,16 +4072,16 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.110",
+ "syn",
  "tempfile",
  "tonic-build",
 ]
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3762,12 +4122,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -3780,7 +4140,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -3861,20 +4221,27 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3885,9 +4252,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -3945,18 +4312,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3967,9 +4334,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3977,31 +4344,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4077,7 +4444,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -4088,7 +4455,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -4359,9 +4726,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -4378,9 +4745,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -4402,7 +4769,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -4413,6 +4780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
 dependencies = [
  "asn1-rs",
+ "aws-lc-rs",
  "data-encoding",
  "der-parser",
  "lazy_static",
@@ -4420,7 +4788,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -4452,28 +4820,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -4493,7 +4861,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
  "synstructure",
 ]
 
@@ -4502,6 +4870,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4533,8 +4915,14 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "ztunnel"
@@ -4573,6 +4961,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "hyperlocal",
  "ipnet",
  "itertools 0.14.0",
  "jemalloc_pprof",
@@ -4581,6 +4970,7 @@ dependencies = [
  "local-ip-address",
  "log",
  "matches",
+ "mockall",
  "netns-rs",
  "nix 0.30.1",
  "notify",
@@ -4596,7 +4986,7 @@ dependencies = [
  "pprof",
  "prometheus-client",
  "prometheus-parse",
- "prost 0.14.1",
+ "prost 0.14.3",
  "prost-types",
  "rand 0.9.2",
  "rcgen",
@@ -4611,11 +5001,13 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "socket2 0.6.1",
+ "spiffe",
+ "spire-api",
  "split-iter",
  "tempfile",
  "test-case",
  "textnonce",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tikv-jemallocator",
  "time",
  "tls-listener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,9 @@ num_cpus = "1.16"
 ppp = "2.3"
 prometheus-client = { version = "0.24" }
 prometheus-parse = "0.2"
-prost = { version = "0.14", default-features = false }
-prost-types = { version = "0.14", default-features = false }
+prost = { version = "0.14.2" }
+prost-types = { version = "0.14.2" }
+tonic-prost = { version = "0.14.2" }
 rand = { version = "0.9" , features = ["small_rng"]}
 rcgen = { version = "0.14", optional = true, features = ["pem"] }
 rustls = { version = "0.23", features = ["tls12"], default-features = false }
@@ -97,8 +98,7 @@ tls-listener = { version = "0.11" }
 tokio = { version = "1.44", features = ["full", "test-util"] }
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.14", default-features = false, features = ["codegen"] }
-tonic-prost = { version = "0.14", default-features = false }
+tonic = { version = "0.14.2", features = ["codegen", "transport"] }
 tower = { version = "0.5", features = ["full"] }
 tracing = { version = "0.1"}
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "json"] }
@@ -118,7 +118,11 @@ tracing-core = "0.1"
 tracing-appender = "0.2"
 tokio-util = { version = "0.7", features = ["io-util"] }
 educe = "0.6"
-tempfile = { version = "3.21", optional = true}
+spire-api = "0.3.6"
+spiffe = "0.7"
+tempfile = { version = "3.23", optional = true}
+hyperlocal = "0.9.1"
+mockall = "0.14.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netns-rs = "0.1"
@@ -158,7 +162,7 @@ local-ip-address = "0.6"
 matches = "0.1"
 test-case = "3.3"
 oid-registry = "0.8"
-rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
+rcgen = { version = "0.14", features = ["pem", "x509-parser", "crypto"] }
 x509-parser = { version = "0.17", default-features = false, features = ["verify"] }
 time = "0.3"
 ctor = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ educe = "0.6"
 spire-api = "0.3.6"
 spiffe = "0.7"
 tempfile = { version = "3.23", optional = true}
-hyperlocal = "0.9.1"
 mockall = "0.14.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+# Base image: cc-debian12 provides glibc + libgcc_s + CA certificates.
+# Use :nonroot for production, :debug for a busybox shell.
+ARG BASE_IMAGE=gcr.io/distroless/cc-debian12:nonroot
+
+FROM ${BASE_IMAGE}
+
+LABEL org.opencontainers.image.source="https://github.com/cilium/ztunnel"
+LABEL org.opencontainers.image.description="Cilium ztunnel - ambient mesh proxy"
+
+WORKDIR /
+
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/ztunnel /usr/local/bin/ztunnel
+
+ENTRYPOINT ["/usr/local/bin/ztunnel"]

--- a/Makefile
+++ b/Makefile
@@ -65,5 +65,6 @@ export
 
 export GOBIN ?= $(GOPATH)/bin
 include Makefile.core.mk
+include Makefile.docker
 
 endif

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -18,6 +18,9 @@ coverage:
 build:
 	cargo build $(FEATURES)
 
+build-release:
+	cargo build --release $(FEATURES)
+
 # Build the inpodserver example
 inpodserver:
 	cargo build --example inpodserver
@@ -69,3 +72,5 @@ clean:
 
 rust-version:
 	./common/scripts/run.sh /usr/bin/rustc -vV
+
+.PHONY: build-release

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,38 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+export DOCKER_BUILDKIT=1
+
+DOCKER ?= docker
+IMAGE_REGISTRY ?= quay.io/cilium
+IMAGE_NAME ?= ztunnel
+IMAGE_TAG ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+BASE_IMAGE ?= gcr.io/distroless/cc-debian12:nonroot
+DOCKER_PLATFORMS ?= linux/amd64,linux/arm64
+ARCH ?= amd64
+
+# Stage pre-built binary into Docker build context
+docker-context:
+	@mkdir -p out/docker/$(ARCH)
+	cp out/rust/release/ztunnel out/docker/$(ARCH)/ztunnel
+
+# Build image for local platform (assumes binary already built via `make build-release`)
+docker-image: docker-context
+	cp Dockerfile out/docker/Dockerfile
+	$(DOCKER) build \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		-t $(IMAGE) \
+		out/docker/
+
+# Build and push multi-arch (for CI use with buildx)
+docker-image-push:
+	cp Dockerfile out/docker/Dockerfile
+	$(DOCKER) buildx build \
+		--platform $(DOCKER_PLATFORMS) \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		-t $(IMAGE) \
+		--push \
+		out/docker/
+
+.PHONY: docker-context docker-image docker-image-push

--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 Ztunnel provides an implementation of the ztunnel component of
 [ambient mesh](https://istio.io/latest/blog/2022/introducing-ambient-mesh/).
 
+## SPIRE CA Support (Fork)
+
+Upstream ztunnel only supports Istio's built-in CA for certificate issuance. This fork adds support for SPIRE as an alternative Certificate Authority, enabling SPIFFE-based workload identity for environments that use SPIRE instead of Istio's CA.
+
+### Why Under Cilium
+
+- Cilium is the primary consumer of this SPIRE integration for now.
+- Provides a home for the fork while the SPIRE CA support is developed and validated.
+- Once the implementation is mature and merged upstream, the fork can be archived.
+
+This is a temporary fork, not a permanent divergence. The goal is to upstream the SPIRE CA support to Istio's ztunnel repository.
+
 ## Feature Scope
 
 Ztunnel is intended to be a purpose built implementation of the node proxy in [ambient mesh](https://istio.io/latest/blog/2022/introducing-ambient-mesh/).

--- a/build.rs
+++ b/build.rs
@@ -38,6 +38,7 @@ fn main() -> Result<(), anyhow::Error> {
         "proto/authorization.proto",
         "proto/citadel.proto",
         "proto/zds.proto",
+        "proto/cri-api.proto",
     ]
     .iter()
     .map(|name| std::env::current_dir().unwrap().join(name))

--- a/proto/cri-api.proto
+++ b/proto/cri-api.proto
@@ -1,0 +1,871 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// To regenerate api.pb.go run `hack/update-codegen.sh protobindings`
+syntax = "proto3";
+
+package runtime.v1;
+option go_package = "k8s.io/cri-api/pkg/apis/runtime/v1";
+
+// Runtime service defines the public APIs for remote container runtimes
+service RuntimeService {
+    // Version returns the runtime name, runtime version, and runtime API version.
+    rpc Version(VersionRequest) returns (VersionResponse) {}
+    // PodSandboxStatus returns the status of the PodSandbox. If the PodSandbox is not
+    // present, returns an error.
+    rpc PodSandboxStatus(PodSandboxStatusRequest) returns (PodSandboxStatusResponse) {}
+    // ListPodSandbox returns a list of PodSandboxes.
+    rpc ListPodSandbox(ListPodSandboxRequest) returns (ListPodSandboxResponse) {}
+    // ListContainers lists all containers by filters.
+    rpc ListContainers(ListContainersRequest) returns (ListContainersResponse) {}
+    // ContainerStatus returns status of the container. If the container is not
+    // present, returns an error.
+    rpc ContainerStatus(ContainerStatusRequest) returns (ContainerStatusResponse) {}
+    // Status returns the status of the runtime.
+    rpc Status(StatusRequest) returns (StatusResponse) {}
+}
+
+message VersionRequest {
+    // Version of the kubelet runtime API.
+    string version = 1;
+}
+
+message VersionResponse {
+    // Version of the kubelet runtime API.
+    string version = 1;
+    // Name of the container runtime.
+    string runtime_name = 2;
+    // Version of the container runtime. The string must be
+    // semver-compatible.
+    string runtime_version = 3;
+    // API version of the container runtime. The string must be
+    // semver-compatible.
+    string runtime_api_version = 4;
+}
+
+enum MountPropagation {
+    // No mount propagation ("rprivate" in Linux terminology).
+    PROPAGATION_PRIVATE = 0;
+    // Mounts get propagated from the host to the container ("rslave" in Linux).
+    PROPAGATION_HOST_TO_CONTAINER = 1;
+    // Mounts get propagated from the host to the container and from the
+    // container to the host ("rshared" in Linux).
+    PROPAGATION_BIDIRECTIONAL = 2;
+}
+
+// Mount specifies a host volume to mount into a container.
+message Mount {
+    // Path of the mount within the container.
+    string container_path = 1;
+    // Path of the mount on the host. Has to be empty if the image field below
+    // is provided, because those fields are mutually exclusive. If the image
+    // field below is nil and the host path doesn't exist, then runtimes should
+    // report an error. If the hostpath is a symbolic link, runtimes should
+    // follow the symlink and mount the real destination to container.
+    string host_path = 2;
+    // If set, the mount is read-only.
+    bool readonly = 3;
+    // If set, the mount needs SELinux relabeling.
+    bool selinux_relabel = 4;
+    // Requested propagation mode.
+    MountPropagation propagation = 5;
+    // UidMappings specifies the runtime UID mappings for the mount.
+    repeated IDMapping uidMappings = 6;
+    // GidMappings specifies the runtime GID mappings for the mount.
+    repeated IDMapping gidMappings = 7;
+    // If set to true, the mount is made recursive read-only.
+    // In this CRI API, recursive_read_only is a plain true/false boolean, although its equivalent
+    // in the Kubernetes core API is a quaternary that can be nil, "Enabled", "IfPossible", or "Disabled".
+    // kubelet translates that quaternary value in the core API into a boolean in this CRI API.
+    // Remarks:
+    // - nil is just treated as false
+    // - when set to true, readonly must be explicitly set to true, and propagation must be PRIVATE (0).
+    // - (readonly == false && recursive_read_only == false) does not make the mount read-only.
+    bool recursive_read_only = 8;
+    // Mount an image reference (image ID, with or without digest), which is a
+    // special use case for image volume mounts. If this field is set, then
+    // host_path should be unset. All image mounts are per feature definition
+    // readonly (noexec). The kubelet does an PullImage RPC and evaluates the returned
+    // PullImageResponse.image_ref value, which is then set to the
+    // ImageSpec.image field. Runtimes are expected to mount the image as
+    // required.
+    // Introduced in the Image Volume Source KEP: https://kep.k8s.io/4639
+    ImageSpec image = 9;
+    // Specific image sub path to be used from inside the image instead of its
+    // root, only necessary if the above image field is set. If the sub path is
+    // not empty and does not exist in the image, then runtimes should fail and
+    // return an error.
+    // Introduced in the Image Volume Source KEP beta graduation: https://kep.k8s.io/4639
+    string image_sub_path = 10;
+}
+
+// IDMapping describes host to container ID mappings for a pod sandbox.
+message IDMapping {
+    // HostId is the id on the host.
+    uint32 host_id = 1;
+    // ContainerId is the id in the container.
+    uint32 container_id = 2;
+    // Length is the size of the range to map.
+    uint32 length = 3;
+}
+
+// A NamespaceMode describes the intended namespace configuration for each
+// of the namespaces (Network, PID, IPC) in NamespaceOption. Runtimes should
+// map these modes as appropriate for the technology underlying the runtime.
+enum NamespaceMode {
+    // A POD namespace is common to all containers in a pod.
+    // For example, a container with a PID namespace of POD expects to view
+    // all of the processes in all of the containers in the pod.
+    POD       = 0;
+    // A CONTAINER namespace is restricted to a single container.
+    // For example, a container with a PID namespace of CONTAINER expects to
+    // view only the processes in that container.
+    CONTAINER = 1;
+    // A NODE namespace is the namespace of the Kubernetes node.
+    // For example, a container with a PID namespace of NODE expects to view
+    // all of the processes on the host running the kubelet.
+    NODE      = 2;
+    // TARGET targets the namespace of another container. When this is specified,
+    // a target_id must be specified in NamespaceOption and refer to a container
+    // previously created with NamespaceMode CONTAINER. This containers namespace
+    // will be made to match that of container target_id.
+    // For example, a container with a PID namespace of TARGET expects to view
+    // all of the processes that container target_id can view.
+    TARGET    = 3;
+}
+
+// UserNamespace describes the intended user namespace configuration for a pod sandbox.
+message UserNamespace {
+    // Mode is the NamespaceMode for this UserNamespace.
+    // Note: NamespaceMode for UserNamespace currently supports only POD and NODE, not CONTAINER OR TARGET.
+    NamespaceMode mode = 1;
+
+    // Uids specifies the UID mappings for the user namespace.
+    repeated IDMapping uids = 2;
+
+    // Gids specifies the GID mappings for the user namespace.
+    repeated IDMapping gids = 3;
+}
+
+// NamespaceOption provides options for Linux namespaces.
+message NamespaceOption {
+    // Network namespace for this container/sandbox.
+    // Note: There is currently no way to set CONTAINER scoped network in the Kubernetes API.
+    // Namespaces currently set by the kubelet: POD, NODE
+    NamespaceMode network = 1;
+    // PID namespace for this container/sandbox.
+    // Note: The CRI default is POD, but the v1.PodSpec default is CONTAINER.
+    // The kubelet's runtime manager will set this to CONTAINER explicitly for v1 pods.
+    // Namespaces currently set by the kubelet: POD, CONTAINER, NODE, TARGET
+    NamespaceMode pid = 2;
+    // IPC namespace for this container/sandbox.
+    // Note: There is currently no way to set CONTAINER scoped IPC in the Kubernetes API.
+    // Namespaces currently set by the kubelet: POD, NODE
+    NamespaceMode ipc = 3;
+    // Target Container ID for NamespaceMode of TARGET. This container must have been
+    // previously created in the same pod. It is not possible to specify different targets
+    // for each namespace.
+    string target_id = 4;
+    // UsernsOptions for this pod sandbox.
+    // The Kubelet picks the user namespace configuration to use for the pod sandbox.  The mappings
+    // are specified as part of the UserNamespace struct.  If the struct is nil, then the POD mode
+    // must be assumed.  This is done for backward compatibility with older Kubelet versions that
+    // do not set a user namespace.
+    UserNamespace userns_options = 5;
+}
+
+// SupplementalGroupsPolicy defines how supplemental groups 
+// of the first container processes are calculated.
+enum SupplementalGroupsPolicy {
+    // Merge means that the container's provided SupplementalGroups 
+    // and FsGroup (specified in SecurityContext) will be merged with 
+    // the primary user's groups as defined in the container image
+    // (in /etc/group).
+    Merge = 0;
+    // Strict means that the container's provided SupplementalGroups
+    // and FsGroup (specified in SecurityContext) will be used instead of 
+    // any groups defined in the container image.
+    Strict = 1;
+}
+
+// Int64Value is the wrapper of int64.
+message Int64Value {
+    // The value.
+    int64 value = 1;
+}
+
+// A security profile which can be used for sandboxes and containers.
+message SecurityProfile {
+    // Available profile types.
+    enum ProfileType {
+        // The container runtime default profile should be used.
+        RuntimeDefault = 0;
+        // Disable the feature for the sandbox or the container.
+        Unconfined = 1;
+        // A pre-defined profile on the node should be used.
+        Localhost = 2;
+    }
+    // Indicator which `ProfileType` should be applied.
+    ProfileType profile_type = 1;
+    // Indicates that a pre-defined profile on the node should be used.
+    // Must only be set if `ProfileType` is `Localhost`.
+    // For seccomp, it must be an absolute path to the seccomp profile.
+    // For AppArmor, this field is the AppArmor `<profile name>/`
+    string localhost_ref = 2;
+}
+
+// PodSandboxMetadata holds all necessary information for building the sandbox name.
+// The container runtime is encouraged to expose the metadata associated with the
+// PodSandbox in its user interface for better user experience. For example,
+// the runtime can construct a unique PodSandboxName based on the metadata.
+message PodSandboxMetadata {
+    // Pod name of the sandbox. Same as the pod name in the Pod ObjectMeta.
+    string name = 1;
+    // Pod UID of the sandbox. Same as the pod UID in the Pod ObjectMeta.
+    string uid = 2;
+    // Pod namespace of the sandbox. Same as the pod namespace in the Pod ObjectMeta.
+    string namespace = 3;
+    // Attempt number of creating the sandbox. Default: 0.
+    uint32 attempt = 4;
+}
+
+message PodSandboxStatusRequest {
+    // ID of the PodSandbox for which to retrieve status.
+    string pod_sandbox_id = 1;
+    // Verbose indicates whether to return extra information about the pod sandbox.
+    bool verbose = 2;
+}
+
+// PodIP represents an ip of a Pod
+message PodIP{
+    // an ip is a string representation of an IPv4 or an IPv6
+    string ip = 1;
+}
+// PodSandboxNetworkStatus is the status of the network for a PodSandbox.
+// Currently ignored for pods sharing the host networking namespace.
+message PodSandboxNetworkStatus {
+    // IP address of the PodSandbox.
+    string ip = 1;
+    // list of additional ips (not inclusive of PodSandboxNetworkStatus.Ip) of the PodSandBoxNetworkStatus
+    repeated PodIP additional_ips  = 2;
+}
+
+// Namespace contains paths to the namespaces.
+message Namespace {
+    // Namespace options for Linux namespaces.
+    NamespaceOption options = 2;
+}
+
+// LinuxSandboxStatus contains status specific to Linux sandboxes.
+message LinuxPodSandboxStatus {
+    // Paths to the sandbox's namespaces.
+    Namespace namespaces = 1;
+}
+
+enum PodSandboxState {
+    SANDBOX_READY    = 0;
+    SANDBOX_NOTREADY = 1;
+}
+
+// PodSandboxStatus contains the status of the PodSandbox.
+message PodSandboxStatus {
+    // ID of the sandbox.
+    string id = 1;
+    // Metadata of the sandbox.
+    PodSandboxMetadata metadata = 2;
+    // State of the sandbox.
+    PodSandboxState state = 3;
+    // Creation timestamp of the sandbox in nanoseconds. Must be > 0.
+    int64 created_at = 4;
+    // Network contains network status if network is handled by the runtime.
+    PodSandboxNetworkStatus network = 5;
+    // Linux-specific status to a pod sandbox.
+    LinuxPodSandboxStatus linux = 6;
+    // Labels are key-value pairs that may be used to scope and select individual resources.
+    map<string, string> labels = 7;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding PodSandboxConfig used to
+    // instantiate the pod sandbox this status represents.
+    map<string, string> annotations = 8;
+    // runtime configuration used for this PodSandbox.
+    string runtime_handler = 9;
+}
+
+message PodSandboxStatusResponse {
+    // Status of the PodSandbox.
+    PodSandboxStatus status = 1;
+    // Info is extra information of the PodSandbox. The key could be arbitrary string, and
+    // value should be in json format. The information could include anything useful for
+    // debug, e.g. network namespace for linux container based container runtime.
+    // It should only be returned non-empty when Verbose is true.
+    map<string, string> info = 2;
+    // Container statuses
+    repeated ContainerStatus containers_statuses = 3;
+    // Timestamp in nanoseconds at which container and pod statuses were recorded
+    int64 timestamp = 4;
+}
+
+// PodSandboxStateValue is the wrapper of PodSandboxState.
+message PodSandboxStateValue {
+    // State of the sandbox.
+    PodSandboxState state = 1;
+}
+
+// PodSandboxFilter is used to filter a list of PodSandboxes.
+// All those fields are combined with 'AND'
+message PodSandboxFilter {
+    // ID of the sandbox.
+    string id = 1;
+    // State of the sandbox.
+    PodSandboxStateValue state = 2;
+    // LabelSelector to select matches.
+    // Only api.MatchLabels is supported for now and the requirements
+    // are ANDed. MatchExpressions is not supported yet.
+    map<string, string> label_selector = 3;
+}
+
+message ListPodSandboxRequest {
+    // PodSandboxFilter to filter a list of PodSandboxes.
+    PodSandboxFilter filter = 1;
+}
+
+// PodSandbox contains minimal information about a sandbox.
+message PodSandbox {
+    // ID of the PodSandbox.
+    string id = 1;
+    // Metadata of the PodSandbox.
+    PodSandboxMetadata metadata = 2;
+    // State of the PodSandbox.
+    PodSandboxState state = 3;
+    // Creation timestamps of the PodSandbox in nanoseconds. Must be > 0.
+    int64 created_at = 4;
+    // Labels of the PodSandbox.
+    map<string, string> labels = 5;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding PodSandboxConfig used to
+    // instantiate this PodSandbox.
+    map<string, string> annotations = 6;
+    // runtime configuration used for this PodSandbox.
+    string runtime_handler = 7;
+}
+
+message ListPodSandboxResponse {
+    // List of PodSandboxes.
+    repeated PodSandbox items = 1;
+}
+
+// ImageSpec is an internal representation of an image.
+message ImageSpec {
+    // Container's Image field (e.g. imageID or imageDigest).
+    string image = 1;
+    // Unstructured key-value map holding arbitrary metadata.
+    // ImageSpec Annotations can be used to help the runtime target specific
+    // images in multi-arch images.
+    map<string, string> annotations = 2;
+    // The container image reference specified by the user (e.g. image[:tag] or digest).
+    // Only set if available within the RPC context.
+    string user_specified_image = 18;
+    // Runtime handler to use for pulling the image.
+    // If the runtime handler is unknown, the request should be rejected.
+    // An empty string would select the default runtime handler.
+    string runtime_handler = 19;
+}
+
+message KeyValue {
+    string key = 1;
+    string value = 2;
+}
+
+// LinuxContainerResources specifies Linux specific configuration for
+// resources.
+message LinuxContainerResources {
+    // CPU CFS (Completely Fair Scheduler) period. Default: 0 (not specified).
+    int64 cpu_period = 1;
+    // CPU CFS (Completely Fair Scheduler) quota. Default: 0 (not specified).
+    int64 cpu_quota = 2;
+    // CPU shares (relative weight vs. other containers). Default: 0 (not specified).
+    int64 cpu_shares = 3;
+    // Memory limit in bytes. Default: 0 (not specified).
+    int64 memory_limit_in_bytes = 4;
+    // OOMScoreAdj adjusts the oom-killer score. Default: 0 (not specified).
+    int64 oom_score_adj = 5;
+    // CpusetCpus constrains the allowed set of logical CPUs. Default: "" (not specified).
+    string cpuset_cpus = 6;
+    // CpusetMems constrains the allowed set of memory nodes. Default: "" (not specified).
+    string cpuset_mems = 7;
+    // List of HugepageLimits to limit the HugeTLB usage of container per page size. Default: nil (not specified).
+    repeated HugepageLimit hugepage_limits = 8;
+    // Unified resources for cgroup v2. Default: nil (not specified).
+    // Each key/value in the map refers to the cgroup v2.
+    // e.g. "memory.max": "6937202688" or "io.weight": "default 100".
+    map<string, string> unified = 9;
+    // Memory swap limit in bytes. Default 0 (not specified).
+    int64 memory_swap_limit_in_bytes = 10;
+}
+
+// HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
+// For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
+message HugepageLimit {
+    // The value of PageSize has the format <size><unit-prefix>B (2MB, 1GB),
+    // and must match the <hugepagesize> of the corresponding control file found in `hugetlb.<hugepagesize>.limit_in_bytes`.
+    // The values of <unit-prefix> are intended to be parsed using base 1024("1KB" = 1024, "1MB" = 1048576, etc).
+    string page_size = 1;
+    // limit in bytes of hugepagesize HugeTLB usage.
+    uint64 limit = 2;
+}
+
+// SELinuxOption are the labels to be applied to the container.
+message SELinuxOption {
+    string user = 1;
+    string role = 2;
+    string type = 3;
+    string level = 4;
+}
+
+// Capability contains the container capabilities to add or drop
+// Dropping a capability will drop it from all sets.
+// If a capability is added to only the add_capabilities list then it gets added to permitted,
+// inheritable, effective and bounding sets, i.e. all sets except the ambient set.
+// If a capability is added to only the add_ambient_capabilities list then it gets added to all sets, i.e permitted
+// inheritable, effective, bounding and ambient sets.
+// If a capability is added to add_capabilities and add_ambient_capabilities lists then it gets added to all sets, i.e.
+// permitted, inheritable, effective, bounding and ambient sets.
+message Capability {
+    // List of capabilities to add.
+    repeated string add_capabilities = 1;
+    // List of capabilities to drop.
+    repeated string drop_capabilities = 2;
+    // List of ambient capabilities to add.
+    repeated string add_ambient_capabilities = 3;
+}
+
+// LinuxContainerSecurityContext holds linux security configuration that will be applied to a container.
+message LinuxContainerSecurityContext {
+    // Capabilities to add or drop.
+    Capability capabilities = 1;
+    // If set, run container in privileged mode.
+    // Privileged mode is incompatible with the following options. If
+    // privileged is set, the following features MAY have no effect:
+    // 1. capabilities
+    // 2. selinux_options
+    // 4. seccomp
+    // 5. apparmor
+    //
+    // Privileged mode implies the following specific options are applied:
+    // 1. All capabilities are added.
+    // 2. Sensitive paths, such as kernel module paths within sysfs, are not masked.
+    // 3. Any sysfs and procfs mounts are mounted RW.
+    // 4. AppArmor confinement is not applied.
+    // 5. Seccomp restrictions are not applied.
+    // 6. The device cgroup does not restrict access to any devices.
+    // 7. All devices from the host's /dev are available within the container.
+    // 8. SELinux restrictions are not applied (e.g. label=disabled).
+    bool privileged = 2;
+    // Configurations for the container's namespaces.
+    // Only used if the container uses namespace for isolation.
+    NamespaceOption namespace_options = 3;
+    // SELinux context to be optionally applied.
+    SELinuxOption selinux_options = 4;
+    // UID to run the container process as. Only one of run_as_user and
+    // run_as_username can be specified at a time.
+    Int64Value run_as_user = 5;
+    // GID to run the container process as. run_as_group should only be specified
+    // when run_as_user or run_as_username is specified; otherwise, the runtime
+    // MUST error.
+    Int64Value run_as_group = 12;
+    // User name to run the container process as. If specified, the user MUST
+    // exist in the container image (i.e. in the /etc/passwd inside the image),
+    // and be resolved there by the runtime; otherwise, the runtime MUST error.
+    string run_as_username = 6;
+    // If set, the root filesystem of the container is read-only.
+    bool readonly_rootfs = 7;
+    // List of groups applied to the first process run in each container.
+    // supplemental_groups_policy can control how groups will be calculated.
+    repeated int64 supplemental_groups = 8;
+    // supplemental_groups_policy defines how supplemental groups of the first 
+    // container processes are calculated.
+    // Valid values are "Merge" and "Strict".
+    // If not specified, "Merge" is used.
+    SupplementalGroupsPolicy supplemental_groups_policy = 17;
+    // no_new_privs defines if the flag for no_new_privs should be set on the
+    // container.
+    bool no_new_privs = 11;
+    // masked_paths is a slice of paths that should be masked by the container
+    // runtime, this can be passed directly to the OCI spec.
+    repeated string masked_paths = 13;
+    // readonly_paths is a slice of paths that should be set as readonly by the
+    // container runtime, this can be passed directly to the OCI spec.
+    repeated string readonly_paths = 14;
+    // Seccomp profile for the container.
+    SecurityProfile seccomp = 15;
+    // AppArmor profile for the container.
+    SecurityProfile apparmor = 16;
+    // AppArmor profile for the container, candidate values are:
+    // * runtime/default: equivalent to not specifying a profile.
+    // * unconfined: no profiles are loaded
+    // * localhost/<profile_name>: profile loaded on the node
+    //    (localhost) by name. The possible profile names are detailed at
+    //    https://gitlab.com/apparmor/apparmor/-/wikis/AppArmor_Core_Policy_Reference
+    string apparmor_profile = 9 [deprecated=true];
+    // Seccomp profile for the container, candidate values are:
+    // * runtime/default: the default profile for the container runtime
+    // * unconfined: unconfined profile, ie, no seccomp sandboxing
+    // * localhost/<full-path-to-profile>: the profile installed on the node.
+    //   <full-path-to-profile> is the full path of the profile.
+    // Default: "", which is identical with unconfined.
+    string seccomp_profile_path = 10 [deprecated=true];
+}
+
+// LinuxContainerConfig contains platform-specific configuration for
+// Linux-based containers.
+message LinuxContainerConfig {
+    // Resources specification for the container.
+    LinuxContainerResources resources = 1;
+    // LinuxContainerSecurityContext configuration for the container.
+    LinuxContainerSecurityContext security_context = 2;
+}
+
+message LinuxContainerUser {
+    // uid is the primary uid initially attached to the first process in the container
+    int64 uid = 1;
+    // gid is the primary gid initially attached to the first process in the container
+    int64 gid = 2;
+    // supplemental_groups are the supplemental groups initially attached to the first process in the container
+    repeated int64 supplemental_groups = 3;
+}
+
+// ContainerMetadata holds all necessary information for building the container
+// name. The container runtime is encouraged to expose the metadata in its user
+// interface for better user experience. E.g., runtime can construct a unique
+// container name based on the metadata. Note that (name, attempt) is unique
+// within a sandbox for the entire lifetime of the sandbox.
+message ContainerMetadata {
+    // Name of the container. Same as the container name in the PodSpec.
+    string name = 1;
+    // Attempt number of creating the container. Default: 0.
+    uint32 attempt = 2;
+}
+
+enum Signal {
+    RUNTIME_DEFAULT   = 0;
+    SIGABRT           = 1;
+    SIGALRM           = 2;
+    SIGBUS            = 3;
+    SIGCHLD           = 4;
+    SIGCLD            = 5;
+    SIGCONT           = 6;
+    SIGFPE            = 7;
+    SIGHUP            = 8;
+    SIGILL            = 9;
+    SIGINT            = 10;
+    SIGIO             = 11;
+    SIGIOT            = 12;
+    SIGKILL           = 13;
+    SIGPIPE           = 14;
+    SIGPOLL           = 15;
+    SIGPROF           = 16;
+    SIGPWR            = 17;
+    SIGQUIT           = 18;
+    SIGSEGV           = 19;
+    SIGSTKFLT         = 20;
+    SIGSTOP           = 21;
+    SIGSYS            = 22;
+    SIGTERM           = 23;
+    SIGTRAP           = 24;
+    SIGTSTP           = 25;
+    SIGTTIN           = 26;
+    SIGTTOU           = 27;
+    SIGURG            = 28;
+    SIGUSR1           = 29;
+    SIGUSR2           = 30;
+    SIGVTALRM         = 31;
+    SIGWINCH          = 32;
+    SIGXCPU           = 33;
+    SIGXFSZ           = 34;
+    SIGRTMIN          = 35;
+    SIGRTMINPLUS1     = 36;
+    SIGRTMINPLUS2     = 37;
+    SIGRTMINPLUS3     = 38;
+    SIGRTMINPLUS4     = 39;
+    SIGRTMINPLUS5     = 40;
+    SIGRTMINPLUS6     = 41;
+    SIGRTMINPLUS7     = 42;
+    SIGRTMINPLUS8     = 43;
+    SIGRTMINPLUS9     = 44;
+    SIGRTMINPLUS10    = 45;
+    SIGRTMINPLUS11    = 46;
+    SIGRTMINPLUS12    = 47;
+    SIGRTMINPLUS13    = 48;
+    SIGRTMINPLUS14    = 49;
+    SIGRTMINPLUS15    = 50;
+    SIGRTMAXMINUS14   = 51;
+    SIGRTMAXMINUS13   = 52;
+    SIGRTMAXMINUS12   = 53;
+    SIGRTMAXMINUS11   = 54;
+    SIGRTMAXMINUS10   = 55;
+    SIGRTMAXMINUS9    = 56;
+    SIGRTMAXMINUS8    = 57;
+    SIGRTMAXMINUS7    = 58;
+    SIGRTMAXMINUS6    = 59;
+    SIGRTMAXMINUS5    = 60;
+    SIGRTMAXMINUS4    = 61;
+    SIGRTMAXMINUS3    = 62;
+    SIGRTMAXMINUS2    = 63;
+    SIGRTMAXMINUS1    = 64;
+    SIGRTMAX          = 65;
+}
+
+enum ContainerState {
+    CONTAINER_CREATED = 0;
+    CONTAINER_RUNNING = 1;
+    CONTAINER_EXITED  = 2;
+    CONTAINER_UNKNOWN = 3;
+}
+
+// ContainerStateValue is the wrapper of ContainerState.
+message ContainerStateValue {
+    // State of the container.
+    ContainerState state = 1;
+}
+
+// ContainerFilter is used to filter containers.
+// All those fields are combined with 'AND'
+message ContainerFilter {
+    // ID of the container.
+    string id = 1;
+    // State of the container.
+    ContainerStateValue state = 2;
+    // ID of the PodSandbox.
+    string pod_sandbox_id = 3;
+    // LabelSelector to select matches.
+    // Only api.MatchLabels is supported for now and the requirements
+    // are ANDed. MatchExpressions is not supported yet.
+    map<string, string> label_selector = 4;
+}
+
+message ListContainersRequest {
+    ContainerFilter filter = 1;
+}
+
+// Container provides the runtime information for a container, such as ID, hash,
+// state of the container.
+message Container {
+    // ID of the container, used by the container runtime to identify
+    // a container.
+    string id = 1;
+    // ID of the sandbox to which this container belongs.
+    string pod_sandbox_id = 2;
+    // Metadata of the container.
+    ContainerMetadata metadata = 3;
+    // Spec of the image.
+    ImageSpec image = 4;
+    // Digested reference to the image in use.
+    string image_ref = 5;
+    // State of the container.
+    ContainerState state = 6;
+    // Creation time of the container in nanoseconds.
+    int64 created_at = 7;
+    // Key-value pairs that may be used to scope and select individual resources.
+    map<string, string> labels = 8;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding ContainerConfig used to
+    // instantiate this Container.
+    map<string, string> annotations = 9;
+    // Reference to the unique identifier of the image, on the node, as
+    // returned in the image service apis.
+    //
+    // Note: The image_ref above has been historically used by container
+    // runtimes to reference images by digest. The image_ref has been also used
+    // in the kubelet image garbage collection, which does not work with
+    // digests at all. To separate and avoid possible misusage, we now
+    // introduce the image_id field, which should always refer to a unique
+    // image identifier on the node.
+    string image_id = 10;
+}
+
+message ListContainersResponse {
+    // List of containers.
+    repeated Container containers = 1;
+}
+
+message ContainerStatusRequest {
+    // ID of the container for which to retrieve status.
+    string container_id = 1;
+    // Verbose indicates whether to return extra information about the container.
+    bool verbose = 2;
+}
+
+// ContainerStatus represents the status of a container.
+message ContainerStatus {
+    // ID of the container.
+    string id = 1;
+    // Metadata of the container.
+    ContainerMetadata metadata = 2;
+    // Status of the container.
+    ContainerState state = 3;
+    // Creation time of the container in nanoseconds.
+    int64 created_at = 4;
+    // Start time of the container in nanoseconds. Default: 0 (not specified).
+    int64 started_at = 5;
+    // Finish time of the container in nanoseconds. Default: 0 (not specified).
+    int64 finished_at = 6;
+    // Exit code of the container. Only required when finished_at != 0. Default: 0.
+    int32 exit_code = 7;
+    // Spec of the image.
+    ImageSpec image = 8;
+    // Digested reference to the image in use.
+    string image_ref = 9;
+    // Brief CamelCase string explaining why container is in its current state.
+    // Must be set to "OOMKilled" for containers terminated by cgroup-based Out-of-Memory killer.
+    string reason = 10;
+    // Human-readable message indicating details about why container is in its
+    // current state.
+    string message = 11;
+    // Key-value pairs that may be used to scope and select individual resources.
+    map<string,string> labels = 12;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding ContainerConfig used to
+    // instantiate the Container this status represents.
+    map<string,string> annotations = 13;
+    // Mounts for the container.
+    repeated Mount mounts = 14;
+    // Log path of container.
+    string log_path = 15;
+    // Resource limits configuration of the container.
+    ContainerResources resources = 16;
+    // Reference to the unique identifier of the image, on the node, as
+    // returned in the image service apis.
+    //
+    // Note: The image_ref above has been historically used by container
+    // runtimes to reference images by digest. To separate and avoid possible
+    // misusage, we now introduce the image_id field, which should always refer
+    // to a unique image identifier on the node.
+    string image_id = 17;
+    // User identities initially attached to the container
+    ContainerUser user = 18;
+
+    // Returns the stop signal used by the container runtime to terminate the container 
+    Signal stop_signal = 19;
+}
+
+message ContainerStatusResponse {
+    // Status of the container.
+    ContainerStatus status = 1;
+    // Info is extra information of the Container. The key could be arbitrary string, and
+    // value should be in json format. The information could include anything useful for
+    // debug, e.g. pid for linux container based container runtime.
+    // It should only be returned non-empty when Verbose is true.
+    map<string, string> info = 2;
+}
+
+// ContainerResources holds resource limits configuration for a container.
+message ContainerResources {
+    // Resource limits configuration specific to Linux container.
+    LinuxContainerResources linux = 1;
+}
+
+message ContainerUser {
+    // User identities initially attached to first process in the Linux container.
+    // Note that the actual running identity can be changed if the process has enough privilege to do so.
+    LinuxContainerUser linux = 1;
+
+    // User identities initially attached to first process in the Windows container
+    // This is just reserved for future use.
+    // WindowsContainerUser windows = 2;
+}
+
+// RuntimeCondition contains condition information for the runtime.
+// There are 2 kinds of runtime conditions:
+// 1. Required conditions: Conditions are required for kubelet to work
+// properly. If any required condition is unmet, the node will be not ready.
+// The required conditions include:
+//   * RuntimeReady: RuntimeReady means the runtime is up and ready to accept
+//   basic containers e.g. container only needs host network.
+//   * NetworkReady: NetworkReady means the runtime network is up and ready to
+//   accept containers which require container network.
+// 2. Optional conditions: Conditions are informative to the user, but kubelet
+// will not rely on. Since condition type is an arbitrary string, all conditions
+// not required are optional. These conditions will be exposed to users to help
+// them understand the status of the system.
+message RuntimeCondition {
+    // Type of runtime condition.
+    string type = 1;
+    // Status of the condition, one of true/false. Default: false.
+    bool status = 2;
+    // Brief CamelCase string containing reason for the condition's last transition.
+    string reason = 3;
+    // Human-readable message indicating details about last transition.
+    string message = 4;
+}
+
+// RuntimeStatus is information about the current status of the runtime.
+message RuntimeStatus {
+    // List of current observed runtime conditions.
+    repeated RuntimeCondition conditions = 1;
+}
+
+message StatusRequest {
+    // Verbose indicates whether to return extra information about the runtime.
+    bool verbose = 1;
+}
+
+// RuntimeHandlerFeatures is a set of features implemented by the runtime handler.
+message RuntimeHandlerFeatures {
+    // recursive_read_only_mounts is set to true if the runtime handler supports
+    // recursive read-only mounts.
+    // For runc-compatible runtimes, availability of this feature can be detected by checking whether
+    // the Linux kernel version is >= 5.12, and,  `runc features | jq .mountOptions` contains "rro".
+    bool recursive_read_only_mounts = 1;
+
+    // user_namespaces is set to true if the runtime handler supports user namespaces as implemented
+    // in Kubernetes. This means support for both, user namespaces and idmap mounts.
+    bool user_namespaces = 2;
+}
+
+message RuntimeHandler {
+    // Name must be unique in StatusResponse.
+    // An empty string denotes the default handler.
+    string name = 1;
+    // Supported features.
+    RuntimeHandlerFeatures features = 2;
+}
+
+// RuntimeFeatures describes the set of features implemented by the CRI implementation.
+// The features contained in the RuntimeFeatures should depend only on the cri implementation
+// independent of runtime handlers.
+message RuntimeFeatures {
+    // supplemental_groups_policy is set to true if the runtime supports SupplementalGroupsPolicy and ContainerUser.
+    bool supplemental_groups_policy = 1;
+}
+
+message StatusResponse {
+    // Status of the Runtime.
+    RuntimeStatus status = 1;
+    // Info is extra information of the Runtime. The key could be arbitrary string, and
+    // value should be in json format. The information could include anything useful for
+    // debug, e.g. plugins used by the container runtime.
+    // It should only be returned non-empty when Verbose is true.
+    map<string, string> info = 2;
+    // Runtime handlers.
+    repeated RuntimeHandler runtime_handlers = 3;
+    // features describes the set of features implemented by the CRI implementation.
+    // This field is supposed to propagate to NodeFeatures in Kubernetes API.
+    RuntimeFeatures features = 4;
+}

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -515,11 +515,14 @@ mod tests {
         });
         for i in 0..2 {
             manager
-                .fetch_certificate(&identity::Identity::Spiffe {
-                    trust_domain: "trust_domain".into(),
-                    namespace: "namespace".into(),
-                    service_account: strng::format!("sa-{i}"),
-                })
+                .fetch_certificate(
+                    &identity::Identity::Spiffe {
+                        trust_domain: "trust_domain".into(),
+                        namespace: "namespace".into(),
+                        service_account: strng::format!("sa-{i}"),
+                    }
+                    .to_composite_id(),
+                )
                 .await
                 .unwrap();
             // Make sure certificates are a significant amount of time apart, for better
@@ -528,7 +531,9 @@ mod tests {
         }
 
         manager
-            .fetch_certificate(&identity("spiffe://error/ns/forgotten/sa/sa-failed"))
+            .fetch_certificate(
+                &identity("spiffe://error/ns/forgotten/sa/sa-failed").to_composite_id(),
+            )
             .await
             .unwrap_err();
 
@@ -536,7 +541,9 @@ mod tests {
         let pending_manager = manager.clone();
         let pending_fetch = tokio::task::spawn(async move {
             pending_manager
-                .fetch_certificate(&identity("spiffe://test/ns/test/sa/sa-pending"))
+                .fetch_certificate(
+                    &identity("spiffe://test/ns/test/sa/sa-pending").to_composite_id(),
+                )
                 .await
         });
         tokio::time::sleep(Duration::from_nanos(1)).await;

--- a/src/cert_fetcher.rs
+++ b/src/cert_fetcher.rs
@@ -15,7 +15,7 @@
 use crate::config;
 use crate::config::ProxyMode;
 use crate::identity::Priority::Warmup;
-use crate::identity::{CompositeId, Request, RequestKeyEnum, SecretManager};
+use crate::identity::{CompositeId, Request, RequestKey, SecretManager};
 use crate::inpod::WorkloadUid;
 use crate::state::workload::{InboundProtocol, Workload};
 use std::sync::Arc;
@@ -102,14 +102,14 @@ impl CertFetcherImpl {
             (w.native_tunnel || w.protocol == InboundProtocol::HBONE && !self.cfg.spire_enabled)
     }
 
-    fn build_key(&self, w: &Workload) -> CompositeId<RequestKeyEnum> {
+    fn build_key(&self, w: &Workload) -> CompositeId<RequestKey> {
         if self.cfg.spire_enabled {
             CompositeId::new(
                 w.identity(),
-                RequestKeyEnum::Workload(WorkloadUid::new(w.uid.to_string())),
+                RequestKey::Workload(WorkloadUid::new(w.uid.to_string())),
             )
         } else {
-            CompositeId::new(w.identity(), RequestKeyEnum::Identity(w.identity().clone()))
+            CompositeId::new(w.identity(), RequestKey::Identity(w.identity().clone()))
         }
     }
 }

--- a/src/cert_fetcher.rs
+++ b/src/cert_fetcher.rs
@@ -15,7 +15,8 @@
 use crate::config;
 use crate::config::ProxyMode;
 use crate::identity::Priority::Warmup;
-use crate::identity::{Identity, Request, SecretManager};
+use crate::identity::{CompositeId, Request, RequestKeyEnum, SecretManager};
+use crate::inpod::WorkloadUid;
 use crate::state::workload::{InboundProtocol, Workload};
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -24,7 +25,7 @@ use tracing::{debug, error, info};
 /// Responsible for pre-fetching certs for workloads.
 pub trait CertFetcher: Send + Sync {
     fn prefetch_cert(&self, w: &Workload);
-    fn clear_cert(&self, id: &Identity);
+    fn clear_cert(&self, w: &Workload);
 }
 
 /// A no-op implementation of [CertFetcher].
@@ -32,7 +33,7 @@ pub struct NoCertFetcher();
 
 impl CertFetcher for NoCertFetcher {
     fn prefetch_cert(&self, _: &Workload) {}
-    fn clear_cert(&self, _: &Identity) {}
+    fn clear_cert(&self, _: &Workload) {}
 }
 
 /// Constructs an appropriate [CertFetcher] for the proxy config.
@@ -48,6 +49,7 @@ struct CertFetcherImpl {
     proxy_mode: ProxyMode,
     local_node: Option<String>,
     tx: mpsc::Sender<Request>,
+    cfg: config::Config,
 }
 
 impl CertFetcherImpl {
@@ -84,6 +86,7 @@ impl CertFetcherImpl {
             proxy_mode: cfg.proxy_mode,
             local_node: cfg.local_node.clone(),
             tx,
+            cfg: cfg.clone(),
         }
     }
 
@@ -96,21 +99,36 @@ impl CertFetcherImpl {
             // We only get certs for our own node
             Some(w.node.as_ref()) == self.local_node.as_deref() &&
             // If it doesn't support HBONE it *probably* doesn't need a cert.
-            (w.native_tunnel || w.protocol == InboundProtocol::HBONE)
+            (w.native_tunnel || w.protocol == InboundProtocol::HBONE && !self.cfg.spire_enabled)
+    }
+
+    fn build_key(&self, w: &Workload) -> CompositeId<RequestKeyEnum> {
+        if self.cfg.spire_enabled {
+            CompositeId::new(
+                w.identity(),
+                RequestKeyEnum::Workload(WorkloadUid::new(w.uid.to_string())),
+            )
+        } else {
+            CompositeId::new(w.identity(), RequestKeyEnum::Identity(w.identity().clone()))
+        }
     }
 }
 
 impl CertFetcher for CertFetcherImpl {
     fn prefetch_cert(&self, w: &Workload) {
-        if self.should_prefetch_certificate(w)
-            && let Err(e) = self.tx.try_send(Request::Fetch(w.identity(), Warmup))
-        {
-            info!("couldn't prefetch: {:?}", e)
+        if self.should_prefetch_certificate(w) {
+            let key = self.build_key(w);
+
+            if let Err(e) = self.tx.try_send(Request::Fetch(key, Warmup)) {
+                info!("couldn't prefetch: {:?}", e)
+            }
         }
     }
 
-    fn clear_cert(&self, id: &Identity) {
-        if let Err(e) = self.tx.try_send(Request::Forget(id.clone())) {
+    fn clear_cert(&self, w: &Workload) {
+        let key = self.build_key(w);
+
+        if let Err(e) = self.tx.try_send(Request::Forget(key)) {
             info!("couldn't clear identity: {:?}", e)
         }
     }

--- a/src/cert_fetcher.rs
+++ b/src/cert_fetcher.rs
@@ -99,7 +99,7 @@ impl CertFetcherImpl {
             // We only get certs for our own node
             Some(w.node.as_ref()) == self.local_node.as_deref() &&
             // If it doesn't support HBONE it *probably* doesn't need a cert.
-            (w.native_tunnel || w.protocol == InboundProtocol::HBONE && !self.cfg.spire_enabled)
+            (w.native_tunnel || w.protocol == InboundProtocol::HBONE) && !self.cfg.spire_enabled
     }
 
     fn build_key(&self, w: &Workload) -> CompositeId<RequestKey> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -775,10 +775,8 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             bind_wildcard,
             pc.stats_port.unwrap_or(DEFAULT_STATS_PORT),
         )),
-        readiness_addr: Address::SocketAddr(SocketAddr::new(
-            bind_wildcard,
-            DEFAULT_READINESS_PORT, // There is no config for this in ProxyConfig currently
-        )),
+        // readiness probe should only be accessible over localhost (kubelet runs on same node)
+        readiness_addr: Address::Localhost(ipv6_localhost_enabled, DEFAULT_READINESS_PORT),
 
         socks5_addr,
         inbound_addr,

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,6 +122,13 @@ pub static AUTHZ_POLICY_INFO_LOGGING: once_cell::sync::Lazy<bool> =
     once_cell::sync::Lazy::new(|| {
         env::var("AUTHZ_POLICY_INFO_LOGGING").unwrap_or_default() == "true"
     });
+const SPIRE_ENABLED: &str = "SPIRE_ENABLED";
+
+const SPIRE_TIMEOUT: &str = "SPIRE_TIMEOUT";
+
+const SPIRE_ADMIN_SOCKET: &str = "SPIRE_ADMIN_ENDPOINT_SOCKET";
+
+const CONTAINER_RUNTIME_SOCK_PATH: &str = "CONTAINER_RUNTIME_SOCK_PATH";
 
 #[derive(serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum RootCert {
@@ -324,6 +331,10 @@ pub struct Config {
     // path to CRL file; if set, enables CRL checking
     pub crl_path: Option<PathBuf>,
     pub enable_enhanced_baggage: bool,
+    pub spire_enabled: bool,
+    pub spire_timeout: Duration,
+    pub spire_admin_socket: String,
+    pub container_runtime_sock_path: String,
 }
 
 #[derive(serde::Serialize, Clone, Copy, Debug)]
@@ -882,6 +893,16 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             .filter(|s| !s.is_empty())
             .map(PathBuf::from),
         enable_enhanced_baggage: parse_default(ENABLE_ENHANCED_BAGGAGE, true)?,
+        spire_enabled: parse_default(SPIRE_ENABLED, false)?,
+        container_runtime_sock_path: parse_default(
+            CONTAINER_RUNTIME_SOCK_PATH,
+            "/run/containerd/containerd.sock".to_string(),
+        )?,
+        spire_timeout: parse_duration_default(SPIRE_TIMEOUT, Duration::from_secs(10))?,
+        spire_admin_socket: parse_default(
+            SPIRE_ADMIN_SOCKET,
+            "unix:///run/spire/sockets/admin.sock".to_string(),
+        )?,
     })
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -906,11 +906,25 @@ fn validate_uri(uri_str: Option<String>) -> Result<Option<String>, Error> {
     let Some(uri_str) = uri_str else {
         return Ok(uri_str);
     };
-    let uri = Uri::try_from(&uri_str)?;
-    if uri.scheme().is_none() {
-        return Ok(Some("https://".to_owned() + &uri_str));
+    // Unix socket URIs are not supported by hyper's Uri parser, so handle them separately.
+    // Only absolute paths are accepted (e.g., unix:///path or unix:/path).
+    if uri_str.starts_with("unix:") {
+        if crate::tls::unix_socket_path(&uri_str).is_some() {
+            return Ok(Some(uri_str));
+        }
+        return Err(Error::ProxyConfig(anyhow::anyhow!(
+            "unix URI must include an absolute socket path (e.g., unix:///run/sock)"
+        )));
     }
-    Ok(Some(uri_str))
+    let uri = Uri::try_from(&uri_str)?;
+    match uri.scheme_str() {
+        Some("https") | Some("http") => Ok(Some(uri_str)),
+        None => Ok(Some("https://".to_owned() + &uri_str)), // Default to https
+        Some(scheme) => Err(Error::ProxyConfig(anyhow::anyhow!(
+            "unsupported URI scheme: {}",
+            scheme
+        ))),
+    }
 }
 
 #[derive(serde::Deserialize, Default, Clone, PartialEq, Eq)]
@@ -1186,6 +1200,56 @@ pub mod tests {
             let value: AsciiMetadataValue = AsciiMetadataValue::from_str(&v).unwrap();
             assert!(metadata.vec.contains(&(key, value)));
         }
+    }
+
+    #[test]
+    fn test_validate_uri_unix_schemes() {
+        // unix:///path - standard triple-slash form
+        assert_eq!(
+            validate_uri(Some("unix:///run/spire/sockets/agent.sock".to_string())).unwrap(),
+            Some("unix:///run/spire/sockets/agent.sock".to_string())
+        );
+
+        // unix:/path - single-slash form
+        assert_eq!(
+            validate_uri(Some("unix:/run/sockets/agent.sock".to_string())).unwrap(),
+            Some("unix:/run/sockets/agent.sock".to_string())
+        );
+
+        // relative path - rejected (unix://relative is not an absolute path)
+        assert!(validate_uri(Some("unix://run/sockets/agent.sock".to_string())).is_err());
+
+        // empty path - rejected
+        assert!(validate_uri(Some("unix:".to_string())).is_err());
+        assert!(validate_uri(Some("unix://".to_string())).is_err());
+        assert!(validate_uri(Some("unix:///".to_string())).is_err());
+    }
+
+    #[test]
+    fn test_validate_uri_existing_schemes() {
+        // https - accepted unchanged
+        assert_eq!(
+            validate_uri(Some("https://istiod:15012".to_string())).unwrap(),
+            Some("https://istiod:15012".to_string())
+        );
+
+        // http - accepted unchanged
+        assert_eq!(
+            validate_uri(Some("http://localhost:15012".to_string())).unwrap(),
+            Some("http://localhost:15012".to_string())
+        );
+
+        // No scheme - defaults to https://
+        assert_eq!(
+            validate_uri(Some("istiod:15012".to_string())).unwrap(),
+            Some("https://istiod:15012".to_string())
+        );
+
+        // None input - returns None
+        assert_eq!(validate_uri(None).unwrap(), None);
+
+        // Unsupported scheme - returns error
+        assert!(validate_uri(Some("ftp://example.com".to_string())).is_err());
     }
 
     #[test]

--- a/src/container_runtime.rs
+++ b/src/container_runtime.rs
@@ -1,0 +1,432 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use cri::runtime_service_client::RuntimeServiceClient;
+use hyper_util::rt::TokioIo;
+use tokio::net::UnixStream;
+use tonic::transport::Uri;
+use tonic::{
+    async_trait,
+    transport::{Channel, Endpoint},
+};
+use tower::service_fn;
+
+use crate::{
+    config::Config,
+    container_runtime::cri::{ContainerStatusRequest, ListContainersRequest},
+    identity::{PidClientTrait, WorkloadPid},
+    inpod::WorkloadUid,
+};
+
+pub mod cri {
+    tonic::include_proto!("runtime.v1"); // matches package name in proto
+}
+
+pub struct ContainerRuntimeManager {
+    runtime_client: RuntimeServiceClient<Channel>,
+}
+
+impl ContainerRuntimeManager {
+    pub async fn new(cfg: &Config) -> Result<Self, std::io::Error> {
+        let path = cfg.container_runtime_sock_path.clone();
+
+        let channel = Self::uds_channel(path)
+            .await
+            .map_err(|e| std::io::Error::other(format!("Failed to create UDS channel: {}", e)))?;
+
+        let client = RuntimeServiceClient::new(channel);
+
+        Ok(ContainerRuntimeManager {
+            runtime_client: client,
+        })
+    }
+
+    pub fn new_with_client(client: RuntimeServiceClient<Channel>) -> Self {
+        ContainerRuntimeManager {
+            runtime_client: client,
+        }
+    }
+
+    async fn uds_channel(path: String) -> Result<Channel, tonic::transport::Error> {
+        let endpoint =
+            Endpoint::try_from("http://[::1]:50051")?
+                .connect_with_connector(service_fn(move |_: Uri| {
+                    let path = path.clone();
+                    async move {
+                        Ok::<_, std::io::Error>(TokioIo::new(UnixStream::connect(path).await?))
+                    }
+                }))
+                .await?;
+        Ok(endpoint)
+    }
+
+    pub async fn get_pids_for_pod(&self, pod_uid: String) -> Result<Vec<i32>, tonic::Status> {
+        let mut client = self.runtime_client.clone();
+
+        tracing::info!("Fetching PIDs for pod UID: {}", pod_uid);
+
+        let mut map: HashMap<String, String> = std::collections::HashMap::new();
+        map.insert("io.kubernetes.pod.uid".to_string(), pod_uid.clone());
+
+        let pod_filter = cri::PodSandboxFilter {
+            label_selector: map,
+            ..Default::default()
+        };
+
+        tracing::debug!("Listing pod sandboxes with filter: {:?}", pod_filter);
+
+        // 1. Find the sandbox
+        let sandboxes = match client
+            .list_pod_sandbox(cri::ListPodSandboxRequest {
+                filter: Some(pod_filter),
+            })
+            .await
+        {
+            Ok(response) => response.into_inner().items,
+            Err(e) => {
+                tracing::error!("Failed to list pod sandboxes: {}", e);
+                return Err(e);
+            }
+        };
+
+        tracing::debug!(
+            "Found {} sandboxes for pod UID: {}",
+            sandboxes.len(),
+            pod_uid
+        );
+
+        let sandbox = sandboxes.first().ok_or_else(|| {
+            tracing::error!("No sandbox found for pod UID: {}", pod_uid);
+            tonic::Status::not_found(format!("No sandbox found for pod UID: {}", pod_uid))
+        })?;
+
+        let sandbox_id = sandbox.id.clone();
+        tracing::info!(
+            "Found sandbox for pod UID: {}, sandbox_id: {}",
+            pod_uid,
+            sandbox_id
+        );
+
+        // 2. List containers in that sandbox
+        let containers = match client
+            .list_containers(ListContainersRequest {
+                filter: Some(cri::ContainerFilter {
+                    pod_sandbox_id: sandbox_id.clone(),
+                    ..Default::default()
+                }),
+            })
+            .await
+        {
+            Ok(response) => response.into_inner().containers,
+            Err(e) => {
+                tracing::error!("Failed to list containers in sandbox {}: {}", sandbox_id, e);
+                return Err(e);
+            }
+        };
+
+        tracing::debug!(
+            "Found {} containers in sandbox {}",
+            containers.len(),
+            sandbox_id
+        );
+
+        let mut pids = Vec::new();
+
+        // 3. Query container status → get PID
+        for c in containers {
+            tracing::debug!("Processing container: {}", c.id);
+            let status = match client
+                .container_status(ContainerStatusRequest {
+                    container_id: c.id.clone(),
+                    verbose: true,
+                })
+                .await
+            {
+                Ok(response) => response.into_inner(),
+                Err(e) => {
+                    tracing::error!("Failed to get status for container {}: {}", c.id, e);
+                    return Err(e);
+                }
+            };
+
+            let info = status.info.get("info");
+
+            //info is json string, parse it to get the pid field
+            #[derive(serde::Deserialize)]
+            struct ContainerInfo {
+                pid: i32,
+            }
+            let info_json = info.ok_or_else(|| {
+                tracing::error!(
+                    "Container info not found for container: {}, available keys: {:?}",
+                    c.id,
+                    status.info.keys().collect::<Vec<_>>()
+                );
+                tonic::Status::internal(format!("Container info not found for container: {}", c.id))
+            })?;
+
+            let pid: ContainerInfo = serde_json::from_str(info_json).map_err(|e| {
+                tracing::error!(
+                    "Failed to parse container info for container {}: {}",
+                    c.id,
+                    e
+                );
+                tonic::Status::internal(format!(
+                    "Failed to parse container info for container {}: {}",
+                    c.id, e
+                ))
+            })?;
+
+            tracing::debug!("Found PID {} for container {}", pid.pid, c.id);
+            pids.push(pid.pid);
+        }
+
+        tracing::info!(
+            "Successfully collected {} PIDs for pod UID: {}",
+            pids.len(),
+            pod_uid
+        );
+        Ok(pids)
+    }
+}
+
+#[async_trait]
+impl PidClientTrait for ContainerRuntimeManager {
+    async fn fetch_pid(&self, uid: &WorkloadUid) -> Result<WorkloadPid, std::io::Error> {
+        let pids = self
+            .get_pids_for_pod(uid.clone().into_string())
+            .await
+            .map_err(|e| std::io::Error::other(format!("CRI error: {}", e)))?;
+
+        let pid = pids.first().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "No PID found for pod")
+        })?;
+
+        Ok(WorkloadPid::new(*pid))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use http::Uri;
+    use hyper_util::rt::TokioIo;
+    use tokio::{
+        net::{UnixListener, UnixStream},
+        sync::Mutex,
+    };
+    use tokio_stream::wrappers::UnixListenerStream;
+    use tonic::{
+        Response,
+        transport::{Endpoint, Server},
+    };
+    use tower::service_fn;
+
+    use crate::container_runtime::{
+        ContainerRuntimeManager,
+        cri::{
+            self, Container, ContainerStatusRequest, ContainerStatusResponse,
+            ListContainersRequest, ListContainersResponse, PodSandbox, PodSandboxStatusRequest,
+            PodSandboxStatusResponse, VersionRequest, VersionResponse,
+            runtime_service_client::RuntimeServiceClient,
+            runtime_service_server::{RuntimeService, RuntimeServiceServer},
+        },
+    };
+
+    #[derive(Clone, Default)]
+    struct MockRuntimeService {
+        // You can put shared state here to control responses from your tests
+        containers: Arc<Mutex<Vec<Container>>>,
+        sandboxes: Arc<Mutex<Vec<PodSandbox>>>,
+        container_statuses: Arc<Mutex<HashMap<String, ContainerStatusResponse>>>,
+    }
+
+    #[tonic::async_trait]
+    impl RuntimeService for MockRuntimeService {
+        async fn version(
+            &self,
+            _request: tonic::Request<VersionRequest>,
+        ) -> std::result::Result<tonic::Response<VersionResponse>, tonic::Status> {
+            Ok(tonic::Response::new(VersionResponse::default()))
+        }
+
+        async fn pod_sandbox_status(
+            &self,
+            _request: tonic::Request<PodSandboxStatusRequest>,
+        ) -> std::result::Result<tonic::Response<PodSandboxStatusResponse>, tonic::Status> {
+            Ok(tonic::Response::new(PodSandboxStatusResponse::default()))
+        }
+
+        async fn list_pod_sandbox(
+            &self,
+            request: tonic::Request<cri::ListPodSandboxRequest>,
+        ) -> std::result::Result<tonic::Response<cri::ListPodSandboxResponse>, tonic::Status>
+        {
+            let sandboxes = self.sandboxes.lock().await.clone();
+            let req = request.into_inner();
+
+            let filtered = if let Some(filter) = req.filter {
+                sandboxes
+                    .into_iter()
+                    .filter(|sandbox| {
+                        filter.label_selector.iter().all(|(key, expected_value)| {
+                            sandbox
+                                .labels
+                                .get(key)
+                                .map_or(false, |actual_value| actual_value == expected_value)
+                        })
+                    })
+                    .collect()
+            } else {
+                sandboxes
+            };
+
+            Ok(Response::new(cri::ListPodSandboxResponse {
+                items: filtered,
+            }))
+        }
+
+        async fn list_containers(
+            &self,
+            _request: tonic::Request<ListContainersRequest>,
+        ) -> std::result::Result<tonic::Response<ListContainersResponse>, tonic::Status> {
+            let containers = self.containers.lock().await.clone();
+            Ok(Response::new(ListContainersResponse { containers }))
+        }
+
+        async fn container_status(
+            &self,
+            request: tonic::Request<ContainerStatusRequest>,
+        ) -> std::result::Result<tonic::Response<ContainerStatusResponse>, tonic::Status> {
+            let container_status = self.container_statuses.lock().await;
+
+            let container_id = request.into_inner().container_id.clone();
+
+            let resp = container_status.get(&container_id).unwrap();
+
+            Ok(tonic::Response::new(resp.clone()))
+        }
+
+        async fn status(
+            &self,
+            _request: tonic::Request<cri::StatusRequest>,
+        ) -> std::result::Result<tonic::Response<cri::StatusResponse>, tonic::Status> {
+            Ok(tonic::Response::new(cri::StatusResponse::default()))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_client_uses_mock_cri_over_uds() {
+        // 1. Prepare mock service and data
+        let mock = MockRuntimeService::default();
+        {
+            let mut lock = mock.containers.lock().await;
+            lock.push(Container {
+                id: "fake-id-123".into(),
+                pod_sandbox_id: "fake-sandbox-123".into(),
+                ..Default::default()
+            });
+
+            let mut lock = mock.sandboxes.lock().await;
+            lock.push(cri::PodSandbox {
+                id: "fake-sandbox-123".into(),
+                labels: {
+                    let mut m = HashMap::new();
+                    m.insert("io.kubernetes.pod.uid".into(), "fake-uid-456".into());
+                    m
+                },
+                ..Default::default()
+            });
+
+            let mut lock = mock.container_statuses.lock().await;
+            lock.insert(
+                "fake-id-123".into(),
+                cri::ContainerStatusResponse {
+                    info: {
+                        let mut m = HashMap::new();
+                        m.insert("info".into(), r#"{"pid": 4321}"#.into());
+                        m
+                    },
+                    ..Default::default()
+                },
+            );
+            lock.insert(
+                "fake-id-321".into(),
+                cri::ContainerStatusResponse {
+                    info: {
+                        let mut m = HashMap::new();
+                        m.insert("info".into(), r#"{"pid": 1234}"#.into());
+                        m
+                    },
+                    ..Default::default()
+                },
+            );
+        }
+
+        // 2. Create a temporary Unix socket path
+        let socket_path = "/tmp/test-cri-runtime.sock";
+        // Ensure old socket is gone if it exists
+        let _ = std::fs::remove_file(socket_path);
+
+        // 3. Bind UnixListener
+        let uds = UnixListener::bind(socket_path).expect("failed to bind UDS");
+        let incoming = UnixListenerStream::new(uds);
+
+        // 4. Start gRPC server over UDS
+        let svc = RuntimeServiceServer::new(mock.clone());
+        let server_handle = tokio::spawn(async move {
+            Server::builder()
+                .add_service(svc)
+                .serve_with_incoming(incoming)
+                .await
+                .expect("server failed");
+        });
+
+        // 5. Build a client Channel that dials the same UDS
+        let socket_path_str = socket_path.to_string();
+        let endpoint = Endpoint::try_from("http://[::]:50051").unwrap();
+        let channel = endpoint
+            .connect_with_connector(service_fn(move |_uri: Uri| {
+                let path = socket_path_str.clone();
+                async move {
+                    let stream = UnixStream::connect(path).await?;
+                    Ok::<_, std::io::Error>(TokioIo::new(stream))
+                }
+            }))
+            .await
+            .expect("failed to connect to mock UDS server");
+
+        let client = RuntimeServiceClient::new(channel);
+
+        // 6. Call the real client method against the mock server
+        let cri_manager = ContainerRuntimeManager::new_with_client(client);
+        let pids_result = cri_manager
+            .get_pids_for_pod("non-existent-pod-uid".to_string())
+            .await;
+        assert!(pids_result.is_err()); // Since our mock returns no sandboxes matching the UID, this should error
+
+        let pids_result = cri_manager
+            .get_pids_for_pod("fake-uid-456".to_string())
+            .await;
+        assert!(pids_result.is_ok());
+        assert_eq!(pids_result.unwrap(), vec![4321]);
+
+        // 7. Clean up
+        server_handle.abort();
+        let _ = std::fs::remove_file(socket_path);
+    }
+}

--- a/src/container_runtime.rs
+++ b/src/container_runtime.rs
@@ -81,8 +81,7 @@ impl ContainerRuntimeManager {
         let mut map: HashMap<String, String> = std::collections::HashMap::new();
         map.insert("io.kubernetes.pod.uid".to_string(), pod_uid.clone());
 
-
-        let ready_state = cri::PodSandboxStateValue{
+        let ready_state = cri::PodSandboxStateValue {
             state: 0, // PodSandboxState::SandboxReady
         };
 
@@ -303,16 +302,18 @@ mod tests {
                     .into_iter()
                     .filter(|sandbox| {
                         // Filter by label selector
-                        let labels_match = filter.label_selector.iter().all(|(key, expected_value)| {
-                            sandbox
-                                .labels
-                                .get(key)
-                                .map_or(false, |actual_value| actual_value == expected_value)
-                        });
+                        let labels_match =
+                            filter.label_selector.iter().all(|(key, expected_value)| {
+                                sandbox
+                                    .labels
+                                    .get(key)
+                                    .map_or(false, |actual_value| actual_value == expected_value)
+                            });
                         // Filter by state if specified
-                        let state_match = filter.state.as_ref().map_or(true, |state_filter| {
-                            sandbox.state == state_filter.state
-                        });
+                        let state_match = filter
+                            .state
+                            .as_ref()
+                            .map_or(true, |state_filter| sandbox.state == state_filter.state);
                         labels_match && state_match
                     })
                     .collect()
@@ -343,9 +344,10 @@ mod tests {
                             container.pod_sandbox_id == filter.pod_sandbox_id
                         };
                         // Filter by state if specified
-                        let state_match = filter.state.as_ref().map_or(true, |state_filter| {
-                            container.state == state_filter.state
-                        });
+                        let state_match = filter
+                            .state
+                            .as_ref()
+                            .map_or(true, |state_filter| container.state == state_filter.state);
                         sandbox_match && state_match
                     })
                     .collect()
@@ -353,7 +355,9 @@ mod tests {
                 containers
             };
 
-            Ok(Response::new(ListContainersResponse { containers: filtered }))
+            Ok(Response::new(ListContainersResponse {
+                containers: filtered,
+            }))
         }
 
         async fn container_status(
@@ -483,7 +487,10 @@ mod tests {
     async fn setup_mock_server(
         mock: MockRuntimeService,
         socket_path: &str,
-    ) -> (RuntimeServiceClient<tonic::transport::Channel>, tokio::task::JoinHandle<()>) {
+    ) -> (
+        RuntimeServiceClient<tonic::transport::Channel>,
+        tokio::task::JoinHandle<()>,
+    ) {
         let _ = std::fs::remove_file(socket_path);
         let uds = UnixListener::bind(socket_path).expect("failed to bind UDS");
         let incoming = UnixListenerStream::new(uds);
@@ -560,7 +567,10 @@ mod tests {
                 state: 0, // SANDBOX_READY
                 labels: {
                     let mut m = HashMap::new();
-                    m.insert("io.kubernetes.pod.uid".into(), "pod-with-exited-containers".into());
+                    m.insert(
+                        "io.kubernetes.pod.uid".into(),
+                        "pod-with-exited-containers".into(),
+                    );
                     m
                 },
                 ..Default::default()

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -19,6 +19,9 @@ use std::sync::Arc;
 mod caclient;
 pub use caclient::*;
 
+mod spireclient;
+pub use spireclient::*;
+
 pub mod manager;
 pub use manager::*;
 
@@ -54,6 +57,20 @@ pub enum Error {
     Forgotten,
     #[error("BUG: identity requested {0}, but only allowed {1:?}")]
     BugInvalidIdentityRequest(Identity, Arc<WorkloadInfo>),
+    #[error("failed to fetch pid for workload: {0}")]
+    FailedToFetchBundle(String),
+    #[error("certificate is in invalid format")]
+    CertificateInvalidFormat(),
+    #[error("invalid trust domain: {0}")]
+    InvalidTrustDomain(String),
+    #[error("failed to fetch certificate for workload: {0}")]
+    FailedToFetchCertificate(String),
+    #[error("failed to fetch pid for workload: {0}")]
+    FailedToFetchPidForWorkload(i32),
+    #[error("unable to determine pid for workload: {0}")]
+    UnableToDeterminePidForWorkload(String),
+    #[error("invalid configuration: {0}")]
+    InvalidConfiguration(String),
 }
 
 impl From<tls::Error> for Error {

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -57,7 +57,7 @@ pub enum Error {
     Forgotten,
     #[error("BUG: identity requested {0}, but only allowed {1:?}")]
     BugInvalidIdentityRequest(Identity, Arc<WorkloadInfo>),
-    #[error("failed to fetch pid for workload: {0}")]
+    #[error("failed to fetch bundle for workload: {0}")]
     FailedToFetchBundle(String),
     #[error("certificate is in invalid format")]
     CertificateInvalidFormat(),

--- a/src/identity/caclient.rs
+++ b/src/identity/caclient.rs
@@ -21,9 +21,8 @@ use tonic::IntoRequest;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue};
 use tracing::{debug, error, instrument, warn};
 
-use crate::identity::Error;
 use crate::identity::auth::AuthSource;
-use crate::identity::manager::Identity;
+use crate::identity::{CompositeId, Error, RequestKeyEnum};
 use crate::tls::{self, TlsGrpcChannel};
 use crate::xds::istio::ca::IstioCertificateRequest;
 use crate::xds::istio::ca::istio_certificate_service_client::IstioCertificateServiceClient;
@@ -59,7 +58,10 @@ impl CaClient {
 
 impl CaClient {
     #[instrument(skip_all)]
-    async fn fetch_certificate(&self, id: &Identity) -> Result<tls::WorkloadCertificate, Error> {
+    async fn fetch_certificate(
+        &self,
+        id: &CompositeId<RequestKeyEnum>,
+    ) -> Result<tls::WorkloadCertificate, Error> {
         let cs = tls::csr::CsrOptions {
             san: id.to_string(),
         }
@@ -104,7 +106,7 @@ impl CaClient {
         let leaf = resp
             .cert_chain
             .first()
-            .ok_or_else(|| Error::EmptyResponse(id.to_owned()))?
+            .ok_or_else(|| Error::EmptyResponse(id.id().to_owned()))?
             .as_bytes();
         let chain = if resp.cert_chain.len() > 1 {
             resp.cert_chain[1..].iter().map(|s| s.as_bytes()).collect()
@@ -114,9 +116,9 @@ impl CaClient {
         };
         let certs = tls::WorkloadCertificate::new(&private_key, leaf, chain)?;
         // Make the certificate actually matches the identity we requested.
-        if self.enable_impersonated_identity && certs.identity().as_ref() != Some(id) {
+        if self.enable_impersonated_identity && certs.identity().as_ref() != Some(id.id()) {
             error!("expected identity {:?}, got {:?}", id, certs.identity());
-            return Err(Error::SanError(id.to_owned()));
+            return Err(Error::SanError(id.id().to_owned()));
         }
         Ok(certs)
     }
@@ -124,7 +126,10 @@ impl CaClient {
 
 #[async_trait]
 impl crate::identity::CaClientTrait for CaClient {
-    async fn fetch_certificate(&self, id: &Identity) -> Result<tls::WorkloadCertificate, Error> {
+    async fn fetch_certificate(
+        &self,
+        id: &CompositeId<RequestKeyEnum>,
+    ) -> Result<tls::WorkloadCertificate, Error> {
         self.fetch_certificate(id).await
     }
 }
@@ -199,13 +204,13 @@ pub mod mock {
 
         async fn fetch_certificate(
             &self,
-            id: &Identity,
+            id: &CompositeId<RequestKeyEnum>,
         ) -> Result<tls::WorkloadCertificate, Error> {
             let Identity::Spiffe {
                 trust_domain: td,
                 namespace: ns,
                 ..
-            } = id;
+            } = id.id();
             if td == "error" {
                 return Err(match ns.as_str() {
                     "forgotten" => Error::Forgotten,
@@ -226,13 +231,13 @@ pub mod mock {
             let not_after = not_before + self.cfg.cert_lifetime;
 
             let mut state = self.state.write().await;
-            state.fetches.push(id.to_owned());
+            state.fetches.push(id.id().to_owned());
             if state.error {
                 return Err(Error::Spiffe("injected test error".into()));
             }
             let certs = state
                 .cert_gen
-                .new_certs(&id.to_owned().into(), not_before, not_after);
+                .new_certs(&id.id().to_owned().into(), not_before, not_after);
             Ok(certs)
         }
 
@@ -246,7 +251,7 @@ pub mod mock {
     impl crate::identity::CaClientTrait for CaClient {
         async fn fetch_certificate(
             &self,
-            id: &Identity,
+            id: &CompositeId<RequestKeyEnum>,
         ) -> Result<tls::WorkloadCertificate, Error> {
             self.fetch_certificate(id).await
         }
@@ -271,7 +276,9 @@ mod tests {
     ) -> Result<tls::WorkloadCertificate, Error> {
         let (mock, ca_client) = test_helpers::ca::CaServer::spawn().await;
         mock.send(Ok(res)).unwrap();
-        ca_client.fetch_certificate(&Identity::default()).await
+        ca_client
+            .fetch_certificate(&Identity::default().to_composite_id())
+            .await
     }
 
     #[tokio::test]

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -1377,10 +1377,7 @@ mod tests {
         test.caclient.set_error(true).await;
         assert!(
             test.caclient
-                .fetch_certificate(&CompositeId::with_key(
-                    id.clone(),
-                    id.clone(),
-                ))
+                .fetch_certificate(&CompositeId::with_key(id.clone(), id.clone(),))
                 .await
                 .is_err()
         );

--- a/src/identity/spireclient.rs
+++ b/src/identity/spireclient.rs
@@ -1,0 +1,916 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    config::Config,
+    identity::{CompositeId, Error, Identity, PidClientTrait, RequestKeyEnum},
+    inpod::WorkloadUid,
+    tls,
+};
+use spiffe::{TrustDomain, X509Svid};
+use spire_api::{DelegateAttestationRequest, DelegatedIdentityClient};
+use std::{str::FromStr, sync::Arc};
+use tokio_stream::{Stream, StreamExt};
+use tonic::async_trait;
+
+/// Trait abstraction over the SPIRE DelegatedIdentityClient
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait DelegatedIdentityApi: Send + Sync {
+    async fn get_x509_bundles(
+        &self,
+    ) -> Result<spiffe::X509BundleSet, spiffe::error::GrpcClientError>;
+    async fn get_x509_svids(
+        &self,
+        attest_type: DelegateAttestationRequest,
+    ) -> Result<
+        Box<
+            dyn Stream<Item = Result<spiffe::X509Svid, spiffe::error::GrpcClientError>>
+                + Send
+                + Unpin,
+        >,
+        spiffe::error::GrpcClientError,
+    >;
+}
+
+#[async_trait]
+impl DelegatedIdentityApi for DelegatedIdentityClient {
+    async fn get_x509_bundles(
+        &self,
+    ) -> Result<spiffe::X509BundleSet, spiffe::error::GrpcClientError> {
+        self.clone().fetch_x509_bundles().await
+    }
+
+    async fn get_x509_svids(
+        &self,
+        attest_type: DelegateAttestationRequest,
+    ) -> Result<
+        Box<
+            dyn Stream<Item = Result<spiffe::X509Svid, spiffe::error::GrpcClientError>>
+                + Send
+                + Unpin,
+        >,
+        spiffe::error::GrpcClientError,
+    > {
+        let stream = self.clone().stream_x509_svids(attest_type).await?;
+        Ok(Box::new(stream))
+    }
+}
+
+/// SPIRE client that fetches X.509 certificates for workload identities using
+/// Kubernetes selectors (namespace + service account) rather than PIDs.
+/// This approach works in environments where PID-based attestation is not feasible.
+pub struct SpireClient<C: DelegatedIdentityApi> {
+    /// gRPC client for communicating with the SPIRE Delegated Identity API
+    client: C,
+    /// SPIFFE trust domain (e.g., "cluster.local") used for certificate validation
+    trust_domain: String,
+    /// Optional PID client for workload PID verification
+    pid: Box<dyn PidClientTrait>,
+    /// Shared configuration for SPIRE client behavior
+    cfg: Arc<Config>,
+}
+
+impl<C: DelegatedIdentityApi> SpireClient<C> {
+    /// Creates a new SPIRE client with the provided gRPC client and trust domain.
+    ///
+    /// # Arguments
+    /// * `client` - Configured DelegatedIdentityClient for SPIRE communication
+    /// * `trust_domain` - SPIFFE trust domain string for this cluster
+    /// * `pid` - Optional PID client for workload PID verification
+    /// * `cfg` - Shared configuration for SPIRE client behavior
+    pub fn new(
+        client: C,
+        trust_domain: String,
+        pid: Box<dyn PidClientTrait>,
+        cfg: Arc<Config>,
+    ) -> Self {
+        SpireClient {
+            client,
+            trust_domain,
+            pid,
+            cfg,
+        }
+    }
+
+    /// Fetches a workload certificate using container pid.
+    /// This method implements a streaming approach to handle SPIRE's async certificate delivery.
+    ///
+    /// # Arguments
+    /// * `pid` - The container process ID for the workload
+    /// * `wl_uid` - The unique identifier for the workload
+    ///
+    /// # Returns
+    /// A WorkloadCertificate containing the X.509 certificate and private key
+    ///
+    /// # Errors
+    /// Returns error if stream setup fails, no certificates are received within timeout,
+    /// or certificate construction fails.
+    async fn get_cert_by_pid(
+        &self,
+        pid: i32,
+        wl_uid: &WorkloadUid,
+    ) -> Result<tls::WorkloadCertificate, Error> {
+        let certs = self
+            .get_cert_from_spire(DelegateAttestationRequest::Pid(pid))
+            .await;
+
+        let certs = match certs {
+            Err(e) => {
+                return Err(Error::FailedToFetchCertificate(format!(
+                    "Failed to fetch certificate for PID {}: {}",
+                    pid, e
+                )));
+            }
+            Ok(certs) => certs,
+        };
+
+        let pid_verify = self.pid.fetch_pid(wl_uid).await;
+
+        match pid_verify {
+            Ok(fetched_pid) => {
+                if fetched_pid.into_i32() != pid {
+                    return Err(Error::UnableToDeterminePidForWorkload(format!(
+                        "PID mismatch for workload UID {}: expected {}, got {}",
+                        wl_uid.clone().into_string(),
+                        pid,
+                        fetched_pid.into_i32()
+                    )));
+                }
+                Ok(certs)
+            }
+            Err(e) => Err(Error::UnableToDeterminePidForWorkload(format!(
+                "Failed to verify PID for workload UID {}: {}",
+                wl_uid.clone().into_string(),
+                e
+            ))),
+        }
+    }
+
+    /// Fetches a workload certificate using workload UID to determine PID.
+    /// This method implements a streaming approach to handle SPIRE's async certificate delivery.
+    /// # Arguments
+    /// * `wl_uid` - The unique identifier for the workload
+    ///
+    /// # Returns
+    /// A WorkloadCertificate containing the X.509 certificate and private key
+    ///
+    /// # Errors
+    /// Returns error if PID client is not configured, stream setup fails,
+    /// no certificates are received within timeout, or certificate construction fails.
+    async fn get_cert_by_workload_uid(
+        &self,
+        wl_uid: &WorkloadUid,
+    ) -> Result<tls::WorkloadCertificate, Error> {
+        tracing::info!(
+            "Fetching PID for workload UID: {}",
+            wl_uid.clone().into_string()
+        );
+        let pid = self.pid.fetch_pid(wl_uid).await;
+        match pid {
+            Ok(pid) => self.get_cert_by_pid(pid.into_i32(), wl_uid).await,
+            Err(e) => Err(Error::UnableToDeterminePidForWorkload(format!(
+                "Failed to fetch PID for workload UID {}: {}",
+                wl_uid.clone().into_string(),
+                e
+            ))),
+        }
+    }
+
+    /// Subscribes to the SPIRE server for workload certificates using the provided attestation request.
+    ///
+    /// # Arguments
+    /// * `value` - The attestation request specifying how to identify the workload
+    ///
+    /// # Returns
+    /// The first X509Svid received from the SPIRE server
+    ///
+    /// # Errors
+    /// Returns error if stream setup fails, no certificates are received within timeout,
+    /// or certificate construction fails.
+    async fn subscribe_and_wait_for_workload_cert(
+        &self,
+        value: DelegateAttestationRequest,
+    ) -> Result<X509Svid, Error> {
+        // Initiate streaming request to SPIRE server using Kubernetes selectors
+        // clone() is cheap here as DelegatedIdentityClient uses Arc internally
+        let stream = self.client.get_x509_svids(value).await.map_err(|e| {
+            Error::FailedToFetchCertificate(format!("Failed to stream X.509 SVIDs: {e}"))
+        })?;
+        // Set reasonable timeout to prevent indefinite blocking on unresponsive SPIRE servers
+        let time_out = self.cfg.spire_timeout;
+
+        // Process the stream with timeout protection
+        // SPIRE may deliver multiple responses, but we only need the first successful one
+        tokio::pin!(stream);
+        let sf = tokio::time::timeout(time_out, async {
+            while let Some(svid_response) = stream.next().await {
+                match svid_response {
+                    Ok(response) => {
+                        // Successfully received a certificate - return immediately
+                        return Ok(response);
+                    }
+                    Err(e) => {
+                        // Log stream errors but continue waiting for subsequent responses
+                        // Some responses may fail while others succeed
+                        tracing::warn!("Error receiving SVID response: {}", e);
+                    }
+                }
+            }
+            // Stream ended without delivering any successful responses
+            Err(Error::FailedToFetchCertificate(
+                "No SVIDs received in stream".to_string(),
+            ))
+        })
+        .await;
+
+        // Handle nested Result types from timeout + stream operations
+        let svid_response = match sf {
+            Ok(Ok(response)) => response, // Successfully got certificate within timeout
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                // Timeout expired before receiving any certificates
+                tracing::error!("Timeout while waiting for SVID stream");
+                return Err(Error::FailedToFetchCertificate(
+                    "Timeout while waiting for SVID stream".to_string(),
+                ));
+            }
+        };
+
+        Ok(svid_response)
+    }
+
+    /// Fetches a workload certificate from SPIRE using the provided attestation request.
+    ///
+    /// # Arguments
+    /// * `value` - The attestation request specifying how to identify the workload
+    ///
+    /// # Returns
+    /// A WorkloadCertificate containing the X.509 certificate and private key
+    ///
+    /// # Errors
+    /// Returns error if stream setup fails, no certificates are received within timeout,
+    /// or certificate construction fails.
+    async fn get_cert_from_spire(
+        &self,
+        value: DelegateAttestationRequest,
+    ) -> Result<tls::WorkloadCertificate, Error> {
+        // Handle nested Result types from timeout + stream operations
+        let svid_response = self.subscribe_and_wait_for_workload_cert(value).await?;
+
+        // Fetch the trust bundle containing CA certificates for validation
+        let bundle = self.get_bundle().await?;
+
+        // Construct the final WorkloadCertificate combining SVID and trust bundle
+        let certs = tls::WorkloadCertificate::new_svid(&svid_response, &bundle)?;
+
+        let id = format!(
+            "spiffe://{}{}",
+            svid_response.spiffe_id().trust_domain(),
+            svid_response.spiffe_id().path()
+        );
+
+        // Validate that the returned identity matches the requested one
+        Identity::from_str(&id)?;
+
+        Ok(certs)
+    }
+
+    /// Fetches the X.509 trust bundle from SPIRE containing CA certificates
+    /// for validating certificates within this trust domain.
+    ///
+    /// # Returns
+    /// Vector of CA certificates that can verify certificates in this trust domain
+    ///
+    /// # Errors
+    /// Returns error if bundle fetch fails, trust domain is invalid, or no bundle
+    /// exists for the configured trust domain.
+    async fn get_bundle(&self) -> Result<Vec<spiffe::cert::Certificate>, Error> {
+        // Fetch all available trust bundles from SPIRE server
+        let bundle_req = self.client.get_x509_bundles().await.map_err(|e| {
+            Error::FailedToFetchBundle(format!("Failed to fetch X.509 bundles: {}", e))
+        })?;
+
+        // Parse and validate the trust domain string
+        let td = TrustDomain::new(&self.trust_domain).map_err(|e| {
+            Error::InvalidTrustDomain(format!("Invalid trust domain {}: {}", self.trust_domain, e))
+        })?;
+        tracing::debug!("Fetched bundle for trust domain: {}", td);
+
+        // Extract CA certificates for our specific trust domain
+        let bundles = match bundle_req.get_bundle(&td) {
+            Some(b) => b.authorities(), // Get the CA certificates
+            None => {
+                // No trust bundle available for this domain - configuration error
+                return Err(Error::InvalidTrustDomain(format!(
+                    "No bundle found for trust domain: {}",
+                    td
+                )));
+            }
+        };
+
+        // Clone the certificates to return owned values
+        // This allows the bundle request to be dropped while keeping the certificates
+        Ok(bundles.clone())
+    }
+}
+
+/// Implementation of the CaClientTrait that integrates SPIRE with ztunnel's
+/// certificate management system. This allows the SPIRE client to be used
+/// interchangeably with other certificate authority implementations.
+#[async_trait]
+impl<C: DelegatedIdentityApi> crate::identity::CaClientTrait for SpireClient<C> {
+    /// Fetches a certificate for the given identity using SPIRE's selector-based approach.
+    /// This is the main integration point with ztunnel's certificate manager.
+    ///
+    /// # Arguments
+    /// * `id` - SPIFFE identity to fetch certificate for
+    ///
+    /// # Returns
+    /// WorkloadCertificate that can be used for TLS operations
+    async fn fetch_certificate(
+        &self,
+        id: &CompositeId<RequestKeyEnum>,
+    ) -> Result<tls::WorkloadCertificate, Error> {
+        match id.key() {
+            RequestKeyEnum::Workload(wl_uid) => self.get_cert_by_workload_uid(wl_uid).await,
+            _ => Err(Error::InvalidConfiguration(
+                "PID mode requires workload UID for attestation".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod spire_tests {
+    use crate::config;
+    use crate::identity::CaClientTrait;
+    use crate::identity::MockPidClientTrait;
+    use crate::identity::SecretManager;
+    use crate::identity::WorkloadPid;
+
+    use super::*;
+    use futures::SinkExt;
+    use futures::channel::mpsc;
+    use mockall::predicate::*;
+    use rcgen::BasicConstraints;
+    use rcgen::Certificate;
+    use rcgen::CertificateParams;
+    use rcgen::CertifiedIssuer;
+    use rcgen::DnType;
+    use rcgen::IsCa;
+    use rcgen::KeyPair;
+    use rcgen::KeyUsagePurpose;
+    use rcgen::SanType;
+    use rcgen::string::Ia5String;
+    use spiffe::error::GrpcClientError;
+    use spiffe::*;
+
+    use rcgen::ExtendedKeyUsagePurpose as EKU;
+
+    #[tokio::test]
+    async fn test_get_bundle_success() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "example.org".to_string(),
+            Box::new(pid_client),
+            Arc::new(cfg),
+        );
+
+        let result = spire_client.get_bundle().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_bundle_trust_domain_not_found() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "wrong.trust_domain".to_string(),
+            Box::new(pid_client),
+            Arc::new(cfg),
+        );
+
+        let result = spire_client.get_bundle().await;
+        assert!(result.is_err());
+        let err = result.err().unwrap().to_string();
+        assert!(err.contains("No bundle found for trust domain"));
+    }
+
+    #[tokio::test]
+    async fn test_get_cert_by_pid_success() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client.expect_get_x509_svids().returning(|_req| {
+            let stream = mock_stream_svid_success_response(
+                "spiffe://example.org/ns/default/sa/test-sa".to_string(),
+            );
+            Ok(stream)
+        });
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        pid_client
+            .expect_fetch_pid()
+            .returning(|_| Ok(WorkloadPid::new(10)));
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+
+        let cfg = Arc::new(cfg);
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "example.org".to_string(),
+            Box::new(pid_client),
+            Arc::clone(&cfg),
+        );
+
+        let identity =
+            Identity::from_parts("example.org".into(), "default".into(), "test-sa".into());
+        let result = spire_client
+            .get_cert_by_pid(10, &WorkloadUid::new("uid-123456".to_string()))
+            .await;
+
+        assert!(result.is_ok());
+
+        let workload_cert = result.unwrap();
+
+        let id = workload_cert.identity();
+
+        assert!(id.unwrap().to_string() == "spiffe://example.org/ns/default/sa/test-sa");
+
+        assert!(identity.to_string() == "spiffe://example.org/ns/default/sa/test-sa");
+
+        let composite_id = CompositeId::new(
+            identity,
+            RequestKeyEnum::Workload(WorkloadUid::new("uid-123456".to_string())),
+        );
+
+        let fetch_result = spire_client.fetch_certificate(&composite_id).await;
+
+        assert!(fetch_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_cert_by_pid_not_found() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client.expect_get_x509_svids().returning(|_req| {
+            let stream = mock_stream_svid_success_response(
+                "spiffe://example.org/ns/default/sa/test-sa".to_string(),
+            );
+            Ok(stream)
+        });
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        pid_client.expect_fetch_pid().returning(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "No PID found for pod",
+            ))
+        });
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "example.org".to_string(),
+            Box::new(pid_client),
+            Arc::new(cfg),
+        );
+
+        let result = spire_client
+            .get_cert_by_pid(10, &WorkloadUid::new("uid-123456".to_string()))
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_cert_by_secret_manager_with_pid_success() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client.expect_get_x509_svids().returning(|_req| {
+            let stream = mock_stream_svid_success_response(
+                "spiffe://example.org/ns/default/sa/test-sa".to_string(),
+            );
+            Ok(stream)
+        });
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        pid_client
+            .expect_fetch_pid()
+            .returning(|_| Ok(WorkloadPid::new(10)));
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+
+        let cfg = Arc::new(cfg);
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "example.org".to_string(),
+            Box::new(pid_client),
+            Arc::clone(&cfg),
+        );
+
+        let composite_id = CompositeId::new(
+            Identity::from_parts("example.org".into(), "default".into(), "test-sa".into()),
+            RequestKeyEnum::Workload(WorkloadUid::new("uid-123456".to_string())),
+        );
+        let composite_id_diff_uid = CompositeId::new(
+            Identity::from_parts("example.org".into(), "default".into(), "test-sa".into()),
+            RequestKeyEnum::Workload(WorkloadUid::new("uid-654321".to_string())),
+        );
+        let sm = SecretManager::new_with_client(spire_client);
+        let certs = sm.fetch_certificate(&composite_id).await.unwrap();
+        assert!(
+            certs.identity().unwrap().to_string() == "spiffe://example.org/ns/default/sa/test-sa"
+        );
+        assert!(sm.cache_len().await == 1);
+        let certs = sm.fetch_certificate(&composite_id).await.unwrap();
+        assert!(
+            certs.identity().unwrap().to_string() == "spiffe://example.org/ns/default/sa/test-sa"
+        );
+        assert!(sm.cache_len().await == 1);
+        let certs = sm.fetch_certificate(&composite_id_diff_uid).await.unwrap();
+        assert!(
+            certs.identity().unwrap().to_string() == "spiffe://example.org/ns/default/sa/test-sa"
+        );
+        assert!(sm.cache_len().await == 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_cert_by_secret_manager_with_pid_not_found() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client.expect_get_x509_svids().returning(|_req| {
+            let stream = mock_stream_svid_success_response(
+                "spiffe://example.org/ns/default/sa/test-sa".to_string(),
+            );
+            Ok(stream)
+        });
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        pid_client.expect_fetch_pid().returning(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "No PID found for pod",
+            ))
+        });
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+
+        let cfg = Arc::new(cfg);
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "example.org".to_string(),
+            Box::new(pid_client),
+            Arc::clone(&cfg),
+        );
+
+        let composite_id = CompositeId::new(
+            Identity::from_parts("example.org".into(), "default".into(), "test-sa".into()),
+            RequestKeyEnum::Workload(WorkloadUid::new("uid-123456".to_string())),
+        );
+        let sm = SecretManager::new_with_client(spire_client);
+        let certs = sm.fetch_certificate(&composite_id).await;
+        assert!(certs.is_err());
+        assert!(sm.cache_len().await == 1);
+        let err = certs.err().unwrap().to_string();
+        assert!(err.contains("No PID found for pod"));
+    }
+
+    #[tokio::test]
+    async fn test_get_cert_by_pid_success_delay_response() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client.expect_get_x509_svids().returning(|_req| {
+            let stream = mock_stream_svid_success_delay_response(
+                "spiffe://example.org/ns/default/sa/test-sa".to_string(),
+            );
+            Ok(stream)
+        });
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        pid_client
+            .expect_fetch_pid()
+            .returning(|_| Ok(WorkloadPid::new(10)));
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+
+        let cfg = Arc::new(cfg);
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "example.org".to_string(),
+            Box::new(pid_client),
+            Arc::clone(&cfg),
+        );
+
+        let identity =
+            Identity::from_parts("example.org".into(), "default".into(), "test-sa".into());
+        let result = spire_client
+            .get_cert_by_pid(10, &WorkloadUid::new("uid-123456".to_string()))
+            .await;
+
+        assert!(result.is_ok());
+
+        let workload_cert = result.unwrap();
+
+        let id = workload_cert.identity();
+
+        assert!(id.unwrap().to_string() == "spiffe://example.org/ns/default/sa/test-sa");
+
+        assert!(identity.to_string() == "spiffe://example.org/ns/default/sa/test-sa");
+
+        let composite_id = CompositeId::new(
+            identity,
+            RequestKeyEnum::Workload(WorkloadUid::new("uid-123456".to_string())),
+        );
+
+        let fetch_result = spire_client.fetch_certificate(&composite_id).await;
+
+        assert!(fetch_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_cert_by_pid_delay_response_timeout() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client.expect_get_x509_svids().returning(|_req| {
+            let stream = mock_stream_svid_success_delay_response_timeout(
+                "spiffe://example.org/ns/default/sa/test-sa".to_string(),
+            );
+            Ok(stream)
+        });
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        pid_client
+            .expect_fetch_pid()
+            .returning(|_| Ok(WorkloadPid::new(10)));
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+        cfg.spire_timeout = std::time::Duration::from_secs(5);
+
+        let cfg = Arc::new(cfg);
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "example.org".to_string(),
+            Box::new(pid_client),
+            Arc::clone(&cfg),
+        );
+
+        let result = spire_client
+            .get_cert_by_pid(10, &WorkloadUid::new("uid-123456".to_string()))
+            .await;
+
+        assert!(result.is_err());
+
+        let err = result.err().unwrap().to_string();
+        assert!(err.contains("No SVIDs received in stream"));
+    }
+
+    #[tokio::test]
+    async fn test_get_cert_by_pid_delay_response_timeout_empty() {
+        let mut mock_client = MockDelegatedIdentityApi::new();
+        let mut pid_client = MockPidClientTrait::new();
+
+        mock_client.expect_get_x509_svids().returning(|_req| {
+            let stream = mock_stream_svid_success_delay_response_timeout_empty(
+                "spiffe://example.org/ns/default/sa/test-sa".to_string(),
+            );
+            Ok(stream)
+        });
+
+        mock_client
+            .expect_get_x509_bundles()
+            .returning(|| Ok(mock_bundle_response()));
+
+        pid_client
+            .expect_fetch_pid()
+            .returning(|_| Ok(WorkloadPid::new(10)));
+
+        let mut cfg = config::parse_config().unwrap();
+        cfg.spire_enabled = true;
+
+        let cfg = Arc::new(cfg);
+
+        let spire_client = SpireClient::new(
+            mock_client,
+            "example.org".to_string(),
+            Box::new(pid_client),
+            Arc::clone(&cfg),
+        );
+
+        let result = spire_client
+            .get_cert_by_pid(10, &WorkloadUid::new("uid-123456".to_string()))
+            .await;
+
+        assert!(result.is_err());
+
+        let err = result.err().unwrap().to_string();
+        assert!(err.contains("Timeout while waiting for SVID stream"));
+    }
+
+    fn mock_bundle_response() -> spiffe::X509BundleSet {
+        let ca_key = KeyPair::generate().unwrap();
+        let ca_params = ca_params("example.org").unwrap();
+
+        // CertifiedIssuer gives you both the issuer + its self-signed cert
+        let ca_issuer = CertifiedIssuer::self_signed(ca_params, ca_key).unwrap();
+
+        let td = TrustDomain::new("example.org").unwrap();
+        let mut bundle = X509Bundle::new(td.clone());
+
+        let ca_der_slice: &[u8] = ca_issuer.der();
+        bundle.add_authority(ca_der_slice).unwrap();
+
+        let mut set = spiffe::X509BundleSet::new();
+        set.add_bundle(bundle);
+
+        return set;
+    }
+
+    fn mock_stream_svid_success_response(
+        spiffe_id: String,
+    ) -> Box<dyn Stream<Item = Result<X509Svid, GrpcClientError>> + Send + Unpin> {
+        // build a stream that yields X509Svid responses
+        // can you provide a minimal example of building such a stream?
+        let (mut tx, rx) = mpsc::channel(10);
+        tokio::spawn(async move {
+            let svid = generate_svid(&spiffe_id, "example.org");
+            tx.send(Ok(svid)).await.unwrap();
+        });
+        Box::new(rx)
+    }
+
+    fn mock_stream_svid_success_delay_response(
+        spiffe_id: String,
+    ) -> Box<dyn Stream<Item = Result<X509Svid, GrpcClientError>> + Send + Unpin> {
+        // build a stream that yields X509Svid responses
+        // can you provide a minimal example of building such a stream?
+        let (mut tx, rx) = mpsc::channel(10);
+        tokio::spawn(async move {
+            tx.send(Err(GrpcClientError::EmptyResponse)).await.unwrap();
+
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+            let svid = generate_svid(&spiffe_id, "example.org");
+            tx.send(Ok(svid)).await.unwrap();
+        });
+        Box::new(rx)
+    }
+
+    fn mock_stream_svid_success_delay_response_timeout(
+        _: String,
+    ) -> Box<dyn Stream<Item = Result<X509Svid, GrpcClientError>> + Send + Unpin> {
+        // build a stream that yields X509Svid responses
+        // can you provide a minimal example of building such a stream?
+        let (_, rx) = mpsc::channel(10);
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        });
+        Box::new(rx)
+    }
+
+    fn mock_stream_svid_success_delay_response_timeout_empty(
+        _: String,
+    ) -> Box<dyn Stream<Item = Result<X509Svid, GrpcClientError>> + Send + Unpin> {
+        // build a stream that yields X509Svid responses
+        // can you provide a minimal example of building such a stream?
+        let (mut tx, rx) = mpsc::channel(10);
+        tokio::spawn(async move {
+            tx.send(Err(GrpcClientError::EmptyResponse)).await.unwrap();
+
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        });
+        Box::new(rx)
+    }
+
+    fn ca_params(cn: &str) -> Result<CertificateParams, rcgen::Error> {
+        // Empty Vec<String> => no DNS SANs; we'll just use DN for the CA
+        let mut params = CertificateParams::new(Vec::<String>::new())?;
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+        params.distinguished_name.push(DnType::CommonName, cn);
+        params.use_authority_key_identifier_extension = true;
+        Ok(params)
+    }
+
+    fn spiffe_leaf_params(spiffe_id: &str) -> Result<CertificateParams, rcgen::Error> {
+        // Again, no default DNS SANs
+        let mut params = CertificateParams::new(Vec::<String>::new())?;
+        params.is_ca = IsCa::ExplicitNoCa;
+        params.use_authority_key_identifier_extension = true;
+        params.key_usages = vec![
+            KeyUsagePurpose::DigitalSignature,
+            KeyUsagePurpose::KeyEncipherment,
+            KeyUsagePurpose::ContentCommitment,
+        ];
+        params.extended_key_usages = vec![EKU::ClientAuth, EKU::ServerAuth];
+
+        // Optional subject DN
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "spiffe-workload");
+
+        // SPIFFE ID as URI SAN: URI(Ia5String)
+        let uri = Ia5String::try_from(spiffe_id)?;
+        params.subject_alt_names.push(SanType::URI(uri));
+
+        Ok(params)
+    }
+
+    fn generate_svid(spiffe_id: &str, cn: &str) -> X509Svid {
+        let ca_key = KeyPair::generate().unwrap();
+        let ca_params = ca_params(cn).unwrap();
+
+        // CertifiedIssuer gives you both the issuer + its self-signed cert
+        let ca_issuer = CertifiedIssuer::self_signed(ca_params, ca_key).unwrap();
+
+        // ----- Leaf cert with SPIFFE SAN -----
+        let leaf_key = KeyPair::generate().unwrap();
+        let leaf_params = spiffe_leaf_params(spiffe_id).unwrap();
+
+        // Sign leaf with CA
+        let leaf_cert: Certificate = leaf_params.signed_by(&leaf_key, &*ca_issuer).unwrap();
+
+        let leaf_cert_der: Vec<u8> = leaf_cert.der().to_vec();
+        let leaf_key_der: Vec<u8> = leaf_key.serialize_der();
+        let ca_cert_der: Vec<u8> = ca_issuer.der().to_vec();
+
+        // Combine leaf cert and CA cert chain
+        let mut cert_chain = leaf_cert_der.clone();
+        cert_chain.extend_from_slice(&ca_cert_der);
+
+        let svid = X509Svid::parse_from_der(&cert_chain, &leaf_key_der)
+            .map_err(|e| {
+                tracing::error!("Failed to parse SVID: {}", e);
+                e
+            })
+            .unwrap();
+
+        svid
+    }
+}

--- a/src/identity/spireclient.rs
+++ b/src/identity/spireclient.rs
@@ -473,10 +473,8 @@ pub mod spire_tests {
 
         assert!(identity.to_string() == "spiffe://example.org/ns/default/sa/test-sa");
 
-        let composite_id = CompositeId::with_key(
-            identity,
-            WorkloadUid::new("uid-123456".to_string()),
-        );
+        let composite_id =
+            CompositeId::with_key(identity, WorkloadUid::new("uid-123456".to_string()));
 
         let fetch_result = spire_client.fetch_certificate(&composite_id).await;
 
@@ -676,10 +674,8 @@ pub mod spire_tests {
 
         assert!(identity.to_string() == "spiffe://example.org/ns/default/sa/test-sa");
 
-        let composite_id = CompositeId::with_key(
-            identity,
-            WorkloadUid::new("uid-123456".to_string()),
-        );
+        let composite_id =
+            CompositeId::with_key(identity, WorkloadUid::new("uid-123456".to_string()));
 
         let fetch_result = spire_client.fetch_certificate(&composite_id).await;
 
@@ -793,8 +789,6 @@ pub mod spire_tests {
     fn mock_stream_svid_success_response(
         spiffe_id: String,
     ) -> Box<dyn Stream<Item = Result<X509Svid, GrpcClientError>> + Send + Unpin> {
-        // build a stream that yields X509Svid responses
-        // can you provide a minimal example of building such a stream?
         let (mut tx, rx) = mpsc::channel(10);
         tokio::spawn(async move {
             let svid = generate_svid(&spiffe_id, "example.org");
@@ -806,8 +800,6 @@ pub mod spire_tests {
     fn mock_stream_svid_success_delay_response(
         spiffe_id: String,
     ) -> Box<dyn Stream<Item = Result<X509Svid, GrpcClientError>> + Send + Unpin> {
-        // build a stream that yields X509Svid responses
-        // can you provide a minimal example of building such a stream?
         let (mut tx, rx) = mpsc::channel(10);
         tokio::spawn(async move {
             tx.send(Err(GrpcClientError::EmptyResponse)).await.unwrap();
@@ -823,8 +815,6 @@ pub mod spire_tests {
     fn mock_stream_svid_success_delay_response_timeout(
         _: String,
     ) -> Box<dyn Stream<Item = Result<X509Svid, GrpcClientError>> + Send + Unpin> {
-        // build a stream that yields X509Svid responses
-        // can you provide a minimal example of building such a stream?
         let (_, rx) = mpsc::channel(10);
         tokio::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
@@ -835,8 +825,6 @@ pub mod spire_tests {
     fn mock_stream_svid_success_delay_response_timeout_empty(
         _: String,
     ) -> Box<dyn Stream<Item = Result<X509Svid, GrpcClientError>> + Send + Unpin> {
-        // build a stream that yields X509Svid responses
-        // can you provide a minimal example of building such a stream?
         let (mut tx, rx) = mpsc::channel(10);
         tokio::spawn(async move {
             tx.send(Err(GrpcClientError::EmptyResponse)).await.unwrap();

--- a/src/identity/spireclient.rs
+++ b/src/identity/spireclient.rs
@@ -204,52 +204,46 @@ impl<C: DelegatedIdentityApi> SpireClient<C> {
         &self,
         value: DelegateAttestationRequest,
     ) -> Result<X509Svid, Error> {
-        // Initiate streaming request to SPIRE server using Kubernetes selectors
-        // clone() is cheap here as DelegatedIdentityClient uses Arc internally
-        let stream = self.client.get_x509_svids(value).await.map_err(|e| {
-            Error::FailedToFetchCertificate(format!("Failed to stream X.509 SVIDs: {e}"))
-        })?;
-        // Set reasonable timeout to prevent indefinite blocking on unresponsive SPIRE servers
         let time_out = self.cfg.spire_timeout;
 
-        // Process the stream with timeout protection
-        // SPIRE may deliver multiple responses, but we only need the first successful one
-        tokio::pin!(stream);
+        // Wrap both stream establishment AND reading in a single timeout.
+        // The gRPC stream_x509_svids call can hang indefinitely if the SPIRE
+        // agent's socket accepts the connection but never responds (e.g., during
+        // a prolonged restart). Without this, a hung connection blocks the
+        // identity manager's fetch slot and prevents cert rotation.
         let sf = tokio::time::timeout(time_out, async {
+            let stream = self.client.get_x509_svids(value).await.map_err(|e| {
+                Error::FailedToFetchCertificate(format!("Failed to stream X.509 SVIDs: {e}"))
+            })?;
+
+            // SPIRE may deliver multiple responses, but we only need the first successful one
+            tokio::pin!(stream);
             while let Some(svid_response) = stream.next().await {
                 match svid_response {
                     Ok(response) => {
-                        // Successfully received a certificate - return immediately
                         return Ok(response);
                     }
                     Err(e) => {
-                        // Log stream errors but continue waiting for subsequent responses
-                        // Some responses may fail while others succeed
                         tracing::warn!("Error receiving SVID response: {}", e);
                     }
                 }
             }
-            // Stream ended without delivering any successful responses
             Err(Error::FailedToFetchCertificate(
                 "No SVIDs received in stream".to_string(),
             ))
         })
         .await;
 
-        // Handle nested Result types from timeout + stream operations
-        let svid_response = match sf {
-            Ok(Ok(response)) => response, // Successfully got certificate within timeout
-            Ok(Err(e)) => return Err(e),
+        match sf {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(e)) => Err(e),
             Err(_) => {
-                // Timeout expired before receiving any certificates
-                tracing::error!("Timeout while waiting for SVID stream");
-                return Err(Error::FailedToFetchCertificate(
+                tracing::error!("Timeout while waiting for SPIRE SVID (stream establishment or reading took longer than {:?})", time_out);
+                Err(Error::FailedToFetchCertificate(
                     "Timeout while waiting for SVID stream".to_string(),
-                ));
+                ))
             }
-        };
-
-        Ok(svid_response)
+        }
     }
 
     /// Fetches a workload certificate from SPIRE using the provided attestation request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod assertions;
 pub mod baggage;
 pub mod cert_fetcher;
 pub mod config;
+pub mod container_runtime;
 pub mod copy;
 pub mod dns;
 pub mod drain;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -33,7 +33,7 @@ use tracing::{Instrument, debug, trace, warn};
 use inbound::Inbound;
 pub use metrics::*;
 
-use crate::identity::{CompositeId, Identity, RequestKeyEnum, SecretManager};
+use crate::identity::{CompositeId, Identity, RequestKey, SecretManager};
 
 use crate::dns::resolver::Resolver;
 use crate::drain::DrainWatcher;
@@ -217,10 +217,10 @@ impl LocalWorkloadInformation {
         let key = if self.cfg.spire_enabled {
             CompositeId::new(
                 id.clone(),
-                RequestKeyEnum::Workload(WorkloadUid::new(wl.uid.to_string())),
+                RequestKey::Workload(WorkloadUid::new(wl.uid.to_string())),
             )
         } else {
-            CompositeId::new(id.clone(), RequestKeyEnum::Identity(wl.identity().clone()))
+            CompositeId::new(id.clone(), RequestKey::Identity(wl.identity().clone()))
         };
 
         self.full_cert_manager.fetch_certificate(&key).await

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -22,6 +22,7 @@ use std::{fmt, io};
 
 use hickory_proto::ProtoError;
 
+use crate::inpod::WorkloadUid;
 use crate::strng::Strng;
 use rand::Rng;
 use socket2::TcpKeepalive;
@@ -32,7 +33,7 @@ use tracing::{Instrument, debug, trace, warn};
 use inbound::Inbound;
 pub use metrics::*;
 
-use crate::identity::{Identity, SecretManager};
+use crate::identity::{CompositeId, Identity, RequestKeyEnum, SecretManager};
 
 use crate::dns::resolver::Resolver;
 use crate::drain::DrainWatcher;
@@ -177,6 +178,7 @@ pub struct LocalWorkloadInformation {
     // full_cert_manager gives access to the full SecretManager. This MUST only be given restricted
     // access to the appropriate certificates
     full_cert_manager: Arc<SecretManager>,
+    cfg: Arc<config::Config>,
 }
 
 impl LocalWorkloadInformation {
@@ -184,11 +186,13 @@ impl LocalWorkloadInformation {
         wi: Arc<WorkloadInfo>,
         state: DemandProxyState,
         cert_manager: Arc<SecretManager>,
+        cfg: Arc<config::Config>,
     ) -> LocalWorkloadInformation {
         LocalWorkloadInformation {
             wi,
             state,
             full_cert_manager: cert_manager,
+            cfg: cfg.clone(),
         }
     }
 
@@ -209,7 +213,17 @@ impl LocalWorkloadInformation {
             namespace: (&self.wi.namespace).into(),
             service_account: (&self.wi.service_account).into(),
         };
-        self.full_cert_manager.fetch_certificate(id).await
+
+        let key = if self.cfg.spire_enabled {
+            CompositeId::new(
+                id.clone(),
+                RequestKeyEnum::Workload(WorkloadUid::new(wl.uid.to_string())),
+            )
+        } else {
+            CompositeId::new(id.clone(), RequestKeyEnum::Identity(wl.identity().clone()))
+        };
+
+        self.full_cert_manager.fetch_certificate(&key).await
     }
 
     pub fn workload_info(&self) -> Arc<WorkloadInfo> {

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -959,6 +959,7 @@ mod tests {
             }),
             state.clone(),
             new_secret_manager(Duration::from_secs(10)),
+            Arc::new(cfg.clone()),
         ));
         let pi = Arc::new(ProxyInputs::new(
             Arc::new(cfg),

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -868,6 +868,7 @@ mod tests {
             Arc::new(wi.clone()),
             state.clone(),
             identity::mock::new_secret_manager(Duration::from_secs(10)),
+            cfg.clone(),
         ));
         let outbound = OutboundConnection {
             pi: Arc::new(ProxyInputs {
@@ -1974,6 +1975,7 @@ mod tests {
             Arc::new(wi.clone()),
             state.clone(),
             identity::mock::new_secret_manager(Duration::from_secs(10)),
+            cfg.clone(),
         ));
 
         let outbound = OutboundConnection {

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -1027,6 +1027,7 @@ mod test {
             }),
             mock_proxy_state,
             identity::mock::new_secret_manager(Duration::from_secs(10)),
+            Arc::new(cfg.clone()),
         ));
         let pool = WorkloadHBONEPool::new(Arc::new(cfg), sock_fact, local_workload);
         let server = TestServer {

--- a/src/proxyfactory.rs
+++ b/src/proxyfactory.rs
@@ -128,6 +128,7 @@ impl ProxyFactory {
             Arc::new(proxy_workload_info),
             self.state.clone(),
             self.cert_manager.clone(),
+            self.config.clone(),
         ));
 
         // Optionally create the DNS proxy.
@@ -196,6 +197,7 @@ impl ProxyFactory {
                 Arc::new(ztunnel_workload.clone()),
                 self.state.clone(),
                 self.cert_manager.clone(),
+                self.config.clone(),
             ));
 
             let socket_factory = Arc::new(DefaultSocketFactory(self.config.socket_config));

--- a/src/tls/certificate.rs
+++ b/src/tls/certificate.rs
@@ -18,6 +18,7 @@ use base64::engine::general_purpose::STANDARD;
 use bytes::Bytes;
 use itertools::Itertools;
 use std::{cmp, iter};
+use x509_parser::asn1_rs::FromDer;
 
 use rustls::client::Resumption;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
@@ -269,6 +270,59 @@ impl WorkloadCertificate {
             private_key: key,
             roots,
             root_store: Arc::new(roots_store),
+        })
+    }
+
+    pub fn new_svid(
+        svid: &spiffe::X509Svid,
+        bundle: &[spiffe::cert::Certificate],
+    ) -> Result<WorkloadCertificate, Error> {
+        let leaf = svid.leaf();
+        let chain = svid
+            .cert_chain()
+            .iter()
+            .map(|c| {
+                let (_, cert) = x509_parser::parse_x509_certificate(c.content()).unwrap();
+                Certificate {
+                    der: c.content().to_vec().into(),
+                    expiry: expiration(cert),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let cert = X509Certificate::from_der(leaf.content()).unwrap();
+        let cert = Certificate {
+            der: leaf.content().to_vec().into(),
+            expiry: expiration(cert.1),
+        };
+
+        let private_key = PrivateKeyDer::Pkcs8(svid.private_key().content().to_vec().into());
+
+        let roots = bundle
+            .iter()
+            .map(|c| {
+                let (_, cert) = x509_parser::parse_x509_certificate(c.content()).unwrap();
+                Certificate {
+                    der: c.content().to_vec().into(),
+                    expiry: expiration(cert),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut roots_store = RootCertStore::empty();
+
+        let (_valid, invalid) = roots_store
+            .add_parsable_certificates(bundle.iter().map(|c| c.content().to_vec().into()));
+        if invalid > 0 {
+            tracing::warn!("warning: found {invalid} invalid root certs");
+        }
+
+        Ok(WorkloadCertificate {
+            cert,
+            private_key,
+            roots,
+            root_store: Arc::new(roots_store),
+            chain,
         })
     }
 

--- a/src/tls/control.rs
+++ b/src/tls/control.rs
@@ -20,6 +20,7 @@ use hyper::Uri;
 use hyper::body::Incoming;
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioIo;
 use itertools::Itertools;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
@@ -30,6 +31,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
+use tokio::net::UnixStream;
 use tonic::body::Body;
 use tracing::debug;
 
@@ -273,5 +275,249 @@ impl tower::Service<http::Request<Body>> for TlsGrpcChannel {
             auth.insert_headers(req.headers_mut()).await?;
             Ok(client.request(req).await?)
         })
+    }
+}
+
+/// UdsConnector provides a hyper connector for Unix domain sockets.
+#[derive(Clone)]
+struct UdsConnector {
+    path: String,
+}
+
+impl tower::Service<Uri> for UdsConnector {
+    type Response = TokioIo<UnixStream>;
+    type Error = std::io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _uri: Uri) -> Self::Future {
+        let path = self.path.clone();
+        Box::pin(async move {
+            let stream = tokio::time::timeout(Duration::from_secs(5), UnixStream::connect(&path))
+                .await
+                .map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!("unix socket connect timeout: {path}"),
+                    )
+                })?
+                .map_err(|e| std::io::Error::other(format!("unix socket {path}: {e}")))?;
+            Ok(TokioIo::new(stream))
+        })
+    }
+}
+
+/// UdsGrpcChannel provides a gRPC channel over Unix domain sockets.
+/// Unix domain sockets are used for local inter-process communication and are
+/// not exposed over the network, so TLS is not required.
+#[derive(Clone)]
+pub struct UdsGrpcChannel {
+    client: hyper_util::client::legacy::Client<UdsConnector, Body>,
+    auth: Arc<AuthSource>,
+}
+
+/// uds_grpc_connector creates a gRPC channel over a Unix domain socket.
+pub fn uds_grpc_connector(socket_path: String, auth: AuthSource) -> Result<UdsGrpcChannel, Error> {
+    let connector = UdsConnector { path: socket_path };
+    let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+        .http2_only(true)
+        .http2_keep_alive_interval(Duration::from_secs(30))
+        .http2_keep_alive_timeout(Duration::from_secs(10))
+        .timer(crate::hyper_util::TokioTimer)
+        .build(connector);
+
+    Ok(UdsGrpcChannel {
+        client,
+        auth: Arc::new(auth),
+    })
+}
+
+impl tower::Service<http::Request<Body>> for UdsGrpcChannel {
+    type Response = http::Response<Incoming>;
+    type Error = anyhow::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Ok(()).into()
+    }
+
+    fn call(&mut self, mut req: http::Request<Body>) -> Self::Future {
+        // For Unix sockets, use a dummy authority since we connect to a path
+        let uri = Uri::builder()
+            .scheme("http")
+            .authority("localhost")
+            .path_and_query(
+                req.uri()
+                    .path_and_query()
+                    .map(|pq| pq.to_owned())
+                    .unwrap_or_else(|| "/".parse().unwrap()),
+            )
+            .build()
+            .expect("uri must be valid");
+        *req.uri_mut() = uri;
+
+        let client = self.client.clone();
+        let auth = self.auth.clone();
+        Box::pin(async move {
+            auth.insert_headers(req.headers_mut()).await?;
+            Ok(client.request(req).await?)
+        })
+    }
+}
+
+/// GrpcChannel represents a gRPC channel that can be either TLS-based or Unix socket-based.
+#[derive(Clone)]
+pub enum GrpcChannel {
+    Tls(TlsGrpcChannel),
+    Uds(UdsGrpcChannel),
+}
+
+impl tower::Service<http::Request<Body>> for GrpcChannel {
+    type Response = http::Response<Incoming>;
+    type Error = anyhow::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self {
+            GrpcChannel::Tls(c) => c.poll_ready(cx),
+            GrpcChannel::Uds(c) => c.poll_ready(cx),
+        }
+    }
+
+    fn call(&mut self, req: http::Request<Body>) -> Self::Future {
+        match self {
+            GrpcChannel::Tls(c) => c.call(req),
+            GrpcChannel::Uds(c) => c.call(req),
+        }
+    }
+}
+
+/// Creates a gRPC channel based on the URI scheme.
+/// - `unix:///path` -> Unix socket connection (no TLS)
+/// - `https://host:port` -> TLS connection
+pub fn grpc_channel(
+    uri: String,
+    auth: AuthSource,
+    tls_config: Option<ClientConfig>,
+) -> Result<GrpcChannel, Error> {
+    if let Some(path) = unix_socket_path(&uri) {
+        return Ok(GrpcChannel::Uds(uds_grpc_connector(
+            path.to_string(),
+            auth,
+        )?));
+    }
+
+    // Use TLS connector (existing behavior)
+    let tls_config = tls_config.ok_or_else(|| {
+        Error::InvalidRootCert("TLS config required for HTTPS connections".to_string())
+    })?;
+    Ok(GrpcChannel::Tls(grpc_connector(uri, auth, tls_config)?))
+}
+
+/// Checks if a URI string uses the unix: scheme and extracts the socket path.
+/// Only absolute paths (starting with `/`) are accepted.
+/// Supported forms: `unix:///path`, `unix:/path`.
+/// hyper's Uri parser does not support unix: URIs, so this uses string parsing.
+pub fn unix_socket_path(uri: &str) -> Option<&str> {
+    let path = uri
+        .strip_prefix("unix://")
+        .or_else(|| uri.strip_prefix("unix:"))?;
+    // Only accept absolute paths with a real filename (not just "/")
+    if path.starts_with('/') && path.len() > 1 {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::AuthSource;
+
+    #[test]
+    fn test_grpc_channel_returns_uds_for_unix_scheme() {
+        // unix:///path form
+        let channel = grpc_channel("unix:///tmp/test.sock".to_string(), AuthSource::None, None);
+        assert!(channel.is_ok(), "expected Ok, got: {:?}", channel.err());
+        assert!(matches!(channel.unwrap(), GrpcChannel::Uds(_)));
+
+        // unix:/path form
+        let channel = grpc_channel("unix:/tmp/test.sock".to_string(), AuthSource::None, None);
+        assert!(channel.is_ok(), "expected Ok, got: {:?}", channel.err());
+        assert!(matches!(channel.unwrap(), GrpcChannel::Uds(_)));
+
+        // relative path rejected — falls through to TLS path which fails without TLS config
+        let channel = grpc_channel(
+            "unix://relative/test.sock".to_string(),
+            AuthSource::None,
+            None,
+        );
+        assert!(channel.is_err());
+    }
+
+    #[test]
+    fn test_grpc_channel_requires_tls_for_https() {
+        let channel = grpc_channel(
+            "https://localhost:15012".to_string(),
+            AuthSource::None,
+            None,
+        );
+        assert!(channel.is_err());
+    }
+
+    #[test]
+    fn test_grpc_channel_invalid_uri() {
+        let channel = grpc_channel("".to_string(), AuthSource::None, None);
+        assert!(channel.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_uds_connector_connects_to_socket() {
+        use tempfile::tempdir;
+        use tokio::net::UnixListener;
+        use tower::Service;
+
+        let dir = tempdir().unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let _listener = UnixListener::bind(&sock_path).unwrap();
+
+        let mut connector = UdsConnector {
+            path: sock_path.to_str().unwrap().to_string(),
+        };
+
+        let ready = futures::future::poll_fn(|cx| connector.poll_ready(cx)).await;
+        assert!(ready.is_ok());
+
+        let result = connector.call("http://localhost".parse().unwrap()).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_uds_connector_fails_on_nonexistent_socket() {
+        use tower::Service;
+
+        let mut connector = UdsConnector {
+            path: "/tmp/ztunnel_test_nonexistent.sock".to_string(),
+        };
+
+        let result = connector.call("http://localhost".parse().unwrap()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_uds_grpc_connector_builds_channel() {
+        use tempfile::tempdir;
+        use tokio::net::UnixListener;
+
+        let dir = tempdir().unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let _listener = UnixListener::bind(&sock_path).unwrap();
+
+        let channel = uds_grpc_connector(sock_path.to_str().unwrap().to_string(), AuthSource::None);
+        assert!(channel.is_ok());
     }
 }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -191,7 +191,7 @@ impl ProxyStateUpdateMutator {
                     .workloads
                     .was_last_identity_on_node(&prev.node, &prev.identity())
             {
-                self.cert_fetcher.clear_cert(&prev.identity());
+                self.cert_fetcher.clear_cert(&prev);
             }
             // We removed a workload, no reason to attempt to remove a service with the same name
             return;

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -622,13 +622,23 @@ impl AdsClient {
         };
 
         let addr = self.config.address.clone();
-        let tls_grpc_channel = tls::grpc_connector(
+        let is_unix = tls::unix_socket_path(&self.config.address).is_some();
+
+        let tls_config = if is_unix {
+            None // Unix domain sockets provide local IPC, TLS is not required
+        } else {
+            Some(
+                self.config
+                    .tls_builder
+                    .fetch_cert(self.config.alt_hostname.clone())
+                    .await?,
+            )
+        };
+
+        let grpc_channel = tls::grpc_channel(
             self.config.address.clone(),
             self.config.auth.clone(),
-            self.config
-                .tls_builder
-                .fetch_cert(self.config.alt_hostname.clone())
-                .await?,
+            tls_config,
         )?;
 
         let mut req = tonic::Request::new(outbound);
@@ -640,7 +650,7 @@ impl AdsClient {
             }
         });
 
-        let ads_connection = AggregatedDiscoveryServiceClient::new(tls_grpc_channel)
+        let ads_connection = AggregatedDiscoveryServiceClient::new(grpc_channel)
             .max_decoding_message_size(200 * 1024 * 1024)
             .delta_aggregated_resources(req)
             .await;
@@ -1295,5 +1305,31 @@ mod tests {
         // JSON null
         v = serde_json::json!(());
         assert_eq!(Config::json_to_value(v).kind.unwrap(), NullValue(0));
+    }
+
+    #[test]
+    fn test_unix_uri_scheme_detection() {
+        use crate::tls::unix_socket_path;
+
+        // unix:///path extracts the socket path
+        assert_eq!(
+            unix_socket_path("unix:///run/xds.sock"),
+            Some("/run/xds.sock")
+        );
+
+        // unix:/path also works
+        assert_eq!(
+            unix_socket_path("unix:/run/xds.sock"),
+            Some("/run/xds.sock")
+        );
+
+        // relative path rejected
+        assert_eq!(unix_socket_path("unix://run/xds.sock"), None);
+
+        // https is not a unix socket
+        assert_eq!(unix_socket_path("https://istiod:15012"), None);
+
+        // plain hostname is not a unix socket
+        assert_eq!(unix_socket_path("istiod:15012"), None);
     }
 }

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -1024,7 +1024,10 @@ mod namespaced {
                 let dst_id =
                     identity::Identity::from_str("spiffe://cluster.local/ns/default/sa/server")
                         .unwrap();
-                let cert = zt.cert_manager.fetch_certificate(id).await?;
+                let cert = zt
+                    .cert_manager
+                    .fetch_certificate(&id.to_composite_id())
+                    .await?;
                 let connector = cert.outbound_connector(vec![dst_id]).unwrap();
                 let hbone = SocketAddr::new(srv.ip(), 15008);
                 let tcp_stream = TcpStream::connect(hbone).await.unwrap();
@@ -1086,7 +1089,10 @@ mod namespaced {
                 let dst_id =
                     identity::Identity::from_str("spiffe://cluster.local/ns/default/sa/server")
                         .unwrap();
-                let cert = zt.cert_manager.fetch_certificate(id).await?;
+                let cert = zt
+                    .cert_manager
+                    .fetch_certificate(&id.to_composite_id())
+                    .await?;
                 let connector = cert.outbound_connector(vec![dst_id]).unwrap();
                 let tcp_stream = TcpStream::connect(SocketAddr::from((srv.ip(), 15008)))
                     .await
@@ -1168,7 +1174,10 @@ mod namespaced {
                 let dst_id =
                     identity::Identity::from_str("spiffe://cluster.local/ns/default/sa/server")
                         .unwrap();
-                let cert = zt.cert_manager.fetch_certificate(id).await?;
+                let cert = zt
+                    .cert_manager
+                    .fetch_certificate(&id.to_composite_id())
+                    .await?;
                 let connector = cert.outbound_connector(vec![dst_id]).unwrap();
                 let tcp_stream = TcpStream::connect(SocketAddr::from((srv.ip(), 15008)))
                     .await
@@ -1325,7 +1334,7 @@ mod namespaced {
         let ta = manager.deploy_ztunnel(DEFAULT_NODE).await?;
         let ztunnel_identity_obj = ta.ztunnel_identity.as_ref().unwrap().clone();
         ta.cert_manager
-            .fetch_certificate(&ztunnel_identity_obj)
+            .fetch_certificate(&ztunnel_identity_obj.to_composite_id())
             .await?;
         let ztunnel_identity_str = ztunnel_identity_obj.to_string();
 

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -1219,7 +1219,7 @@ mod namespaced {
                 (zt, 15080, Request),      // socks5: localhost
                 (zt, 15000, Request),      // admin: localhost
                 (zt, 15020, Http),         // Stats: accept connection and returns a HTTP error
-                (zt, 15021, Http),         // Readiness: accept connection and returns a HTTP error
+                (zt, 15021, Request),      // Readiness: bound to localhost, connection reset
                 (ourself, 15001, Request), // Outbound: should be blocked due to recursive call
                 (ourself, 15006, Request), // Inbound: should be blocked due to recursive call
                 (ourself, 15008, Request), // HBONE: expected TLS, reject
@@ -1251,7 +1251,7 @@ mod namespaced {
                 (zt, 15080, Connection), // socks5: localhost
                 (zt, 15000, Connection), // admin: localhost
                 (zt, 15020, Http),       // Stats: accept connection and returns a HTTP error
-                (zt, 15021, Http),       // Readiness: accept connection and returns a HTTP error
+                (zt, 15021, Connection), // Readiness: bound to localhost, not reachable
                 // All are accepted as "inbound plaintext" but then immediately closed
                 (ourself, 15001, Request),
                 (ourself, 15006, Request),


### PR DESCRIPTION
# SPIRE Delegated Identity API Integration for ztunnel

## Overview

This document describes the design and implementation of SPIRE integration in ztunnel using the Delegated Identity API. The implementation supports one attestation mode: **PID-based**, each with different security and efficiency trade-offs.

## Background

### Current ztunnel Certificate Management

The existing ztunnel certificate management uses `SecretManager` to cache certificates by `Identity` (SPIFFE ID). When multiple pods share the same service account, they share a single cached certificate, reducing CA calls and memory usage.

### SPIRE Delegated Identity API

SPIRE's Delegated Identity API allows a trusted delegate (ztunnel) to request certificates on behalf of workloads. The API supports two attestation methods:

1. **Selectors**: Identify workloads by Kubernetes namespace + service account (We are not using this as its Spire specific)
2. **PID**: Identify workloads by their process ID for stronger attestation

## Design

### Attestation Modes

In PID mode, each workload is attested individually using its container process ID. This approach:

- Provides stronger security through per-workload attestation
- Each pod receives its own certificate from SPIRE
- Higher SPIRE server load and memory usage
- SPIRE verifies the actual running process, not just Kubernetes metadata

```
┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
│  Pod A (PID 1)  │     │  Pod B (PID 2)  │     │  Pod C (PID 3)  │
└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
         │                       │                       │
         ▼                       ▼                       ▼
┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
│  Certificate A  │     │  Certificate B  │     │  Certificate C  │
│ (SPIRE call #1) │     │ (SPIRE call #2) │     │ (SPIRE call #3) │
└─────────────────┘     └─────────────────┘     └─────────────────┘
```

### CompositeId Design

#### Motivation

The original `SecretManager` used `Identity` as the cache key. To support PID-based attestation while maintaining backward compatibility with the existing `CaClientTrait` interface, we introduced `CompositeId<RequestKeyEnum>`.

#### Structure

```rust
pub struct CompositeId<RequestKeyEnum> {
    id: Identity,           // The SPIFFE identity (ns/sa)
    key: RequestKeyEnum,    // Distinguishes individual workloads
}

pub enum RequestKeyEnum {
    Identity(Identity),     // For backwards compability
    Workload(WorkloadUid),  // For PID mode: key by workload UID
}
```

#### Trade-offs

This design was chosen to maintain backward compatibility with `CaClientTrait`:

```rust
#[async_trait]
pub trait CaClientTrait: Send + Sync {
    async fn fetch_certificate(
        &self, 
        id: &CompositeId<RequestKeyEnum>
    ) -> Result<tls::WorkloadCertificate, Error>;
}
```

**Benefits:**

- Single interface works for both SPIRE modes and the original CA client
- No breaking changes to existing code paths
- `SecretManager` can track per-workload state when needed

**Consequences:**

- In PID mode, `SecretManager` caches by `CompositeId`, resulting in one cache entry per pod even if they share the same identity
- This is intentional—each workload must be individually attested

### PID Verification Flow

In PID mode, ztunnel performs the following steps:

1. Receive certificate request with `WorkloadUid`
2. Query Container Runtime (CRI) for the container's PID
3. Call SPIRE with the PID for attestation
4. Re-verify PID after SPIRE returns (guards against PID reuse attacks)
5. Return certificate to caller

```rust
async fn get_cert_by_pid(&self, pid: i32, wl_uid: &WorkloadUid) -> Result<...> {
    // 1. Get certificate from SPIRE using PID
    let certs = self.get_cert_from_spire(DelegateAttestationRequest::Pid(pid)).await;
    
    // 2. Re-verify PID hasn't changed (TOCTOU protection)
    if let Some(pid_client) = &self.pid {
        let fetched_pid = pid_client.fetch_pid(wl_uid).await?;
        if fetched_pid.into_i32() != pid {
            return Err(Error::UnableToDeterminePidForWorkload(...));
        }
    }
    
    Ok(certs?)
}
```

## Comparison Summary

| Aspect | Selector Mode | PID Mode |
|--------|---------------|----------|
| **Attestation Granularity** | Per identity (ns/sa) | Per workload (pod) |
| **Certificate Sharing** | Yes—same identity shares cert | No—each pod gets own cert |
| **SPIRE Calls** | 1 per unique identity | 1 per pod |
| **Memory Usage** | Lower | Higher |
| **Security Level** | Standard | Enhanced |
| **Cache Key** | `CompositeId` with `Identity` key | `CompositeId` with `WorkloadUid` key |

## Configuration

```yaml
# Enable SPIRE integration
spire_enabled: true

# Choose attestation mode
spire_mode: "ByPid"  # or "BySelectors"

# SPIRE socket path
spire_socket_path: "/run/spire/sockets/agent.sock"

# Timeout for SPIRE operations  
spire_timeout: "30s"
```

## Future Considerations

1. **Certificate Caching with Per-Pod Attestation**: In PID mode, we should cache and reuse certificates by `Identity` while still attesting every pod individually. This would reduce SPIRE server load and memory usage—multiple pods with the same identity would share one certificate after each pod passes local PID verification. The first pod triggers a SPIRE call; subsequent pods with the same identity only require local PID verification before reusing the cached certificate.

2. **Collaborate with SPIRE/SPIFFE Community**: Work with the SPIRE and SPIFFE community to improve the Delegated Identity API and related interfaces to better support delegated attestation use cases like ztunnel's.

3. Consider a different trait for attested workloads instead of modifying fetch_certificate.