### PR TITLE
Update tonic/prost crates to 0.14.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
  "flate2",
  "num",
  "paste",
- "prost",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -2448,23 +2448,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.1",
  "prost-types",
  "regex",
  "syn 2.0.110",
@@ -2478,7 +2488,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
@@ -2486,11 +2509,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
- "prost",
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -3501,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3513,7 +3536,7 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "sync_wrapper",
  "tokio-stream",
  "tower-layer",
  "tower-service",
@@ -3522,9 +3545,32 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+dependencies = [
+ "bytes",
+ "prost 0.14.1",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3532,6 +3578,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.110",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -4410,8 +4458,7 @@ dependencies = [
  "pprof",
  "prometheus-client",
  "prometheus-parse",
- "prost",
- "prost-build",
+ "prost 0.14.1",
  "prost-types",
  "rand 0.9.2",
  "rcgen",
@@ -4436,7 +4483,8 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ num_cpus = "1.16"
 ppp = "2.3"
 prometheus-client = { version = "0.24" }
 prometheus-parse = "0.2"
-prost = "0.13"
-prost-types = "0.13"
+prost = { version = "0.14", default-features = false }
+prost-types = { version = "0.14", default-features = false }
 rand = { version = "0.9" , features = ["small_rng"]}
 rcgen = { version = "0.14", optional = true, features = ["pem"] }
 rustls = { version = "0.23", default-features = false }
@@ -94,7 +94,8 @@ tls-listener = { version = "0.11" }
 tokio = { version = "1.44", features = ["full", "test-util"] }
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.13", default-features = false, features = ["prost", "codegen"] }
+tonic = { version = "0.14", default-features = false, features = ["codegen"] }
+tonic-prost = { version = "0.14", default-features = false }
 tower = { version = "0.5", features = ["full"] }
 tracing = { version = "0.1"}
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "json"] }
@@ -119,8 +120,7 @@ netns-rs = "0.1"
 pprof = { version = "0.15", features = ["protobuf", "protobuf-codec", "criterion"] }
 
 [build-dependencies]
-tonic-build = { version = "0.13", default-features = false, features = ["prost"] }
-prost-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false }
 anyhow = "1.0"
 rustc_version = "0.4"
 

--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), anyhow::Error> {
         .map(|i| std::env::current_dir().unwrap().join(i))
         .collect::<Vec<_>>();
     let config = {
-        let mut c = prost_build::Config::new();
+        let mut c = tonic_prost_build::Config::new();
         c.disable_comments(Some("."));
         c.bytes([
             ".istio.workload.Workload",
@@ -47,9 +47,9 @@ fn main() -> Result<(), anyhow::Error> {
         ]);
         c
     };
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
-        .compile_protos_with_config(
+        .compile_with_config(
             config,
             &proto_files
                 .iter()

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2135,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2145,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -2178,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
 ]
@@ -3072,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3084,7 +3084,7 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "sync_wrapper",
  "tokio-stream",
  "tower-layer",
  "tower-service",
@@ -3093,9 +3093,32 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
+checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3103,6 +3126,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -3897,7 +3922,6 @@ dependencies = [
  "prometheus-client",
  "prometheus-parse",
  "prost",
- "prost-build",
  "prost-types",
  "rand 0.9.0",
  "rcgen",
@@ -3919,7 +3943,8 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower",
  "tracing",
  "tracing-appender",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 hyper = "1.1"
 libfuzzer-sys = "0.4"
-prost = "0.13"
+prost = { version = "0.14", default-features = false }
 anyhow = "1.0"
 
 [dependencies.ztunnel]

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -131,7 +131,7 @@ struct HandlerWrapper<T: prost::Message> {
     h: Box<dyn Handler<T>>,
 }
 
-impl<T: 'static + prost::Message + Default> RawHandler for HandlerWrapper<T> {
+impl<T: 'static + fmt::Debug + prost::Message + Default> RawHandler for HandlerWrapper<T> {
     fn handle(
         &self,
         state: &mut State,
@@ -270,7 +270,7 @@ impl Config {
 
     pub fn with_watched_handler<F>(self, type_url: Strng, f: impl Handler<F>) -> Config
     where
-        F: 'static + prost::Message + Default,
+        F: 'static + fmt::Debug + prost::Message + Default,
     {
         let no_on_demand = f.no_on_demand();
         self.with_handler(type_url.clone(), f)
@@ -279,7 +279,7 @@ impl Config {
 
     fn with_handler<F>(mut self, type_url: Strng, f: impl Handler<F>) -> Config
     where
-        F: 'static + prost::Message + Default,
+        F: 'static + fmt::Debug + prost::Message + Default,
     {
         let h = HandlerWrapper { h: Box::new(f) };
         self.handlers.insert(type_url, Box::new(h));


### PR DESCRIPTION
The only relevant breaking change is that `prost::Message` is no longer
a supertrait of `fmt::Debug`, so that bound is added in the few places
that need it.
