### PR TITLE
[RFC] Update WDS definition to include service scope

### DIFF
--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -87,8 +87,41 @@ message Service {
   // IP families provides configuration about the IP families this service supports.
   IPFamilies ip_families = 9;
 
+  // Constraints what endpoints can be discovered for this service.
+  // We need this information only when the service has a waypoint. For services with waypoint, ztunnel picks a waypoint
+  // endpoint instead of the actual service endpoint. In multi-cluster environments, it could happen that the scope of
+  // the waypoint itself does not match the scope of the service (e.g., the service is local to the cluster, while waypoint
+  // is global). And when that happens, in an unlikely event when local waypoint is unhealthy we could route a request to
+  // a remote cluster waypoint violating the original scope of the service.
+  //
+  // To deal with the above issue we could record the scope of the service in this field. ztunnel when it picks a waypoint
+  // endpoint can look at the service locality constraint and discard remote waypoint endpoints if the service is local.
+  LocalityConstraint locality_constraint = 11;
+
   // Extension provides a mechanism to attach arbitrary additional configuration to an object.
   repeated Extension extensions = 10;
+}
+
+enum ServiceScope {
+  LOCAL = 0;
+  GLOBAL = 1;
+}
+
+// NOTE: We currently support only uniform service discovery setup, so the service is either globally discoverable everywhere
+// or it's local everywhere. However, it's not inconsivable that in the future we will support more elaborate service
+// discoverability configurations. To make introducing additional types of locality constraints easier in the future, we've
+// extracted service scope into its own proto message.
+message LocalityConstraint {
+  oneof constraint {
+    // When the setup is uniform, e.g., when the service is either local or global in all the clusters of multi-cluster
+    // setup, we only need to tell ztunnel what the service scope:
+    // - when the service scope is GLOBAL it would indicate that instances of the service in all clusters are discoverable
+    //   by all other clusters, so we can use waypoint endpoints in any cluster without constraints; It's also equivalent
+    //   to not setting locality constraints at all.
+    // - when the service scope is LOCAL it means that only the instance of the service in the same cluster as the client
+    //   workload is discoverable, so we should not pick waypoint endpoints outside of the client cluster.
+    ServiceScope scope = 1;
+  }
 }
 
 enum IPFamilies {

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -692,6 +692,7 @@ mod tests {
                 health_policy: 1,
             }), // ..Default::default() // intentionally don't default. we want all fields populated
             ip_families: 0,
+            locality_constraint: Default::default(),
             extensions: Default::default(),
         };
 

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -1122,7 +1122,7 @@ mod tests {
                     waypoint: None,
                     load_balancing: None,
                     ip_families: 0,
-                    extensions: Default::default(),
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -1156,7 +1156,7 @@ mod tests {
                     waypoint: None,
                     load_balancing: None,
                     ip_families: 0,
-                    extensions: Default::default(),
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -1213,7 +1213,7 @@ mod tests {
                     waypoint: None,
                     load_balancing: None,
                     ip_families: 0,
-                    extensions: Default::default(),
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -1524,7 +1524,7 @@ mod tests {
                     waypoint: None,
                     load_balancing: None,
                     ip_families: 0,
-                    extensions: Default::default(),
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -1551,7 +1551,7 @@ mod tests {
                         health_policy: HealthPolicy::AllowAll as i32,
                     }),
                     ip_families: 0,
-                    extensions: Default::default(),
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -1602,7 +1602,7 @@ mod tests {
                 health_policy: HealthPolicy::AllowAll as i32,
             }),
             ip_families: 0,
-            extensions: Default::default(),
+            ..Default::default()
         };
         updater
             .insert_service(
@@ -1623,7 +1623,7 @@ mod tests {
                     waypoint: None,
                     load_balancing: None,
                     ip_families: 0,
-                    extensions: Default::default(),
+                    ..Default::default()
                 },
             )
             .unwrap();


### PR DESCRIPTION
I brough the topic a while back in the WG meeting and started a discussion in slack about it, but we didn't really reach any conclusions yet.

Background: in ambient multi-cluster deployment we control service discoverability by marking them as global (or not). If a service marked as global, the way the API is documented, we expect it to be discoverable from other clusters, if it's not marked as global, then the service is not discoverable from other clusters.

At the moment we only support uniform configurations, e.g., when the same service is either marked as global everywhere or nowhere. It's debatable if we want/need to support non-uniform configurations, so for now we don't commit to decision.

Services may have waypoints configured. When a service has a waypoint, ztunnel when it makes a decision on where to route the request picks one of the waypoint endpoints instead of actual service endpoints.

The problem: waypoints can be made global or local independently of the service. For example, the same waypoint can be shared between a local and a global service, and presumably, be marked as global in this case.

When a service is local, but the waypoint that serves it is global we may end up in the following situation:

1. ztunnel handles an outgoing request for the local service with global waypoint
2. because service has a waypoint ztunnel need to pick a waypoint endpoint to proxy the request to
   - normally, we'd pick a waypoint endpoint that is closest to the ztunnel node, because waypoints are configured `PreferClose` by default
   - in the unlikely case when we don't have any healthy local waypoint endpoint, ztunnel may route to an endpoint in the remote cluster (remember that waypoint itself is global in this scenario)
3. waypoint in the remote cluster receives the request, applies L7 policies and picks a backend in the same cluster as the waypoint:
   - it's ok for the waypoint to pick a backend in the same cluster as the waypoint in general
   - however, in this case, it would mean that request for a local service traveled to another cluster, which goes against the service scope.

All-in-all, we might send a request for a local service to a remote cluster instead of failing it.

NOTE: In case of multi-network multicluster deployment, the request will fail in the E/W gateway in this case, which is better than what we have in single network multicluster, but worse than just failing it in ztunnel.

Currently ztunnel does not actually have any information about the scope of the service. Pilot naturally knows the scope of the service, but it does not distribute it to ztunnels in any way.

Proposed solution:
I propose a WDS change, so that when we push the service metadata to ztunnel we include in that metadata service scope.

With service scope available to ztunnel, when ztunnel selects a waypoint endpoint it can discard those endpoints that don't match the scope of the service, thus avoid proxying traffic to a remote cluster for local service.

In the currently supported cases, where the service is either global everywhere or local everywhere, it's enough to just report whether the service is global or local. When the service is local, it means that we can only allow waypoint endpoints in the same cluster and should discard all other endpoints, even if it means failing the request.

When the service is global, it means that there are no restrictions on service endpoints and we can route the request to any cluster without restrictions.

NOTE: If at some point in the future we decide to support non-uniform configurations, we'd have to extend this API to provide somehow the list of allowed or prohibited clusters for services that are not configured uniformly. For now though we don't commit to supporting such a use case and we haven't heard of any users that would want it.

Other considerations:

Istio also supports waypoints for workloads, even though it's not the default. Workloads don't have a scope like services do, so currently ztunnel can pick any waypoint endpoint when we are targeting a workload, including a waypoint on another network, which is not correct.

To address this problem for workloads we don't actually need to make any changes to WDS though. When we target a workload, it should be enough to limit waypoint endpoints to the endpoints on the same network when we target a workload instead of a service.

Related to https://github.com/istio/istio/issues/57710

NOTE: I also have an implementation of the ztunnel and pilot changes, but I cannot put ztunnel and pilot changes in one PR and opted to separate discussion of the WDS changes from the actual ztunnel implementation, though if anybody would find it helpful to see those changes I can provide them as well.

CC a few people involved into the discussion of this issue at different times explicitly:

@keithmattix @therealmitchconnors @ilrudie @howardjohn @jaellio @Stevenjin8 @grnmeira 