### PR TITLE
[Release-1.30.0] Add release-1.30 dependabot tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,20 @@ updates:
     ignore:
       - dependency-name: "criterion"
         versions: [">= 0.6"]
+    target-branch: "release-1.30"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    ignore:
+      - dependency-name: "criterion"
+        versions: [">= 0.6"]
     target-branch: "release-1.29"
     groups:
       all-dependencies:


### PR DESCRIPTION
Adds release-1.30 entry to .github/dependabot.yml mirroring the existing release-1.29 stanza. Refs istio/istio#59425