### PR TITLE
Enforce ServiceEntry exportTo visibility in ztunnel

### DIFF
--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -93,6 +93,14 @@ message Service {
   // canonical marks this Service as taking priority during hostname lookups,
   // when there is not a match in the namespace of the client.
   bool canonical = 11;
+
+  // export_to defines the namespaces to which this service is visible.
+  // Follows Istio exportTo semantics:
+  //   "." means only the namespace where the service is defined.
+  //   "*" means all namespaces.
+  //   A specific namespace name means only that namespace.
+  // If empty, the service is visible to all namespaces (equivalent to ["*"]).
+  repeated string export_to = 12;
 }
 
 enum IPFamilies {

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -368,6 +368,8 @@ impl Store {
                     .get_by_host(&search_name_str)
                     .into_iter()
                     .flatten()
+                    // Filter by namespace visibility (exportTo enforcement).
+                    .filter(|service| service.is_visible_to(&client.namespace))
                     // Remove things without a VIP, unless they are Kubernetes headless services.
                     // This will trigger us to forward upstream.
                     // TODO: we should have a reliable way to distinguish these. In sidecars, we use

--- a/src/state.rs
+++ b/src/state.rs
@@ -254,7 +254,7 @@ impl ProxyState {
         match self.workloads.find_address(network_addr) {
             None => {
                 // 2. handle service
-                if let Some(svc) = self.services.get_by_vip(network_addr) {
+                if let Some(svc) = self.services.get_by_vip_unscoped(network_addr) {
                     return Some(Address::Service(svc));
                 }
                 None
@@ -302,7 +302,7 @@ impl ProxyState {
     ) -> Option<UpstreamDestination> {
         if let Some(svc) = self
             .services
-            .get_by_vip(&network_addr(network.clone(), addr.ip()))
+            .get_by_vip(&network_addr(network.clone(), addr.ip()), &source_workload.namespace)
         {
             if let Some(lb) = &svc.load_balancer
                 && lb.mode == LoadBalancerMode::Passthrough

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -58,6 +58,33 @@ pub struct Service {
 
     #[serde(default)]
     pub canonical: bool,
+
+    /// Namespaces to which this service is visible.
+    /// Empty means visible to all (equivalent to ["*"]).
+    /// "." means only the namespace where the service is defined.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub export_to: Vec<Strng>,
+}
+
+impl Service {
+    /// Returns true if this service is visible to the given client namespace.
+    pub fn is_visible_to(&self, client_ns: &Strng) -> bool {
+        if self.export_to.is_empty() {
+            return true;
+        }
+        for vis in &self.export_to {
+            if vis.as_str() == "*" {
+                return true;
+            }
+            if vis.as_str() == "." {
+                return client_ns == &self.namespace;
+            }
+            if vis == client_ns {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 /// EndpointSet is an abstraction over a set of endpoints.
@@ -332,6 +359,7 @@ impl TryFrom<&XdsService> for Service {
             load_balancer: lb,
             ip_families,
             canonical: s.canonical,
+            export_to: s.export_to.iter().map(strng::new).collect(),
         };
         Ok(svc)
     }
@@ -355,8 +383,18 @@ pub struct ServiceStore {
 }
 
 impl ServiceStore {
-    /// Returns the [Service] matching the given VIP.
-    pub fn get_by_vip(&self, vip: &NetworkAddress) -> Option<Arc<Service>> {
+    /// Returns the [Service] matching the given VIP, filtered by namespace visibility.
+    pub fn get_by_vip(&self, vip: &NetworkAddress, client_ns: &Strng) -> Option<Arc<Service>> {
+        self.by_vip
+            .get(vip)
+            .filter(|s| s.is_visible_to(client_ns))
+            .cloned()
+    }
+
+    /// Returns the [Service] matching the given VIP without namespace filtering.
+    /// Used for inbound traffic and general address resolution where the source
+    /// namespace is not relevant.
+    pub fn get_by_vip_unscoped(&self, vip: &NetworkAddress) -> Option<Arc<Service>> {
         self.by_vip.get(vip).cloned()
     }
 

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -1202,7 +1202,7 @@ mod tests {
                 .get_by_vip(&NetworkAddress {
                     network: strng::EMPTY,
                     address: IpAddr::V4(vip1),
-                })
+                }, &strng::new("ns"))
                 .unwrap()),
         );
 
@@ -1276,7 +1276,7 @@ mod tests {
                 .get_by_vip(&NetworkAddress {
                     network: strng::EMPTY,
                     address: IpAddr::V4(vip1),
-                })
+                }, &strng::new("ns"))
                 .unwrap()),
         );
 
@@ -1303,7 +1303,7 @@ mod tests {
                 .get_by_vip(&NetworkAddress {
                     network: strng::EMPTY,
                     address: IpAddr::V4(vip1),
-                })
+                }, &strng::new("ns"))
                 .unwrap()),
         );
 


### PR DESCRIPTION
## Summary

Enforce `exportTo` namespace visibility for ServiceEntries in ztunnel, preventing cross-namespace DNS resolution and VIP routing leakage in multi-tenant ambient deployments.

## Changes

- `workload.proto`: Added `export_to` field to `Service` message (matches companion istiod PR)
- `service.rs`: Added `export_to` field to `Service` struct, `is_visible_to(client_ns)` method, namespace-scoped `get_by_vip`, and unscoped `get_by_vip_unscoped` for inbound paths
- `dns/server.rs`: `find_server` filters services by `is_visible_to(client.namespace)` before `find_best_match`
- `state.rs`: `find_upstream` passes `source_workload.namespace` to `get_by_vip`

## How it works

istiod populates the `export_to` field on each `workloadapi.Service` from the ServiceEntry's `spec.exportTo` (with `DefaultServiceExportTo` mesh config fallback). ztunnel checks this field at two critical lookup points:

1. **DNS resolution**: services not visible to the source pod's namespace are filtered out, preventing cross-namespace hostname resolution
2. **VIP routing**: `get_by_vip` checks visibility against the source workload's namespace, preventing cross-namespace VIP traffic routing

The check is O(1) for the common case (empty `export_to` = visible to all).

## Companion PR

istiod-side changes (proto + population): istio/istio#59653

Fixes istio/istio#59652

🤖 Generated with [Claude Code](https://claude.com/claude-code)