### PR TITLE
Address review comments

### DIFF
--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -353,7 +353,7 @@ impl OutboundConnection {
             )
             .method(hyper::Method::CONNECT)
             .version(hyper::Version::HTTP_2)
-            .header(BAGGAGE_HEADER, baggage(req, self.pi.cfg.cluster_id.clone()))
+            .header(BAGGAGE_HEADER, baggage(req))
             .header(
                 FORWARDED,
                 build_forwarded(remote_addr, &req.intended_destination_service),
@@ -728,17 +728,8 @@ fn build_forwarded(remote_addr: SocketAddr, server: &Option<ServiceDescription>)
     }
 }
 
-fn baggage(r: &Request, cluster: String) -> String {
-    baggage::baggage_header_val(
-        &cluster,
-        &r.source.namespace,
-        &r.source.workload_type,
-        &r.source.workload_name,
-        &r.source.canonical_name,
-        &r.source.canonical_revision,
-        &r.source.locality.region,
-        &r.source.locality.zone,
-    )
+fn baggage(r: &Request) -> String {
+    baggage::baggage_header_val(&r.source.baggage(), &r.source.workload_type)
 }
 
 #[derive(Debug)]

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -14,6 +14,7 @@
 
 use crate::identity::Identity;
 
+use crate::baggage::Baggage;
 use crate::state::WorkloadInfo;
 use crate::strng::Strng;
 use crate::xds::istio::workload::{Port, PortList};
@@ -299,6 +300,19 @@ impl Workload {
             trust_domain: self.trust_domain.clone(),
             namespace: self.namespace.clone(),
             service_account: self.service_account.clone(),
+        }
+    }
+
+    pub fn baggage(&self) -> Baggage {
+        Baggage {
+            cluster_id: (!self.cluster_id.is_empty()).then_some(self.cluster_id.clone()),
+            namespace: (!self.namespace.is_empty()).then_some(self.namespace.clone()),
+            workload_name: (!self.workload_name.is_empty()).then_some(self.workload_name.clone()),
+            service_name: (!self.canonical_name.is_empty()).then_some(self.canonical_name.clone()),
+            revision: (!self.canonical_revision.is_empty())
+                .then_some(self.canonical_revision.clone()),
+            region: (!self.locality.region.is_empty()).then_some(self.locality.region.clone()),
+            zone: (!self.locality.zone.is_empty()).then_some(self.locality.zone.clone()),
         }
     }
 }


### PR DESCRIPTION
The fixes include:

1. Rework of the baggage_header_val to take Baggage structure and workload type as input
2. Adding some tests to make sure that the baggage value we generate can be parsed by our code correctly
3. Fix one of the tests for baggage parsing function

Other than that, I reworked the code to not include items with empty values into baggage string.

And finally, in a few places we took cluster from the proxy config when we already had workload available - I removed that and now cluster always comes from the workload structure.

+cc @keithmattix @grnmeira @Stevenjin8 