### PR TITLE
bump hickory crates to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -866,24 +896,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "enum-ordinalize"
@@ -1237,6 +1249,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1349,43 +1362,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hickory-client"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c466cd63a4217d5b2b8e32f23f58312741ce96e3c84bf7438677d2baff0fc555"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "hickory-proto",
- "once_cell",
- "radix_trie",
- "rand 0.9.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
- "serde",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1394,22 +1386,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "resolv-conf",
  "serde",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1417,16 +1435,16 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+checksum = "91725f56e8e6b1fc4e68d4f86cf15714f1050f68ae817da6916da67041949f02"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "ipnet",
@@ -1828,6 +1846,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "neli"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,15 +2177,6 @@ checksum = "344d87cf1178954a3e8c0b3fd537b9966a8748c83734798f9c25cbcfc26467e3"
 dependencies = [
  "nix 0.29.0",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -2599,10 +2663,11 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
 dependencies = [
+ "either",
  "ipnet",
  "num-traits",
 ]
@@ -2831,16 +2896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,6 +2927,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2930,6 +2996,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -3327,6 +3399,22 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -4802,7 +4890,7 @@ dependencies = [
  "futures-util",
  "h2",
  "hashbrown 0.17.0",
- "hickory-client",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "hickory-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,10 @@ futures-util = "0.3"
 jemalloc_pprof = { version = "0.8", optional = true, features = ["symbolize"] }
 tikv-jemallocator = { version = "0.6.0", features = ["profiling", "unprefixed_malloc_on_supported_platforms"], optional = true }
 hashbrown = "0.17"
-hickory-client = "0.25"
-hickory-proto = "0.25"
-hickory-resolver = "0.25"
-hickory-server = { version = "0.25", features = [ "resolver" ]}
+hickory-net = "0.26.0"
+hickory-proto = "0.26.0"
+hickory-resolver = { version = "0.26.0", features = ["serde"] }
+hickory-server = { version = "0.26.0", features = [ "resolver" ]}
 http-body = { version = "1" }
 http-body-util = "0.1"
 hyper = { version = "1.9", features = ["full"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -311,6 +311,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +396,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -622,24 +652,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "enum-ordinalize"
@@ -921,6 +933,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1015,43 +1028,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hickory-client"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c466cd63a4217d5b2b8e32f23f58312741ce96e3c84bf7438677d2baff0fc555"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "hickory-proto",
- "once_cell",
- "radix_trie",
- "rand 0.9.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
- "serde",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1060,22 +1052,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "resolv-conf",
  "serde",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1083,16 +1101,16 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+checksum = "91725f56e8e6b1fc4e68d4f86cf15714f1050f68ae817da6916da67041949f02"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "ipnet",
@@ -1464,6 +1482,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1733,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "netns-rs"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,15 +1746,6 @@ checksum = "344d87cf1178954a3e8c0b3fd537b9966a8748c83734798f9c25cbcfc26467e3"
 dependencies = [
  "nix 0.29.0",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -2060,10 +2124,11 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
 dependencies = [
+ "either",
  "ipnet",
  "num-traits",
 ]
@@ -2246,16 +2311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,6 +2342,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2345,6 +2411,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -2716,6 +2788,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -4004,7 +4092,7 @@ dependencies = [
  "futures-util",
  "h2",
  "hashbrown 0.17.0",
- "hickory-client",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "hickory-server",

--- a/src/dns/forwarder.rs
+++ b/src/dns/forwarder.rs
@@ -14,13 +14,12 @@
 
 use crate::dns::resolver::{Answer, Resolver};
 use crate::proxy::SocketFactory;
-use hickory_proto::runtime::RuntimeProvider;
-use hickory_proto::runtime::iocompat::AsyncIoTokioAsStd;
-use hickory_resolver::ResolveError;
+use hickory_net::NetError;
+use hickory_net::runtime::RuntimeProvider;
+use hickory_net::runtime::iocompat::AsyncIoTokioAsStd;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-use hickory_resolver::name_server::GenericConnector;
-use hickory_server::authority::LookupError;
 use hickory_server::server::Request;
+use hickory_server::zone_handler::LookupError;
 use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
@@ -30,7 +29,7 @@ use std::time::Duration;
 use tokio::net::{TcpStream, UdpSocket};
 
 /// A forwarding [Resolver] that delegates requests to an upstream [TokioAsyncResolver].
-pub struct Forwarder(hickory_resolver::Resolver<GenericConnector<RuntimeProviderAdaptor>>);
+pub struct Forwarder(hickory_resolver::Resolver<RuntimeProviderAdaptor>);
 
 impl Forwarder {
     /// Creates a new [Forwarder] from the provided resolver configuration.
@@ -38,26 +37,26 @@ impl Forwarder {
         cfg: ResolverConfig,
         socket_factory: Arc<dyn SocketFactory + Send + Sync>,
         opts: ResolverOpts,
-    ) -> Result<Self, ResolveError> {
-        let provider = GenericConnector::new(RuntimeProviderAdaptor {
+    ) -> Result<Self, NetError> {
+        let provider = RuntimeProviderAdaptor {
             socket_factory,
             handle: Default::default(),
-        });
+        };
         let mut resolver = hickory_resolver::Resolver::builder_with_config(cfg, provider);
         *resolver.options_mut() = opts;
-        Ok(Self(resolver.build()))
+        Ok(Self(resolver.build()?))
     }
 }
 
 #[derive(Clone)]
 struct RuntimeProviderAdaptor {
     socket_factory: Arc<dyn SocketFactory + Send + Sync>,
-    handle: hickory_proto::runtime::TokioHandle,
+    handle: hickory_net::runtime::TokioHandle,
 }
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 impl RuntimeProvider for RuntimeProviderAdaptor {
-    type Handle = hickory_proto::runtime::TokioHandle;
-    type Timer = hickory_proto::runtime::TokioTime;
+    type Handle = hickory_net::runtime::TokioHandle;
+    type Timer = hickory_net::runtime::TokioTime;
     type Udp = UdpSocket;
     type Tcp = AsyncIoTokioAsStd<TcpStream>;
 
@@ -126,11 +125,11 @@ mod tests {
     use crate::dns::resolver::Resolver;
     use crate::test_helpers::dns::{a_request, ip, n, run_dns, socket_addr};
     use crate::test_helpers::helpers::initialize_telemetry;
-    use hickory_proto::ProtoErrorKind;
+    use hickory_net::xfer::Protocol;
+    use hickory_net::{DnsError, NetError, NoRecords};
     use hickory_proto::op::ResponseCode;
     use hickory_proto::rr::RecordType;
-    use hickory_proto::xfer::Protocol;
-    use hickory_resolver::ResolveErrorKind;
+    use hickory_server::zone_handler::LookupError;
     use std::collections::HashMap;
 
     #[tokio::test]
@@ -154,7 +153,7 @@ mod tests {
         assert!(!answer.is_authoritative());
 
         let record = answer.record_iter().next().unwrap();
-        assert_eq!(n("test.example.com."), *record.name());
+        assert_eq!(n("test.example.com."), record.name);
         assert_eq!(RecordType::A, record.record_type());
     }
 
@@ -171,22 +170,15 @@ mod tests {
             Protocol::Udp,
         );
 
-        // Expect a ResolveError.
-        let err = f
-            .lookup(&req)
-            .await
-            .expect_err("expected error")
-            .into_resolve_error()
-            .expect("expected resolve error");
-
-        // Expect NoRecordsFound with a NXDomain response code.
-        if let ResolveErrorKind::Proto(proto) = err.kind()
-            && let ProtoErrorKind::NoRecordsFound { response_code, .. } = proto.kind()
-        {
-            // Respond with the error code.
-            assert_eq!(&ResponseCode::NXDomain, response_code);
-            return;
+        match f.lookup(&req).await.expect_err("expected error") {
+            LookupError::NetError(NetError::Dns(DnsError::NoRecordsFound(NoRecords {
+                response_code,
+                ..
+            }))) => {
+                assert_eq!(ResponseCode::NXDomain, response_code);
+                return;
+            }
+            err => panic!("unexpected error kind {err:?}"),
         }
-        panic!("unexpected error kind {}", err.kind())
     }
 }

--- a/src/dns/handler.rs
+++ b/src/dns/handler.rs
@@ -67,7 +67,10 @@ impl RequestHandler for Handler {
                 }
             },
             MessageType::Response => {
-                warn!("got a response as a request from id: {}", request.metadata.id);
+                warn!(
+                    "got a response as a request from id: {}",
+                    request.metadata.id
+                );
                 send_error(request, response_handle, ResponseCode::FormErr).await
             }
         }
@@ -125,7 +128,9 @@ async fn send_lookup_error<R: ResponseHandler>(
         LookupError::NetError(NetError::Dns(DnsError::ResponseCode(code))) => {
             send_error(request, response_handle, code).await
         }
-        LookupError::NetError(_) => send_error(request, response_handle, ResponseCode::ServFail).await,
+        LookupError::NetError(_) => {
+            send_error(request, response_handle, ResponseCode::ServFail).await
+        }
         LookupError::Io(_) => {
             // TODO(nmittler): log?
             send_error(request, response_handle, ResponseCode::ServFail).await
@@ -305,7 +310,9 @@ mod tests {
             encoder.set_max_size(self.max_size);
 
             // Serialize the response.
-            let response_info = response.destructive_emit(&mut encoder).map_err(NetError::from)?;
+            let response_info = response
+                .destructive_emit(&mut encoder)
+                .map_err(NetError::from)?;
 
             // Deserialize back into the response message.
             let msg = Message::from_vec(&buf)

--- a/src/dns/handler.rs
+++ b/src/dns/handler.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use crate::dns::resolver::{Answer, Resolver};
-use hickory_proto::ProtoErrorKind;
-use hickory_proto::op::{Edns, Header, MessageType, OpCode, ResponseCode};
+use hickory_net::runtime::Time;
+use hickory_net::{DnsError, NetError, NoRecords};
+use hickory_proto::op::{Edns, Header, HeaderCounts, MessageType, Metadata, OpCode, ResponseCode};
 use hickory_proto::rr::Record;
-use hickory_resolver::ResolveErrorKind;
-use hickory_server::authority::{LookupError, MessageResponse, MessageResponseBuilder};
 use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
+use hickory_server::zone_handler::{LookupError, MessageResponse, MessageResponseBuilder};
 use std::sync::Arc;
 use tracing::{error, warn};
 
@@ -53,21 +53,21 @@ impl Handler {
 
 #[async_trait::async_trait]
 impl RequestHandler for Handler {
-    async fn handle_request<R: ResponseHandler>(
+    async fn handle_request<R: ResponseHandler, T: Time>(
         &self,
         request: &Request,
         response_handle: R,
     ) -> ResponseInfo {
-        match request.message_type() {
-            MessageType::Query => match request.op_code() {
+        match request.metadata.message_type {
+            MessageType::Query => match request.metadata.op_code {
                 OpCode::Query => self.lookup(request, response_handle).await,
                 _ => {
-                    warn!("unimplemented op_code: {:?}", request.op_code());
+                    warn!("unimplemented op_code: {:?}", request.metadata.op_code);
                     send_error(request, response_handle, ResponseCode::NotImp).await
                 }
             },
             MessageType::Response => {
-                warn!("got a response as a request from id: {}", request.id());
+                warn!("got a response as a request from id: {}", request.metadata.id);
                 send_error(request, response_handle, ResponseCode::FormErr).await
             }
         }
@@ -79,23 +79,24 @@ async fn send_lookup<R: ResponseHandler>(
     response_handle: R,
     answer: Answer,
 ) -> ResponseInfo {
-    let mut response_header = Header::response_from_request(request.header());
+    let mut response_metadata = Metadata::response_from_request(&request.metadata);
 
     // We are the authority here, since we control DNS for known hostnames
-    response_header.set_authoritative(answer.is_authoritative());
-    response_header.set_recursion_available(true);
+    response_metadata.authoritative = answer.is_authoritative();
+    response_metadata.recursion_available = true;
 
     // Create the response builder.
     let mut builder = MessageResponseBuilder::from_message_request(request);
 
     // Set EDNS if supplied in the request.
-    if let Some(edns) = response_edns(request) {
+    let edns = response_edns(request);
+    if let Some(ref edns) = edns {
         builder.edns(edns);
     }
 
     // Build the response.
     let response = builder.build(
-        response_header,
+        response_metadata,
         answer.record_iter(),
         None.iter(),
         None.iter(),
@@ -103,7 +104,7 @@ async fn send_lookup<R: ResponseHandler>(
     );
 
     // Send the response.
-    send_response(response, response_handle).await
+    send_response(request, response, response_handle).await
 }
 
 async fn send_lookup_error<R: ResponseHandler>(
@@ -117,16 +118,14 @@ async fn send_lookup_error<R: ResponseHandler>(
             send_empty_response(request, response_handle).await
         }
         LookupError::ResponseCode(code) => send_error(request, response_handle, code).await,
-        LookupError::ResolveError(e) => {
-            if let ResolveErrorKind::Proto(proto) = e.kind()
-                && let ProtoErrorKind::NoRecordsFound { response_code, .. } = proto.kind()
-            {
-                // Respond with the error code.
-                return send_error(request, response_handle, *response_code).await;
-            }
-            // TODO(nmittler): log?
-            send_error(request, response_handle, ResponseCode::ServFail).await
+        LookupError::NetError(NetError::Dns(DnsError::NoRecordsFound(NoRecords {
+            response_code,
+            ..
+        }))) => send_error(request, response_handle, response_code).await,
+        LookupError::NetError(NetError::Dns(DnsError::ResponseCode(code))) => {
+            send_error(request, response_handle, code).await
         }
+        LookupError::NetError(_) => send_error(request, response_handle, ResponseCode::ServFail).await,
         LookupError::Io(_) => {
             // TODO(nmittler): log?
             send_error(request, response_handle, ResponseCode::ServFail).await
@@ -142,9 +141,9 @@ async fn send_error<R: ResponseHandler>(
     code: ResponseCode,
 ) -> ResponseInfo {
     let response =
-        MessageResponseBuilder::from_message_request(request).error_msg(request.header(), code);
+        MessageResponseBuilder::from_message_request(request).error_msg(&request.metadata, code);
 
-    send_response(response, response_handle).await
+    send_response(request, response, response_handle).await
 }
 
 /// Sends an empty response to the [ResponseHandler].
@@ -152,13 +151,16 @@ async fn send_empty_response<R: ResponseHandler>(
     request: &Request,
     response_handle: R,
 ) -> ResponseInfo {
+    let mut response_metadata = Metadata::response_from_request(&request.metadata);
+    response_metadata.recursion_available = true;
     let empty =
-        MessageResponseBuilder::from_message_request(request).build_no_records(*request.header());
-    send_response(empty, response_handle).await
+        MessageResponseBuilder::from_message_request(request).build_no_records(response_metadata);
+    send_response(request, empty, response_handle).await
 }
 
 /// Sends the response to the [ResponseHandler] and handles any errors.
 async fn send_response<'a, R: ResponseHandler>(
+    request: &Request,
     response: MessageResponse<
         '_,
         'a,
@@ -174,9 +176,13 @@ async fn send_response<'a, R: ResponseHandler>(
     match result {
         Err(e) => {
             error!("request error: {}", e);
-            let mut header = Header::new();
-            header.set_response_code(ResponseCode::ServFail);
-            header.into()
+            let mut metadata = Metadata::response_from_request(&request.metadata);
+            metadata.response_code = ResponseCode::ServFail;
+            Header {
+                metadata,
+                counts: HeaderCounts::default(),
+            }
+            .into()
         }
         Ok(info) => info,
     }
@@ -184,7 +190,7 @@ async fn send_response<'a, R: ResponseHandler>(
 
 /// Creates an appropriate response [Edns], if one was available in the request.
 fn response_edns(request: &Request) -> Option<Edns> {
-    if let Some(req_edns) = request.edns() {
+    if let Some(req_edns) = request.edns.as_ref() {
         let mut resp_edns: Edns = Edns::new();
         resp_edns.set_max_payload(req_edns.max_payload().max(512));
         resp_edns.set_version(req_edns.version());
@@ -203,13 +209,15 @@ mod tests {
     use crate::dns::resolver::{Answer, Resolver};
     use crate::test_helpers::dns::{a, a_request, n, socket_addr};
     use crate::test_helpers::helpers::initialize_telemetry;
+    use hickory_net::NetError;
+    use hickory_net::runtime::TokioTime;
+    use hickory_net::xfer::Protocol;
+    use hickory_proto::ProtoError;
     use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
     use hickory_proto::rr::{Name, Record, RecordType};
     use hickory_proto::serialize::binary::BinEncoder;
-    use hickory_proto::xfer::Protocol;
-    use hickory_server::authority::LookupError;
-    use hickory_server::authority::MessageResponse;
     use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
+    use hickory_server::zone_handler::{LookupError, MessageResponse};
     use std::net::Ipv4Addr;
     use std::sync::Arc;
     use tokio::sync::mpsc;
@@ -226,29 +234,29 @@ mod tests {
 
         let (sender, mut receiver) = mpsc::channel(1);
         let _ = p
-            .handle_request(&req, FakeResponseHandler::new(512, sender))
+            .handle_request::<_, TokioTime>(&req, FakeResponseHandler::new(512, sender))
             .await;
 
         let resp = receiver.recv().await.unwrap();
 
         // Check basic response header info.
-        assert_eq!(req.id(), resp.id());
-        assert_eq!(MessageType::Response, resp.message_type());
-        assert_eq!(OpCode::Query, resp.op_code());
-        assert_eq!(ResponseCode::NoError, resp.response_code());
+        assert_eq!(req.metadata.id, resp.metadata.id);
+        assert_eq!(MessageType::Response, resp.metadata.message_type);
+        assert_eq!(OpCode::Query, resp.metadata.op_code);
+        assert_eq!(ResponseCode::NoError, resp.metadata.response_code);
 
         // Check flags.
-        assert!(!resp.authoritative());
-        assert!(!resp.authentic_data());
-        assert!(!resp.checking_disabled());
-        assert!(resp.recursion_available());
-        assert!(resp.recursion_desired());
-        assert!(!resp.truncated());
+        assert!(!resp.metadata.authoritative);
+        assert!(!resp.metadata.authentic_data);
+        assert!(!resp.metadata.checking_disabled);
+        assert!(resp.metadata.recursion_available);
+        assert!(resp.metadata.recursion_desired);
+        assert!(!resp.metadata.truncation);
 
         // Check that we have an answer for the request host.
-        let answers = resp.answers();
+        let answers = &resp.answers;
         assert!(!answers.is_empty());
-        assert_eq!(n("fake.com."), *answers[0].name());
+        assert_eq!(n("fake.com."), answers[0].name);
         assert_eq!(RecordType::A, answers[0].record_type());
 
         let expected = a(n("fake.com."), Ipv4Addr::new(127, 0, 0, 1));
@@ -290,17 +298,19 @@ mod tests {
                 impl Iterator<Item = &'a Record> + Send + 'a,
                 impl Iterator<Item = &'a Record> + Send + 'a,
             >,
-        ) -> std::io::Result<ResponseInfo> {
+        ) -> Result<ResponseInfo, NetError> {
             // Create the encoder.
             let mut buf = Vec::with_capacity(self.max_size as usize);
             let mut encoder = BinEncoder::new(&mut buf);
             encoder.set_max_size(self.max_size);
 
             // Serialize the response.
-            let response_info = response.destructive_emit(&mut encoder)?;
+            let response_info = response.destructive_emit(&mut encoder).map_err(NetError::from)?;
 
             // Deserialize back into the response message.
-            let msg = Message::from_vec(&buf)?;
+            let msg = Message::from_vec(&buf)
+                .map_err(ProtoError::from)
+                .map_err(NetError::from)?;
 
             // Send the message to the consumer.
             self.sender.send(msg).await.unwrap();

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -14,8 +14,8 @@
 
 use hickory_proto::rr::Record;
 use hickory_resolver::lookup::Lookup;
-use hickory_server::authority::LookupError;
 use hickory_server::server::Request;
+use hickory_server::zone_handler::LookupError;
 use std::slice::Iter;
 
 /// Similar to a TrustDNS `Authority`, although the resulting [Answer] indicates whether
@@ -56,7 +56,7 @@ impl Answer {
 impl From<Lookup> for Answer {
     fn from(value: Lookup) -> Self {
         Self {
-            records: value.records().to_vec(),
+            records: value.answers().to_vec(),
             is_authoritative: false, // Non-authoritative, since results came from upstream resolver.
         }
     }

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -1436,7 +1436,10 @@ mod tests {
                 tasks.push(async move {
                     let name = format!("[{protocol}] {}", c.name);
                     let resp = send_request(&mut client, n(c.host), c.query_type).await;
-                    assert_eq!(c.expect_authoritative, resp.metadata.authoritative, "{name}");
+                    assert_eq!(
+                        c.expect_authoritative, resp.metadata.authoritative,
+                        "{name}"
+                    );
                     assert_eq!(c.expect_code, resp.metadata.response_code, "{name}");
 
                     if c.expect_code == ResponseCode::NoError {

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use hickory_proto::ProtoErrorKind;
 use hickory_proto::op::ResponseCode;
 use hickory_proto::rr::rdata::{A, AAAA, CNAME};
 use hickory_proto::rr::{Name, RData, Record, RecordType};
 use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 use hickory_resolver::system_conf::read_system_conf;
-use hickory_server::ServerFuture;
-use hickory_server::authority::LookupError;
+use hickory_server::Server as HickoryServer;
 use hickory_server::server::Request;
+use hickory_server::zone_handler::LookupError;
 use once_cell::sync::Lazy;
 use rand::rng;
 use rand::seq::SliceRandom;
@@ -53,6 +52,7 @@ use crate::strng::Strng;
 use crate::{config, dns};
 
 const DEFAULT_TCP_REQUEST_TIMEOUT: u64 = 5;
+const DEFAULT_TCP_RESPONSE_BUFFER_SIZE: usize = 32;
 const DEFAULT_TTL_SECONDS: u32 = 30;
 
 static SVC: Lazy<Name> = Lazy::new(|| as_name("svc"));
@@ -63,7 +63,7 @@ pub struct Server {
     store: Arc<Store>,
     tcp_addr: SocketAddr,
     udp_addr: SocketAddr,
-    server: ServerFuture<dns::handler::Handler>,
+    server: HickoryServer<dns::handler::Handler>,
     drain: DrainWatcher,
 }
 
@@ -109,7 +109,7 @@ impl Server {
         );
         let store = Arc::new(store);
         let handler = dns::handler::Handler::new(store.clone());
-        let mut server = ServerFuture::new(handler);
+        let mut server = HickoryServer::new(handler);
         info!(
             address=%local_address,
             component="dns",
@@ -128,6 +128,7 @@ impl Server {
             server.register_listener(
                 tcp_listener.inner(),
                 Duration::from_secs(DEFAULT_TCP_REQUEST_TIMEOUT),
+                DEFAULT_TCP_RESPONSE_BUFFER_SIZE,
             );
 
             // Bind and register the UDP socket.
@@ -170,10 +171,7 @@ impl Server {
         tokio::select! {
             res = self.server.block_until_done() =>{
                 if let Err(e) = res {
-                    match e.kind() {
-                        ProtoErrorKind::NoError => (),
-                        _ => warn!("DNS server shutdown error: {e}"),
-                    }
+                    warn!("DNS server shutdown error: {e}");
                 }
             }
             res = self.drain.wait_for_drain() => {
@@ -931,7 +929,7 @@ mod tests {
     use std::net::{SocketAddrV4, SocketAddrV6};
 
     use bytes::Bytes;
-    use hickory_proto::xfer::Protocol;
+    use hickory_net::xfer::Protocol;
     use prometheus_client::registry::Registry;
 
     use super::*;
@@ -1438,11 +1436,11 @@ mod tests {
                 tasks.push(async move {
                     let name = format!("[{protocol}] {}", c.name);
                     let resp = send_request(&mut client, n(c.host), c.query_type).await;
-                    assert_eq!(c.expect_authoritative, resp.authoritative(), "{name}");
-                    assert_eq!(c.expect_code, resp.response_code(), "{name}");
+                    assert_eq!(c.expect_authoritative, resp.metadata.authoritative, "{name}");
+                    assert_eq!(c.expect_code, resp.metadata.response_code, "{name}");
 
                     if c.expect_code == ResponseCode::NoError {
-                        let mut actual = resp.answers().to_vec();
+                        let mut actual = resp.answers.to_vec();
 
                         // The IP records in an authoritative response will be randomly sorted to
                         // accommodate DNS-based load balancing. If the response is authoritative,
@@ -1521,9 +1519,9 @@ mod tests {
             for (protocol, client) in [("tcp", &mut tcp_client), ("udp", &mut udp_client)] {
                 let name = format!("[{protocol}] {}", c.name);
                 let resp = send_request(client, n(c.host), RecordType::A).await;
-                assert_eq!(c.expect_code, resp.response_code(), "{name}");
+                assert_eq!(c.expect_code, resp.metadata.response_code, "{name}");
                 if c.expect_code == ResponseCode::NoError {
-                    assert!(!resp.answers().is_empty());
+                    assert!(!resp.answers.is_empty());
                 }
             }
         }
@@ -1604,13 +1602,13 @@ mod tests {
         let mut udp_client = new_udp_client(udp_addr).await;
 
         let resp = send_request(&mut tcp_client, n("large.com."), RecordType::A).await;
-        assert!(!resp.truncated(), "TCP should not truncate");
-        assert_eq!(256, resp.answers().len());
+        assert!(!resp.metadata.truncation, "TCP should not truncate");
+        assert_eq!(256, resp.answers.len());
 
         let resp = send_request(&mut udp_client, n("large.com."), RecordType::A).await;
         // UDP is truncated
-        assert!(resp.truncated());
-        assert_eq!(74, resp.answers().len(), "expected UDP to be truncated");
+        assert!(resp.metadata.truncation);
+        assert_eq!(74, resp.answers.len(), "expected UDP to be truncated");
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -512,7 +512,7 @@ pub enum Error {
     #[error("dns: {0}")]
     Dns(#[from] ProtoError),
     #[error("dns lookup: {0}")]
-    DnsLookup(#[from] hickory_server::authority::LookupError),
+    DnsLookup(#[from] hickory_server::zone_handler::LookupError),
     #[error("dns response had no valid IP addresses")]
     DnsEmpty,
 }

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -16,11 +16,9 @@ use anyhow::Result;
 use byteorder::{BigEndian, ByteOrder};
 
 use crate::dns::resolver::Resolver;
-use hickory_proto::op::{Message, MessageType, Query};
+use hickory_net::xfer::Protocol;
+use hickory_proto::op::{Message, MessageType, OpCode, Query};
 use hickory_proto::rr::{Name, RecordType};
-use hickory_proto::serialize::binary::BinDecodable;
-use hickory_proto::xfer::Protocol;
-use hickory_server::authority::MessageRequest;
 use hickory_server::server::Request;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -297,10 +295,8 @@ async fn dns_lookup(
     hostname: &str,
 ) -> Result<IpAddr, Error> {
     fn new_message(name: Name, rr_type: RecordType) -> Message {
-        let mut msg = Message::new();
-        msg.set_id(rand::random());
-        msg.set_message_type(MessageType::Query);
-        msg.set_recursion_desired(true);
+        let mut msg = Message::new(rand::random(), MessageType::Query, OpCode::Query);
+        msg.metadata.recursion_desired = true;
         msg.add_query(Query::query(name, rr_type));
         msg
     }
@@ -308,8 +304,7 @@ async fn dns_lookup(
     /// the client IP and protocol.
     fn server_request(msg: &Message, client_addr: SocketAddr, protocol: Protocol) -> Request {
         let wire_bytes = msg.to_vec().unwrap();
-        let msg_request = MessageRequest::from_bytes(&wire_bytes).unwrap();
-        Request::new(msg_request, client_addr, protocol)
+        Request::from_bytes(wire_bytes, client_addr, protocol).unwrap()
     }
 
     /// Creates a A-record [Request] for the given name.
@@ -334,7 +329,7 @@ async fn dns_lookup(
     let answer = resolver.lookup(&req).await?;
     let response = answer
         .record_iter()
-        .filter_map(|rec| rec.data().ip_addr())
+        .filter_map(|rec| rec.data.ip_addr())
         .next() // TODO: do not always use the first result
         .ok_or_else(|| Error::DnsEmpty)?;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -36,7 +36,7 @@ use educe::Educe;
 use futures_util::FutureExt;
 use hickory_resolver::TokioResolver;
 use hickory_resolver::config::*;
-use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use itertools::Itertools;
 use rand::prelude::IteratorRandom;
 use rand::seq::IndexedRandom;
@@ -528,10 +528,10 @@ impl DemandProxyState {
     ) -> Self {
         let mut rb = hickory_resolver::Resolver::builder_with_config(
             dns_resolver_cfg,
-            TokioConnectionProvider::default(),
+            TokioRuntimeProvider::default(),
         );
         *rb.options_mut() = dns_resolver_opts;
-        let dns_resolver = rb.build();
+        let dns_resolver = rb.build().expect("dns resolver config should be valid");
         Self {
             state,
             demand,
@@ -728,9 +728,7 @@ impl DemandProxyState {
         trace!(%hostname, "dns lookup complete {resp:?}");
 
         let (matching, unmatching): (Vec<_>, Vec<_>) = resp
-            .as_lookup()
-            .record_iter()
-            .filter_map(|record| record.data().ip_addr())
+            .iter()
             .partition(|record| record.is_ipv6() == original_target_address.is_ipv6());
         // Randomly pick an IP, prefer to match the IP family of the downstream request.
         // Without this, we run into trouble in pure v4 or pure v6 environments.

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -138,7 +138,7 @@ pub fn test_config_with_port_xds_addr_and_root_cert(
     };
     // Do not let tests use system defaults!
     cfg.dns_resolver_opts = Default::default();
-    cfg.dns_resolver_cfg = ResolverConfig::new();
+    cfg.dns_resolver_cfg = ResolverConfig::from_parts(None, vec![], vec![]);
     cfg
 }
 

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -241,7 +241,7 @@ impl TestApp {
         hostname: &str,
         udp: bool,
         ipv6: bool,
-    ) -> hickory_proto::xfer::DnsResponse {
+    ) -> hickory_proto::op::DnsResponse {
         let addr = if udp {
             self.udp_dns_proxy_address.unwrap()
         } else {
@@ -256,7 +256,7 @@ pub async fn dns_request(
     hostname: &str,
     udp: bool,
     ipv6: bool,
-) -> hickory_proto::xfer::DnsResponse {
+) -> hickory_proto::op::DnsResponse {
     use crate::test_helpers::dns::n;
     use crate::test_helpers::dns::send_request;
     use crate::test_helpers::dns::{new_tcp_client, new_udp_client};

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -113,7 +113,8 @@ pub async fn send_with_max_size(
     max_payload: u16,
 ) -> DnsResponse {
     // Build the request message.
-    let mut message: Message = Message::new(rand::random::<u16>(), MessageType::Query, OpCode::Query);
+    let mut message: Message =
+        Message::new(rand::random::<u16>(), MessageType::Query, OpCode::Query);
     let mut query = Query::query(name, rr_type);
     query.set_query_class(DNSClass::IN);
     message.add_query(query);

--- a/src/test_helpers/dns.rs
+++ b/src/test_helpers/dns.rs
@@ -22,32 +22,27 @@ use crate::state::workload::Workload;
 use crate::test_helpers::new_proxy_state;
 use crate::xds::istio::workload::Workload as XdsWorkload;
 use crate::{dns, drain, metrics};
-use futures_util::ready;
-use futures_util::stream::{Stream, StreamExt};
-use hickory_client::ClientError;
-use hickory_client::client::{Client, ClientHandle};
-use hickory_proto::DnsHandle;
-use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query, ResponseCode};
+use futures_util::StreamExt;
+use hickory_net::DnsHandle;
+use hickory_net::client::{Client, ClientHandle};
+use hickory_net::runtime::TokioRuntimeProvider;
+use hickory_net::runtime::iocompat::AsyncIoTokioAsStd;
+use hickory_net::tcp::TcpClientStream;
+use hickory_net::udp::UdpClientStream;
+use hickory_net::xfer::Protocol;
+use hickory_proto::op::{
+    DnsRequest, DnsRequestOptions, DnsResponse, Edns, Message, MessageType, OpCode, Query,
+    ResponseCode,
+};
 use hickory_proto::rr::rdata::{A, AAAA, CNAME};
 use hickory_proto::rr::{DNSClass, Name, RData, Record, RecordType};
-use hickory_proto::runtime::TokioRuntimeProvider;
-use hickory_proto::runtime::iocompat::AsyncIoTokioAsStd;
-use hickory_proto::serialize::binary::BinDecodable;
-use hickory_proto::tcp::TcpClientStream;
-use hickory_proto::udp::UdpClientStream;
-use hickory_proto::xfer::Protocol;
-use hickory_proto::xfer::{DnsRequest, DnsRequestOptions, DnsResponse};
-use hickory_proto::{ProtoError, ProtoErrorKind};
-use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
-use hickory_server::authority::{LookupError, MessageRequest};
+use hickory_resolver::config::{ConnectionConfig, NameServerConfig, ResolverConfig, ResolverOpts};
 use hickory_server::server::Request;
+use hickory_server::zone_handler::LookupError;
 use prometheus_client::registry::Registry;
 use std::collections::HashMap;
-use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 use tokio::net::TcpStream;
 
 const TTL: u32 = 5;
@@ -74,14 +69,14 @@ pub fn cname(name: Name, canonical_name: Name) -> Record {
 
 /// Creates a new DNS client that establishes a TCP connection to the nameserver at the given
 /// address.
-pub async fn new_tcp_client(addr: SocketAddr) -> Client {
+pub async fn new_tcp_client(addr: SocketAddr) -> Client<TokioRuntimeProvider> {
     let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TcpStream>>::new(
         addr,
         None,
         None,
         TokioRuntimeProvider::new(),
     );
-    let (client, bg) = Client::new(Box::new(stream), sender, None).await.unwrap();
+    let (client, bg) = Client::new(stream.await.unwrap(), sender);
 
     // Run the client exchange in the background.
     tokio::spawn(bg);
@@ -90,10 +85,10 @@ pub async fn new_tcp_client(addr: SocketAddr) -> Client {
 }
 
 /// Creates a new DNS client that establishes a UDP connection to the nameserver at the given address.
-pub async fn new_udp_client(addr: SocketAddr) -> Client {
+pub async fn new_udp_client(addr: SocketAddr) -> Client<TokioRuntimeProvider> {
     let stream =
         UdpClientStream::<TokioRuntimeProvider>::builder(addr, TokioRuntimeProvider::new()).build();
-    let (client, bg) = Client::connect(stream).await.unwrap();
+    let (client, bg) = Client::from_sender(stream);
 
     // Run the client exchange in the background.
     tokio::spawn(bg);
@@ -112,66 +107,35 @@ pub async fn send_request<C: ClientHandle>(
 
 /// Sends a request with the given maximum response payload size.
 pub async fn send_with_max_size(
-    client: &mut Client,
+    client: &mut Client<TokioRuntimeProvider>,
     name: Name,
     rr_type: RecordType,
     max_payload: u16,
 ) -> DnsResponse {
     // Build the request message.
-    let mut message: Message = Message::new();
-    message
-        .add_query({
-            let mut query = Query::query(name, rr_type);
-            query.set_query_class(DNSClass::IN);
-            query
-        })
-        .set_id(rand::random::<u16>())
-        .set_message_type(MessageType::Query)
-        .set_op_code(OpCode::Query)
-        .set_recursion_desired(true)
-        .set_edns({
-            let mut edns = Edns::new();
-            edns.set_max_payload(max_payload).set_version(0);
-            edns
-        });
-
-    // client.send(message).first_answer().await.unwrap()
+    let mut message: Message = Message::new(rand::random::<u16>(), MessageType::Query, OpCode::Query);
+    let mut query = Query::query(name, rr_type);
+    query.set_query_class(DNSClass::IN);
+    message.add_query(query);
+    message.metadata.recursion_desired = true;
+    let mut edns = Edns::new();
+    edns.set_max_payload(max_payload).set_version(0);
+    message.set_edns(edns);
 
     let mut options = DnsRequestOptions::default();
     options.use_edns = true;
-    ClientResponse(client.send(DnsRequest::new(message, options)))
+    client
+        .send(DnsRequest::new(message, options))
+        .next()
         .await
+        .expect("dns response stream ended unexpectedly")
         .unwrap()
-}
-
-/// Copied from Trust-DNS async_client code to allow construction here.
-struct ClientResponse<R>(pub(crate) R)
-where
-    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static;
-
-impl<R> Future for ClientResponse<R>
-where
-    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static,
-{
-    type Output = Result<DnsResponse, ClientError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(
-            match ready!(self.0.poll_next_unpin(cx)) {
-                Some(r) => r,
-                None => Err(ProtoError::from(ProtoErrorKind::Timeout)),
-            }
-            .map_err(ClientError::from),
-        )
-    }
 }
 
 /// Constructs a new [Message] of type [MessageType::Query];
 pub fn new_message(name: Name, rr_type: RecordType) -> Message {
-    let mut msg = Message::new();
-    msg.set_id(123);
-    msg.set_message_type(MessageType::Query);
-    msg.set_recursion_desired(true);
+    let mut msg = Message::new(123, MessageType::Query, OpCode::Query);
+    msg.metadata.recursion_desired = true;
     msg.add_query(Query::query(name, rr_type));
     msg
 }
@@ -183,9 +147,7 @@ pub fn server_request(msg: &Message, client_addr: SocketAddr, protocol: Protocol
     let wire_bytes = msg.to_vec().unwrap();
 
     // Deserialize into a server-side request.
-    let msg_request = MessageRequest::from_bytes(&wire_bytes).unwrap();
-
-    Request::new(msg_request, client_addr, protocol)
+    Request::from_bytes(wire_bytes, client_addr, protocol).unwrap()
 }
 
 /// Creates a A-record [Request] for the given name.
@@ -233,24 +195,18 @@ impl TestDnsServer {
 }
 
 fn internal_resolver_config(tcp: SocketAddr, udp: SocketAddr) -> ResolverConfig {
-    let mut rc = ResolverConfig::new();
-    rc.add_name_server(NameServerConfig {
-        socket_addr: udp,
-        protocol: Protocol::Udp,
-        tls_dns_name: None,
-        http_endpoint: None,
-        trust_negative_responses: false,
-        bind_addr: None,
-    });
-    rc.add_name_server(NameServerConfig {
-        socket_addr: tcp,
-        protocol: Protocol::Tcp,
-        tls_dns_name: None,
-        http_endpoint: None,
-        trust_negative_responses: false,
-        bind_addr: None,
-    });
-    rc
+    let mut udp_conn = ConnectionConfig::udp();
+    udp_conn.port = udp.port();
+    let mut tcp_conn = ConnectionConfig::tcp();
+    tcp_conn.port = tcp.port();
+    ResolverConfig::from_parts(
+        None,
+        vec![],
+        vec![
+            NameServerConfig::new(udp.ip(), true, vec![udp_conn]),
+            NameServerConfig::new(tcp.ip(), true, vec![tcp_conn]),
+        ],
+    )
 }
 
 // run_dns sets up a test DNS server. We happen to have a DNS server implementation, so we abuse that here.


### PR DESCRIPTION
fixes #1457

The hickory-resolver crate had a bug which caused a user-facing impact. Upgrading to 0.26.0 is expected to resolve the issue.

@keithmattix or @jaellio or @mikemorris or @Stevenjin8, would any of you be able to test this with Azure DNS?