### PR TITLE
add support for TLSv1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ boring-sys = { version = "4", optional = true }
 ring = { version = "0.17", optional = true }
 
 # Enabled with 'tls-openssl'
-rustls-openssl = { version = "0.3", optional = true }
+rustls-openssl = { version = "0.3", optional = true, features = ["tls12"]}
 openssl = { version = "0.10", optional = true }
 
 anyhow = "1.0"
@@ -81,7 +81,7 @@ prost = { version = "0.14", default-features = false }
 prost-types = { version = "0.14", default-features = false }
 rand = { version = "0.9" , features = ["small_rng"]}
 rcgen = { version = "0.14", optional = true, features = ["pem"] }
-rustls = { version = "0.23", default-features = false }
+rustls = { version = "0.23", features = ["tls12"], default-features = false }
 rustls-native-certs = "0.8"
 rustls-pemfile = "2.2"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,3 +49,7 @@ pub mod test_helpers;
 #[allow(dead_code)]
 static PQC_ENABLED: Lazy<bool> =
     Lazy::new(|| env::var("COMPLIANCE_POLICY").unwrap_or_default() == "pqc");
+
+#[allow(dead_code)]
+static TLS12_ENABLED: Lazy<bool> =
+    Lazy::new(|| env::var("TLS12_ENABLED").unwrap_or_default() == "true");

--- a/src/tls/certificate.rs
+++ b/src/tls/certificate.rs
@@ -311,7 +311,7 @@ impl WorkloadCertificate {
         let client_cert_verifier =
             crate::tls::workload::TrustDomainVerifier::new(raw_client_cert_verifier, td);
         let mut sc = ServerConfig::builder_with_provider(crate::tls::lib::provider())
-            .with_protocol_versions(tls::TLS_VERSIONS)
+            .with_protocol_versions(tls::tls_versions())
             .expect("server config must be valid")
             .with_client_cert_verifier(client_cert_verifier)
             .with_single_cert(
@@ -326,7 +326,7 @@ impl WorkloadCertificate {
         let roots = self.root_store.clone();
         let verifier = IdentityVerifier { roots, identity };
         let mut cc = ClientConfig::builder_with_provider(crate::tls::lib::provider())
-            .with_protocol_versions(tls::TLS_VERSIONS)
+            .with_protocol_versions(tls::tls_versions())
             .expect("client config must be valid")
             .dangerous() // Customer verifier is requires "dangerous" opt-in
             .with_custom_certificate_verifier(Arc::new(verifier))

--- a/src/tls/control.rs
+++ b/src/tls/control.rs
@@ -182,7 +182,7 @@ async fn control_plane_client_config(
 ) -> Result<ClientConfig, Error> {
     let roots = root_to_store(root_cert).await?;
     let c = ClientConfig::builder_with_provider(provider())
-        .with_protocol_versions(crate::tls::TLS_VERSIONS)?;
+        .with_protocol_versions(crate::tls::tls_versions())?;
     if let Some(alt_hostname) = alt_hostname {
         debug!("using alternate hostname {alt_hostname} for TLS verification");
         Ok(c.dangerous()

--- a/src/tls/mock.rs
+++ b/src/tls/mock.rs
@@ -22,7 +22,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use crate::tls::TLS_VERSIONS;
+use crate::tls::tls_versions;
 use rustls::ServerConfig;
 
 use super::{ServerCertProvider, TlsError, WorkloadCertificate};
@@ -184,7 +184,7 @@ impl MockServerCertProvider {
 impl ServerCertProvider for MockServerCertProvider {
     async fn fetch_cert(&mut self) -> Result<Arc<ServerConfig>, TlsError> {
         let mut sc = ServerConfig::builder_with_provider(crate::tls::lib::provider())
-            .with_protocol_versions(TLS_VERSIONS)
+            .with_protocol_versions(tls_versions())
             .expect("server config must be valid")
             .with_no_client_auth()
             .with_single_cert(


### PR DESCRIPTION
by setting `TLS12_ENABLED` to `true`, ztunnel will negotiate TLSv1.2 or 1.3.

Fixes #1296 until we have FIPS-140-3 support in istiod.