### PR TITLE
Add ENABLE_OUTBOUND_ORIG_SRC config for outbound source IP preservation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,7 @@ const CONNECTION_TERMINATION_DEADLINE: &str = "CONNECTION_TERMINATION_DEADLINE";
 // (Our forceful shutdown is more graceful than a SIGKILL, as we can close connections cleanly).
 const TERMINATION_GRACE_PERIOD_SECONDS: &str = "TERMINATION_GRACE_PERIOD_SECONDS";
 const ENABLE_ORIG_SRC: &str = "ENABLE_ORIG_SRC";
+const ENABLE_OUTBOUND_ORIG_SRC: &str = "ENABLE_OUTBOUND_ORIG_SRC";
 const PROXY_CONFIG: &str = "PROXY_CONFIG";
 const IPV6_ENABLED: &str = "IPV6_ENABLED";
 
@@ -279,6 +280,11 @@ pub struct Config {
     // If set, explicitly configure whether to use original source.
     // If unset (recommended), this is automatically detected based on permissions.
     pub require_original_source: Option<bool>,
+
+    // Enable source IP preservation for outbound connections.
+    // If set to true, outbound connections explicitly bind to the downstream peer address
+    // If false (default), the system determines the outbound address.
+    pub enable_outbound_original_source: bool,
 
     // CLI args passed to ztunnel at runtime
     pub proxy_args: String,
@@ -810,6 +816,7 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         )?,
 
         require_original_source: parse(ENABLE_ORIG_SRC)?,
+        enable_outbound_original_source: parse_default(ENABLE_OUTBOUND_ORIG_SRC, false)?,
         proxy_args: parse_args(),
         dns_resolver_cfg,
         dns_resolver_opts,
@@ -1222,6 +1229,26 @@ pub mod tests {
             // Clean up
             env::remove_var(ZTUNNEL_WORKER_THREADS);
             env::remove_var(ZTUNNEL_CPU_LIMIT);
+        }
+    }
+
+    #[test]
+    fn test_enable_outbound_original_source_parsing() {
+        unsafe {
+            // Test explicitly enabled
+            env::set_var(ENABLE_OUTBOUND_ORIG_SRC, "true");
+            let cfg = construct_config(ProxyConfig::default()).unwrap();
+            assert!(cfg.enable_outbound_original_source);
+
+            // Test explicitly disabled
+            env::set_var(ENABLE_OUTBOUND_ORIG_SRC, "false");
+            let cfg = construct_config(ProxyConfig::default()).unwrap();
+            assert!(!cfg.enable_outbound_original_source);
+
+            // Test unset (default is false)
+            env::remove_var(ENABLE_OUTBOUND_ORIG_SRC);
+            let cfg = construct_config(ProxyConfig::default()).unwrap();
+            assert!(!cfg.enable_outbound_original_source);
         }
     }
 }

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -83,7 +83,12 @@ impl ConnSpawner {
 
         let cert = self.local_workload.fetch_certificate().await?;
         let connector = cert.outbound_connector(key.dst_id.clone())?;
-        let tcp_stream = super::freebind_connect(None, key.dst, self.socket_factory.as_ref())
+        let local = if self.cfg.enable_outbound_original_source {
+            Some(key.src)
+        } else {
+            None
+        };
+        let tcp_stream = super::freebind_connect(local, key.dst, self.socket_factory.as_ref())
             .await
             .map_err(|e: io::Error| match e.kind() {
                 io::ErrorKind::TimedOut => Error::MaybeHBONENetworkPolicyError(e),


### PR DESCRIPTION
For our multi-NIC pods, we use policy based routing (PBR) to influence the outbound interface. The routing looks something like the following

```
$ ip rule show
0:      from all lookup local
32763:  from <ETH0_IP_ADDR> lookup 200
32766:  from all lookup main
32767:  from all lookup default

# Table 200
$ ip route show table 200
default via 169.254.1.1 dev eth0 

# Main table
$ ip route show
default via 169.254.2.1 dev eth1 proto static 
<NETWORK_ADDRESS_RANGE> via 169.254.1.1 dev eth0 proto static 
<POD_SUBNET_ADDRESS_RANGE> via 169.254.1.1 dev eth0 proto static 
<SERVICE_CIDR_RANGE> via 169.254.1.1 dev eth0 proto static 
```

The intention of this change is to enable Ambient to honor the outbound source address it uses (obtained from the peer addr) in cases where it could receive redirected packets from multiple interfaces.

More on our specific use-case here for those interested:
https://github.com/istio/istio/discussions/58681

I wasn't sure if creating a separate env variable and making the distinction between ENABLE_ORIG_SRC, which is currently only used for inbound, was preferred over just re purposing the existing env. Open to suggestions here.