### PR TITLE
add unsafe marker to ctor annotations

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -54,7 +54,7 @@ const N_RULES: usize = 10;
 const N_POLICIES: usize = 10_000;
 const DUMMY_NETWORK: &str = "198.51.100.0/24";
 
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn initialize_namespace_tests() {
     ztunnel::test_helpers::namespaced::initialize_namespace_tests();
 }

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -56,7 +56,7 @@ mod namespaced {
     const WAYPOINT_MESSAGE: &[u8] = b"waypoint\n";
 
     /// initialize_namespace_tests sets up the namespace tests.
-    #[ctor::ctor]
+    #[ctor::ctor(unsafe)]
     fn initialize_namespace_tests() {
         ztunnel::test_helpers::namespaced::initialize_namespace_tests();
     }


### PR DESCRIPTION
Adds `(unsafe)` to the two `#[ctor::ctor]` call sites. No behavior change, just the syntax `ctor 1.0+` requires (e.g. dependabot #1890 on release-1.29). Compiles fine with current `ctor 0.10` too, so this is a safe forward-compat fix.