### PR TITLE
metrics: fix dns histogram

### DIFF
--- a/src/dns/metrics.rs
+++ b/src/dns/metrics.rs
@@ -57,7 +57,7 @@ impl Metrics {
         );
 
         let forwarded_duration = Family::<DnsLabels, Histogram>::new_with_constructor(|| {
-            Histogram::new(vec![0.005f64, 0.001, 0.01, 0.1, 1.0, 5.0])
+            Histogram::new(vec![0.0005f64, 0.001, 0.01, 0.1, 1.0, 5.0])
         });
         registry.register_with_unit(
             "dns_upstream_request_duration",


### PR DESCRIPTION
This was incorrectly a larger value than others. If we want tro keep the same bukcets we should properly order them but i think this is better