### PR TITLE
update fuzz/Cargo.lock in gen target

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -58,6 +58,7 @@ release:
 	./scripts/release.sh
 
 gen: format
+	(cd fuzz; cargo update ztunnel 2>/dev/null || true)
 
 gen-check: gen check-clean-repo
 


### PR DESCRIPTION
Dependabot PRs fail check-clean-repo because fuzz/Cargo.lock drifts when main deps change. The fuzz crate has a path dep on ztunnel, so any dep bump causes the fuzz lockfile to update during cargo check. Add cargo update ztunnel in the gen target so fuzz/Cargo.lock is updated before check-clean-repo runs. Example: https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_ztunnel/1835/test_ztunnel_release-1.29/2042306079001415680