### PR TITLE
avoid Vec allocation in get_best_by_vip and get_best_by_host

### DIFF
--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -388,7 +388,7 @@ impl ServiceStore {
         vip: &NetworkAddress,
         ns: Option<&Strng>,
     ) -> Option<Arc<Service>> {
-        if let Some(services) = self.get_by_vip(vip) {
+        if let Some(services) = self.by_vip.get(vip) {
             return Some(ServiceMatch::find_best_match(services.iter(), ns, None)?.clone());
         }
         self.get_best_by_cidr_vip(vip, ns)
@@ -434,7 +434,7 @@ impl ServiceStore {
     // If a namespace is provided, a Service from that namespace is preferred.
     // Next, a Service marked `canonical` is prerferred.
     pub fn get_best_by_host(&self, hostname: &Strng, ns: Option<&Strng>) -> Option<Arc<Service>> {
-        let services = self.get_by_host(hostname)?;
+        let services = self.by_host.get(hostname)?;
         Some(ServiceMatch::find_best_match(services.iter(), ns, None)?.clone())
     }
 


### PR DESCRIPTION
These call get_by_vip/get_by_host which clone the inner Vec via .to_vec(), then immediately iterate it once and discard. Use the HashMap entry directly to skip the Vec allocation 

Effect (criterion, release profile, lto=true):

| benchmark              | before    | after     |    delta |
|------------------------|-----------|-----------|----------|
| vip_match/exact-hit-1  | 34.214 ns | 23.033 ns |  -32.6 % |
| vip_match/exact-hit-10 | 34.217 ns | 23.029 ns |  -32.7 % |
| vip_match/exact-hit-100| 34.225 ns | 23.022 ns |  -32.7 % |
| vip_match/exact-hit-1k | 34.211 ns | 23.062 ns |  -32.5 % |
| vip_match/exact-hit-10k| 34.208 ns | 23.067 ns |  -32.5 % |
