### PR TITLE
feat: track xDS config freshness without re-arming readiness

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -436,7 +436,7 @@ async fn handle_jemalloc_pprof_heapgen(
         .expect("builder with known status code should not fail"))
 }
 
-#[cfg(not(feature = "jemalloc"))]
+#[cfg(all(not(feature = "jemalloc"), target_os = "linux"))]
 async fn handle_jemalloc_pprof_heapgen(
     _req: Request<Incoming>,
 ) -> anyhow::Result<Response<Full<Bytes>>> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,33 @@ pub async fn build_with_cert(
     config: Arc<config::Config>,
     cert_manager: Arc<SecretManager>,
 ) -> anyhow::Result<Bound> {
+    // Startup orchestration overview:
+    //
+    //  ┌─────────────────────────────────────────────────────────────────┐
+    //  │ 1. Bootstrap                                                    │
+    //  │    data plane pool, drain channel, readiness tasks, metrics     │
+    //  └──────────────────────────┬──────────────────────────────────────┘
+    //                             │
+    //  ┌──────────────────────────▼──────────────────────────────────────┐
+    //  │ 2. ProxyStateManager (creates xDS client)                       │
+    //  └──────────────────────────┬──────────────────────────────────────┘
+    //                             │
+    //  ┌──────────────────────────▼──────────────────────────────────────┐
+    //  │ 3. xDS monitoring task                                          │
+    //  │    Phase 1: wait for initial xDS sync → drop "state manager"    │
+    //  │    Phase 2: freshness metrics                                   │
+    //  │             non-Synced ──► record non-fresh period               │
+    //  │             Synced ACK ──► report completed duration             │
+    //  └──────────────────────────┬──────────────────────────────────────┘
+    //                             │
+    //  ┌──────────────────────────▼──────────────────────────────────────┐
+    //  │ 4. Proxy / DNS listeners (wait for xDS sync before accepting)   │
+    //  └──────────────────────────┬──────────────────────────────────────┘
+    //                             │
+    //  ┌──────────────────────────▼──────────────────────────────────────┐
+    //  │ 5. Admin + metrics servers                                      │
+    //  └─────────────────────────────────────────────────────────────────┘
+    //
     // Start the data plane worker pool.
     let (data_plane_pool, data_plane_handle) = new_data_plane_pool(config.num_worker_threads);
 
@@ -81,13 +108,25 @@ pub async fn build_with_cert(
     metrics::tokio_runtime::TokioRuntimeCollector::register(&mut registry, &data_plane_handle);
     let istio_registry = metrics::sub_registry(&mut registry);
     let _ = metrics::meta::Metrics::new(istio_registry);
-    let xds_metrics = xds::Metrics::new(istio_registry);
+    let remote_xds_metrics_enabled = config.xds_address.is_some();
+    let xds_metrics = xds::Metrics::new_with_remote_xds(istio_registry, remote_xds_metrics_enabled);
+    let xds_monitor_metrics =
+        remote_xds_metrics_enabled.then(|| xds::XdsConnectionMonitorMetrics::new(istio_registry));
+    #[cfg(any(test, feature = "testing"))]
+    let xds_freshness_observations_for_test = xds_monitor_metrics
+        .as_ref()
+        .map(|metrics| metrics.non_fresh_observation_receiver());
     let proxy_metrics = Arc::new(proxy::Metrics::new(istio_registry));
     let dns_metrics = if config.dns_proxy {
         Some(dns::Metrics::new(istio_registry))
     } else {
         None
     };
+
+    #[cfg(not(target_os = "linux"))]
+    if config.socket_config.user_timeout_enabled {
+        warn!("TCP user timeout is configured but unsupported on non-Linux; setting is disabled");
+    }
 
     let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
     // Create the manager that updates proxy state from XDS.
@@ -99,10 +138,41 @@ pub async fn build_with_cert(
         cert_manager.clone(),
     )
     .await?;
-    let mut xds_rx_for_task = xds_rx.clone();
+    let xds_connection_state_rx = state_mgr.xds_connection_state();
+    let xds_connection_initial_state = xds_connection_state_rx.as_ref().map(|rx| *rx.borrow());
+    let xds_connection_state_events_rx = state_mgr.xds_connection_state_events();
+    #[cfg(any(test, feature = "testing"))]
+    let xds_connection_state_for_test = xds_connection_state_rx.clone();
+    #[cfg(any(test, feature = "testing"))]
+    let xds_startup_for_test = xds_rx.clone();
+    #[cfg(any(test, feature = "testing"))]
+    let (xds_freshness_monitor_exited_tx, xds_freshness_monitor_exited_for_test) =
+        tokio::sync::watch::channel(false);
+    let xds_rx_for_task = xds_rx.clone();
+    let remote_xds_configured = xds_connection_state_rx.is_some();
+    let ready_for_startup_gate = ready.clone();
+    let readiness_gate = xds::freshness_monitor::XdsStartupReadinessGate::new(
+        ready_for_startup_gate,
+        state_mgr_task,
+    );
+    let readiness_gate_for_panic = readiness_gate.clone();
     tokio::spawn(async move {
-        let _ = xds_rx_for_task.changed().await;
-        std::mem::drop(state_mgr_task);
+        let task = std::panic::AssertUnwindSafe(xds::freshness_monitor::run_xds_monitor_task(
+            xds_connection_initial_state,
+            xds_connection_state_rx,
+            xds_connection_state_events_rx,
+            xds_rx_for_task,
+            readiness_gate,
+            xds_monitor_metrics,
+        ));
+        if futures::FutureExt::catch_unwind(task).await.is_err() {
+            // The gate used for panic recovery is owned outside the unwinding
+            // future, so any existing blocker is replaced with
+            // `xds monitor dead` if the monitor panics.
+            xds::freshness_monitor::park_monitor_dead_after_panic(readiness_gate_for_panic).await;
+        }
+        #[cfg(any(test, feature = "testing"))]
+        xds_freshness_monitor_exited_tx.send_replace(true);
     });
     let state = state_mgr.state();
 
@@ -143,11 +213,21 @@ pub async fn build_with_cert(
         if let Some(inbound) = proxy_gen.create_ztunnel_self_proxy_listener().await? {
             // Run the inbound listener in the data plane worker pool
             let mut xds_rx_for_inbound = xds_rx.clone();
+            let drain_rx_for_inbound = drain_rx.clone();
             data_plane_pool.send(DataPlaneTask {
                 block_shutdown: true,
                 fut: Box::pin(async move {
                     tracing::info!("Starting ztunnel inbound listener task");
-                    let _ = xds_rx_for_inbound.changed().await;
+                    if !wait_for_initial_xds_sync_or_drain(
+                        &mut xds_rx_for_inbound,
+                        remote_xds_configured,
+                        "ztunnel inbound listener",
+                        drain_rx_for_inbound,
+                    )
+                    .await
+                    {
+                        return Ok(());
+                    }
                     tokio::task::spawn(async move {
                         inbound.run().in_current_span().await;
                     })
@@ -167,10 +247,20 @@ pub async fn build_with_cert(
         )?;
 
         let mut xds_rx_for_proxy = xds_rx.clone();
+        let drain_rx_for_proxy = drain_rx.clone();
         data_plane_pool.send(DataPlaneTask {
             block_shutdown: true,
             fut: Box::pin(async move {
-                let _ = xds_rx_for_proxy.changed().await;
+                if !wait_for_initial_xds_sync_or_drain(
+                    &mut xds_rx_for_proxy,
+                    remote_xds_configured,
+                    "in-pod proxy manager",
+                    drain_rx_for_proxy,
+                )
+                .await
+                {
+                    return Ok(());
+                }
                 run_future.in_current_span().await;
                 Ok(())
             }),
@@ -188,10 +278,20 @@ pub async fn build_with_cert(
 
                 // Run the HBONE proxy in the data plane worker pool.
                 let mut xds_rx_for_proxy = xds_rx.clone();
+                let drain_rx_for_proxy = drain_rx.clone();
                 data_plane_pool.send(DataPlaneTask {
                     block_shutdown: true,
                     fut: Box::pin(async move {
-                        let _ = xds_rx_for_proxy.changed().await;
+                        if !wait_for_initial_xds_sync_or_drain(
+                            &mut xds_rx_for_proxy,
+                            remote_xds_configured,
+                            "dedicated proxy listener",
+                            drain_rx_for_proxy,
+                        )
+                        .await
+                        {
+                            return Ok(());
+                        }
                         proxy.run().in_current_span().await;
                         Ok(())
                     }),
@@ -212,10 +312,20 @@ pub async fn build_with_cert(
 
                 // Run the DNS proxy in the data plane worker pool.
                 let mut xds_rx_for_dns_proxy = xds_rx.clone();
+                let drain_rx_for_dns_proxy = drain_rx.clone();
                 data_plane_pool.send(DataPlaneTask {
                     block_shutdown: true,
                     fut: Box::pin(async move {
-                        let _ = xds_rx_for_dns_proxy.changed().await;
+                        if !wait_for_initial_xds_sync_or_drain(
+                            &mut xds_rx_for_dns_proxy,
+                            remote_xds_configured,
+                            "DNS proxy listener",
+                            drain_rx_for_dns_proxy,
+                        )
+                        .await
+                        {
+                            return Ok(());
+                        }
                         dns_proxy.run().in_current_span().await;
                         Ok(())
                     }),
@@ -249,12 +359,62 @@ pub async fn build_with_cert(
         proxy_addresses,
         tcp_dns_proxy_address,
         udp_dns_proxy_address,
+        #[cfg(any(test, feature = "testing"))]
+        xds_connection_state: xds_connection_state_for_test,
+        #[cfg(any(test, feature = "testing"))]
+        xds_startup: xds_startup_for_test,
+        #[cfg(any(test, feature = "testing"))]
+        xds_freshness_monitor_exited: xds_freshness_monitor_exited_for_test,
+        #[cfg(any(test, feature = "testing"))]
+        xds_freshness_observations: xds_freshness_observations_for_test,
     })
 }
 
 fn register_process_metrics(registry: &mut Registry) {
     #[cfg(unix)]
     registry.register_collector(Box::new(metrics::process::ProcessMetrics::new()));
+}
+
+async fn wait_for_initial_xds_sync(
+    xds_rx: &mut tokio::sync::watch::Receiver<()>,
+    remote_xds_configured: bool,
+    component: &'static str,
+) -> bool {
+    match xds_rx.changed().await {
+        Ok(()) => true,
+        Err(_) if remote_xds_configured => {
+            tracing::error!(
+                component,
+                "xDS startup signal sender dropped before initial sync; not starting listener"
+            );
+            false
+        }
+        Err(_) => true,
+    }
+}
+
+async fn wait_for_initial_xds_sync_or_drain(
+    xds_rx: &mut tokio::sync::watch::Receiver<()>,
+    remote_xds_configured: bool,
+    component: &'static str,
+    drain_rx: drain::DrainWatcher,
+) -> bool {
+    tokio::select! {
+        waited_for_startup =
+            wait_for_initial_xds_sync(xds_rx, remote_xds_configured, component) => {
+                if waited_for_startup {
+                    return true;
+                }
+            }
+        drain = drain_rx.clone().wait_for_drain() => {
+            drop(drain);
+            return false;
+        }
+    }
+
+    let drain = drain_rx.wait_for_drain().await;
+    drop(drain);
+    false
 }
 
 struct DataPlaneTask {
@@ -385,6 +545,15 @@ pub struct Bound {
 
     pub shutdown: signal::Shutdown,
     drain_tx: drain::DrainTrigger,
+
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) xds_connection_state: Option<tokio::sync::watch::Receiver<xds::XdsConnectionState>>,
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) xds_startup: tokio::sync::watch::Receiver<()>,
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) xds_freshness_monitor_exited: tokio::sync::watch::Receiver<bool>,
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) xds_freshness_observations: Option<tokio::sync::watch::Receiver<u64>>,
 }
 
 impl Bound {
@@ -399,5 +568,92 @@ impl Bound {
             .await;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn remote_xds_startup_wait_fails_closed_when_sender_drops() {
+        let (tx, mut rx) = tokio::sync::watch::channel(());
+        drop(tx);
+
+        assert!(!wait_for_initial_xds_sync(&mut rx, true, "test proxy").await);
+    }
+
+    #[tokio::test]
+    async fn local_xds_startup_wait_allows_sender_drop() {
+        let (tx, mut rx) = tokio::sync::watch::channel(());
+        drop(tx);
+
+        assert!(wait_for_initial_xds_sync(&mut rx, false, "test proxy").await);
+    }
+
+    #[tokio::test]
+    async fn remote_xds_startup_failure_waits_for_drain() {
+        let (xds_tx, mut xds_rx) = tokio::sync::watch::channel(());
+        let (drain_tx, drain_rx) = drain::new();
+        drop(xds_tx);
+
+        let wait = tokio::spawn(async move {
+            wait_for_initial_xds_sync_or_drain(&mut xds_rx, true, "test proxy", drain_rx).await
+        });
+        tokio::task::yield_now().await;
+
+        assert!(
+            !wait.is_finished(),
+            "remote xDS startup failure should keep the data-plane task alive until drain"
+        );
+
+        let drain = tokio::spawn(async move {
+            drain_tx
+                .start_drain_and_wait(drain::DrainMode::Graceful)
+                .await;
+        });
+
+        let waited_for_startup = tokio::time::timeout(Duration::from_secs(2), wait)
+            .await
+            .expect("startup failure task did not finish after drain")
+            .expect("startup failure task panicked");
+        assert!(!waited_for_startup);
+        tokio::time::timeout(Duration::from_secs(2), drain)
+            .await
+            .expect("drain did not finish after startup failure task released")
+            .expect("drain task panicked");
+    }
+
+    #[tokio::test]
+    async fn remote_xds_startup_wait_observes_drain_before_sender_drops() {
+        let (_xds_tx, mut xds_rx) = tokio::sync::watch::channel(());
+        let (drain_tx, drain_rx) = drain::new();
+
+        let wait = tokio::spawn(async move {
+            wait_for_initial_xds_sync_or_drain(&mut xds_rx, true, "test proxy", drain_rx).await
+        });
+        tokio::task::yield_now().await;
+
+        assert!(
+            !wait.is_finished(),
+            "remote xDS startup wait should stay pending before initial sync or drain"
+        );
+
+        let drain = tokio::spawn(async move {
+            drain_tx
+                .start_drain_and_wait(drain::DrainMode::Graceful)
+                .await;
+        });
+
+        let waited_for_startup = tokio::time::timeout(Duration::from_secs(2), wait)
+            .await
+            .expect("startup wait did not finish after drain")
+            .expect("startup wait task panicked");
+        assert!(!waited_for_startup);
+        tokio::time::timeout(Duration::from_secs(2), drain)
+            .await
+            .expect("drain did not finish after startup wait released")
+            .expect("drain task panicked");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,7 @@ const LOCAL_XDS_PATH: &str = "LOCAL_XDS_PATH";
 const LOCAL_XDS: &str = "LOCAL_XDS";
 const XDS_ON_DEMAND: &str = "XDS_ON_DEMAND";
 const XDS_ADDRESS: &str = "XDS_ADDRESS";
+
 const PREFERED_SERVICE_NAMESPACE: &str = "PREFERED_SERVICE_NAMESPACE";
 const CA_ADDRESS: &str = "CA_ADDRESS";
 const SECRET_TTL: &str = "SECRET_TTL";
@@ -362,6 +363,19 @@ impl Default for SocketConfig {
     }
 }
 
+impl SocketConfig {
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(crate) fn tcp_user_timeout(self) -> Option<Duration> {
+        if !self.user_timeout_enabled {
+            return None;
+        }
+
+        self.keepalive_interval
+            .checked_mul(self.keepalive_retries)
+            .and_then(|retry_window| self.keepalive_time.checked_add(retry_window))
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("invalid env var {0}={1} ({2})")]
@@ -405,7 +419,11 @@ where
 }
 
 fn parse_duration(env: &str) -> Result<Option<Duration>, Error> {
-    parse::<String>(env)?
+    parse_duration_value(env, parse::<String>(env)?)
+}
+
+fn parse_duration_value(env: &str, value: Option<String>) -> Result<Option<Duration>, Error> {
+    value
         .map(|ds| {
             duration_str::parse(&ds).map_err(|e| Error::EnvVar(env.to_string(), ds, e.to_string()))
         })
@@ -969,6 +987,13 @@ fn validate_config(cfg: Config) -> Result<Config, Error> {
         )));
     }
 
+    #[cfg(target_os = "linux")]
+    if cfg.socket_config.user_timeout_enabled && cfg.socket_config.tcp_user_timeout().is_none() {
+        return Err(Error::InvalidState(
+            "TCP user timeout overflows Duration; reduce KEEPALIVE_TIME, KEEPALIVE_INTERVAL, or KEEPALIVE_RETRIES".to_string(),
+        ));
+    }
+
     Ok(cfg)
 }
 
@@ -1160,6 +1185,7 @@ pub mod tests {
 
     #[test]
     fn config_from_proxyconfig() {
+        let _guard = crate::test_helpers::lock_test_env();
         use crate::test_helpers::{MESH_CONFIG_YAML, temp_file_with_content};
 
         let default_config = construct_config(ProxyConfig::default())
@@ -1260,7 +1286,63 @@ pub mod tests {
     }
 
     #[test]
+    fn test_socket_config_tcp_user_timeout_detects_overflow() {
+        let cfg = SocketConfig {
+            keepalive_time: std::time::Duration::MAX,
+            keepalive_interval: std::time::Duration::from_secs(1),
+            keepalive_retries: 1,
+            keepalive_enabled: false,
+            user_timeout_enabled: true,
+        };
+
+        assert_eq!(cfg.tcp_user_timeout(), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_validate_config_rejects_overflowing_user_timeout() {
+        let mut cfg = crate::test_helpers::test_config();
+        cfg.socket_config.keepalive_time = std::time::Duration::MAX;
+        cfg.socket_config.keepalive_interval = std::time::Duration::from_secs(1);
+        cfg.socket_config.keepalive_retries = 1;
+        cfg.socket_config.user_timeout_enabled = true;
+
+        let err = validate_config(cfg).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::InvalidState(ref msg) if msg.contains("TCP user timeout")
+            ),
+            "expected TCP user timeout validation error, got {err}"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn test_validate_config_allows_overflowing_user_timeout_when_unsupported() {
+        let mut cfg = crate::test_helpers::test_config();
+        cfg.socket_config.keepalive_time = std::time::Duration::MAX;
+        cfg.socket_config.keepalive_interval = std::time::Duration::from_secs(1);
+        cfg.socket_config.keepalive_retries = 1;
+        cfg.socket_config.user_timeout_enabled = true;
+
+        validate_config(cfg)
+            .expect("unsupported TCP user timeout should remain inert on non-Linux");
+    }
+
+    #[test]
+    fn test_parse_config_ignores_removed_xds_non_fresh_threshold_env() {
+        let _guard = crate::test_helpers::lock_test_env();
+        let _proxy_config = crate::test_helpers::EnvVarRestore::remove(PROXY_CONFIG);
+        let _xds_non_fresh_threshold =
+            crate::test_helpers::EnvVarRestore::set("XDS_NON_FRESH_THRESHOLD", "0s");
+
+        parse_config().expect("removed XDS_NON_FRESH_THRESHOLD should be ignored");
+    }
+
+    #[test]
     fn test_parse_worker_threads() {
+        let _guard = crate::test_helpers::lock_test_env();
         unsafe {
             // Test fixed number
             env::set_var(ZTUNNEL_WORKER_THREADS, "4");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -122,9 +122,10 @@ impl DefaultSocketFactory {
         if cfg.user_timeout_enabled {
             // https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/
             // TCP_USER_TIMEOUT = TCP_KEEPIDLE + TCP_KEEPINTVL * TCP_KEEPCNT.
-            let ut = cfg.keepalive_time + cfg.keepalive_retries * cfg.keepalive_interval;
-            let res = socket2::SockRef::from(&s).set_tcp_user_timeout(Some(ut));
-            tracing::trace!("set user timeout: {:?}", res);
+            if let Some(ut) = cfg.tcp_user_timeout() {
+                let res = socket2::SockRef::from(&s).set_tcp_user_timeout(Some(ut));
+                tracing::trace!("set user timeout: {:?}", res);
+            }
         }
         Ok(())
     }

--- a/src/readiness.rs
+++ b/src/readiness.rs
@@ -52,6 +52,20 @@ impl BlockReady {
     pub fn subtask(&self, name: &str) -> BlockReady {
         self.parent.register_task(name)
     }
+
+    /// Atomically replaces this readiness blocker with another blocker.
+    pub(crate) fn replace_with(mut self, name: &str) -> BlockReady {
+        let new_name = name.to_string();
+
+        let mut pending = self.parent.0.lock().unwrap();
+        let removed = pending.remove(&self.name);
+        debug_assert!(removed); // It is a bug to somehow remove something twice
+        pending.insert(new_name.clone());
+        drop(pending);
+
+        self.name = new_name;
+        self
+    }
 }
 
 impl Drop for BlockReady {
@@ -72,5 +86,52 @@ impl Drop for BlockReady {
                 self.name
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replacing_task_holds_replacement_until_replacement_is_dropped() {
+        let ready = Ready::new();
+        let task = ready.register_task("state manager");
+
+        let replacement = task.replace_with("xds monitor dead");
+
+        let pending = ready.pending();
+        assert!(
+            !pending.contains("state manager"),
+            "old readiness blocker should be removed by replacement"
+        );
+        assert!(
+            pending.contains("xds monitor dead"),
+            "replacement readiness blocker should remain registered"
+        );
+
+        drop(replacement);
+        assert!(
+            ready.pending().is_empty(),
+            "replacement blocker should drop normally"
+        );
+    }
+
+    #[test]
+    fn replacing_task_does_not_leak_original_guard_fields() {
+        let ready = Ready::new();
+        let task = ready.register_task("state manager");
+        assert_eq!(std::sync::Arc::strong_count(&ready.0), 2);
+
+        let replacement = task.replace_with("xds monitor dead");
+
+        assert_eq!(
+            std::sync::Arc::strong_count(&ready.0),
+            2,
+            "replacement should transfer the original guard without leaking its Ready clone"
+        );
+
+        drop(replacement);
+        assert_eq!(std::sync::Arc::strong_count(&ready.0), 1);
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -81,16 +81,14 @@ fn orig_dst_addr(stream: &tokio::net::TcpStream) -> io::Result<SocketAddr> {
 
 #[cfg(not(target_os = "linux"))]
 fn orig_dst_addr(_: &tokio::net::TcpStream) -> io::Result<SocketAddr> {
-    Err(Error::new(
-        io::ErrorKind::Other,
+    Err(Error::other(
         "SO_ORIGINAL_DST not supported on this operating system",
     ))
 }
 
 #[cfg(not(target_os = "linux"))]
 pub fn set_freebind_and_transparent(_: &TcpSocket) -> io::Result<()> {
-    Err(Error::new(
-        io::ErrorKind::Other,
+    Err(Error::other(
         "IP_TRANSPARENT and IP_FREEBIND are not supported on this operating system",
     ))
 }
@@ -103,8 +101,7 @@ pub fn set_mark<S: std::os::unix::io::AsFd>(socket: &S, mark: u32) -> io::Result
 
 #[cfg(not(target_os = "linux"))]
 pub fn set_mark(_socket: &TcpSocket, _mark: u32) -> io::Result<()> {
-    Err(io::Error::new(
-        io::ErrorKind::Other,
+    Err(io::Error::other(
         "SO_MARK not supported on this operating system",
     ))
 }
@@ -179,9 +176,13 @@ impl Listener {
                 tracing::trace!("set keepalive: {:?}", res);
             }
             if cfg.user_timeout_enabled {
-                let ut = cfg.keepalive_time + cfg.keepalive_retries * cfg.keepalive_interval;
-                let res = SockRef::from(&stream).set_tcp_user_timeout(Some(ut));
-                tracing::trace!("set user timeout: {:?}", res);
+                #[cfg(target_os = "linux")]
+                {
+                    if let Some(ut) = cfg.tcp_user_timeout() {
+                        let res = SockRef::from(&stream).set_tcp_user_timeout(Some(ut));
+                        tracing::trace!("set user timeout: {:?}", res);
+                    }
+                }
             }
         }
         Ok((stream, remote))
@@ -198,8 +199,7 @@ impl Listener {
 #[cfg(not(target_os = "linux"))]
 impl Listener {
     pub fn set_transparent(&self) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
+        Err(io::Error::other(
             "IP_TRANSPARENT not supported on this operating system",
         ))
     }
@@ -238,7 +238,31 @@ pub mod socket_tests {
             sock.tcp_keepalive_interval().unwrap(),
             cfg.keepalive_interval
         );
-        let ut = cfg.keepalive_time + cfg.keepalive_retries * cfg.keepalive_interval;
-        assert_eq!(sock.tcp_user_timeout().unwrap(), Some(ut));
+        let ut = cfg.tcp_user_timeout();
+        #[cfg(target_os = "linux")]
+        assert_eq!(sock.tcp_user_timeout().unwrap(), ut);
+        #[cfg(not(target_os = "linux"))]
+        let _ = ut;
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[tokio::test]
+    async fn test_user_timeout_disabled_without_non_linux_duration_arithmetic() {
+        let cfg = SocketConfig {
+            keepalive_enabled: false,
+            keepalive_time: std::time::Duration::MAX,
+            keepalive_retries: u32::MAX,
+            keepalive_interval: std::time::Duration::MAX,
+            user_timeout_enabled: true,
+        };
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let mut socklistener = Listener::new(listener);
+        socklistener.set_socket_options(Some(cfg));
+
+        let (accepted, connected) = tokio::join!(socklistener.accept(), TcpStream::connect(addr));
+        accepted.expect("accept should ignore unsupported user timeout on non-Linux");
+        connected.expect("client should connect to test listener");
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1150,6 +1150,14 @@ pub struct ProxyStateManager {
 
     #[serde(skip_serializing)]
     xds_client: Option<AdsClient>,
+
+    /// Tracks the current xDS connection state for freshness metrics.
+    #[serde(skip_serializing)]
+    xds_connection_state: Option<tokio::sync::watch::Receiver<xds::XdsConnectionState>>,
+
+    /// Publishes every xDS connection-state transition for freshness metrics.
+    #[serde(skip_serializing)]
+    xds_connection_state_events: Option<tokio::sync::broadcast::Sender<xds::XdsConnectionState>>,
 }
 
 impl ProxyStateManager {
@@ -1164,20 +1172,22 @@ impl ProxyStateManager {
         let state: Arc<RwLock<ProxyState>> = Arc::new(RwLock::new(ProxyState::new(
             config.local_node.as_ref().map(strng::new),
         )));
-        let xds_client = if config.xds_address.is_some() {
-            let updater = ProxyStateUpdater::new(state.clone(), cert_fetcher.clone());
-            let tls_client_fetcher = Box::new(tls::ControlPlaneAuthentication::RootCert(
-                config.xds_root_cert.clone(),
-            ));
-            Some(
-                xds::Config::new(config.clone(), tls_client_fetcher)
+        let (xds_client, xds_connection_state, xds_connection_state_events) =
+            if config.xds_address.is_some() {
+                let updater = ProxyStateUpdater::new(state.clone(), cert_fetcher.clone());
+                let tls_client_fetcher = Box::new(tls::ControlPlaneAuthentication::RootCert(
+                    config.xds_root_cert.clone(),
+                ));
+                let client = xds::Config::new(config.clone(), tls_client_fetcher)
                     .with_watched_handler::<XdsAddress>(xds::ADDRESS_TYPE, updater.clone())
                     .with_watched_handler::<XdsAuthorization>(xds::AUTHORIZATION_TYPE, updater)
-                    .build(xds_metrics, awaiting_ready),
-            )
-        } else {
-            None
-        };
+                    .build(xds_metrics, awaiting_ready);
+                let conn_state = client.connection_state_receiver();
+                let conn_state_events = client.connection_state_event_sender();
+                (Some(client), Some(conn_state), Some(conn_state_events))
+            } else {
+                (None, None, None)
+            };
         if let Some(cfg) = &config.local_xds_config {
             let local_client = LocalClient {
                 local_node: config.local_node.as_ref().map(strng::new),
@@ -1190,6 +1200,8 @@ impl ProxyStateManager {
         let demand = xds_client.as_ref().and_then(AdsClient::demander);
         Ok(ProxyStateManager {
             xds_client,
+            xds_connection_state,
+            xds_connection_state_events,
             state: DemandProxyState::new(
                 state,
                 demand,
@@ -1202,6 +1214,22 @@ impl ProxyStateManager {
 
     pub fn state(&self) -> DemandProxyState {
         self.state.clone()
+    }
+
+    /// Returns an xDS connection state receiver, if an xDS client is configured.
+    pub(crate) fn xds_connection_state(
+        &self,
+    ) -> Option<tokio::sync::watch::Receiver<xds::XdsConnectionState>> {
+        self.xds_connection_state.clone()
+    }
+
+    /// Returns an xDS connection-state event receiver, if an xDS client is configured.
+    pub(crate) fn xds_connection_state_events(
+        &self,
+    ) -> Option<tokio::sync::broadcast::Receiver<xds::XdsConnectionState>> {
+        self.xds_connection_state_events
+            .as_ref()
+            .map(|events| events.subscribe())
     }
 
     pub async fn run(self) -> anyhow::Result<()> {
@@ -1335,6 +1363,41 @@ mod tests {
         assert!(
             (0.70..0.80).contains(&frac_a),
             "expected ~75% for a, got {frac_a} (a={count_a}, b={count_b})"
+        );
+    }
+
+    #[test]
+    fn xds_connection_state_receiver_can_be_requested_multiple_times() {
+        let mut registry = Registry::default();
+        let metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
+        let state = DemandProxyState::new(
+            Arc::new(RwLock::new(ProxyState::new(None))),
+            None,
+            ResolverConfig::default(),
+            ResolverOpts::default(),
+            metrics,
+        );
+        let (state_tx, state_rx) =
+            tokio::sync::watch::channel(xds::XdsConnectionState::initializing());
+        let state_mgr = ProxyStateManager {
+            state,
+            xds_client: None,
+            xds_connection_state: Some(state_rx),
+            xds_connection_state_events: None,
+        };
+
+        let mut first = state_mgr.xds_connection_state().unwrap();
+        state_tx.send_replace(xds::XdsConnectionState::connected(0));
+        let second = state_mgr.xds_connection_state().unwrap();
+
+        assert_eq!(
+            *first.borrow_and_update(),
+            xds::XdsConnectionState::connected(0)
+        );
+        assert_eq!(*second.borrow(), xds::XdsConnectionState::connected(0));
+        assert!(
+            state_mgr.xds_connection_state().is_some(),
+            "requesting a receiver must not consume future subscribers"
         );
     }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -16,9 +16,7 @@ use crate::config::ConfigSource;
 use crate::config::{self, RootCert};
 use crate::state::service::{Endpoint, EndpointSet, Service, Visibility};
 use crate::state::workload::InboundProtocol::{HBONE, TCP};
-use crate::state::workload::{
-    GatewayAddress, NamespacedHostname, NetworkAddress, Workload, gatewayaddress,
-};
+use crate::state::workload::{GatewayAddress, NetworkAddress, Workload, gatewayaddress};
 use crate::state::workload::{HealthStatus, InboundProtocol};
 use crate::state::{DemandProxyState, ProxyState};
 use crate::xds::istio::security::Authorization as XdsAuthorization;
@@ -30,6 +28,7 @@ use crate::xds::{Handler, LocalConfig, LocalWorkload, ProxyStateUpdater, XdsReso
 use anyhow::anyhow;
 use bytes::{BufMut, Bytes};
 use hickory_resolver::config::*;
+use std::ffi::OsString;
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -43,7 +42,7 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::ops::Add;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 use std::time::{Duration, SystemTime};
 use tokio::sync::mpsc::error::SendError;
 use tokio::time::timeout;
@@ -84,6 +83,16 @@ pub fn test_config_with_waypoint(addr: IpAddr) -> config::Config {
 }
 
 pub fn test_config_with_port_xds_addr_and_root_cert(
+    port: u16,
+    xds_addr: Option<String>,
+    xds_root_cert: Option<RootCert>,
+    xds_config: Option<ConfigSource>,
+) -> config::Config {
+    let _env_guard = lock_test_env();
+    test_config_with_port_xds_addr_and_root_cert_locked(port, xds_addr, xds_root_cert, xds_config)
+}
+
+fn test_config_with_port_xds_addr_and_root_cert_locked(
     port: u16,
     xds_addr: Option<String>,
     xds_root_cert: Option<RootCert>,
@@ -140,6 +149,48 @@ pub fn test_config_with_port_xds_addr_and_root_cert(
     cfg.dns_resolver_opts = Default::default();
     cfg.dns_resolver_cfg = ResolverConfig::from_parts(None, vec![], vec![]);
     cfg
+}
+
+static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn lock_test_env() -> MutexGuard<'static, ()> {
+    TEST_ENV_LOCK.lock().unwrap()
+}
+
+pub(crate) struct EnvVarRestore {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarRestore {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, previous }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn set(key: &'static str, value: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarRestore {
+    fn drop(&mut self) {
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 }
 
 pub fn test_config_with_port(port: u16) -> config::Config {

--- a/src/test_helpers/app.rs
+++ b/src/test_helpers/app.rs
@@ -78,6 +78,108 @@ impl From<(&Bound, Arc<SecretManager>)> for TestApp {
     }
 }
 
+#[cfg(any(test, feature = "testing"))]
+pub struct XdsTestSignals {
+    state: tokio::sync::watch::Receiver<xds::XdsConnectionState>,
+    startup: tokio::sync::watch::Receiver<()>,
+    freshness_monitor_exited: tokio::sync::watch::Receiver<bool>,
+    freshness_observations: tokio::sync::watch::Receiver<u64>,
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl XdsTestSignals {
+    pub fn from_bound(app: &Bound) -> Option<Self> {
+        Some(Self {
+            state: app.xds_connection_state.clone()?,
+            startup: app.xds_startup.clone(),
+            freshness_monitor_exited: app.xds_freshness_monitor_exited.clone(),
+            freshness_observations: app.xds_freshness_observations.clone()?,
+        })
+    }
+
+    pub async fn wait_for_startup_sync(&mut self) {
+        tokio::time::timeout(Duration::from_secs(2), self.startup.changed())
+            .await
+            .expect("timed out waiting for app startup xDS sync")
+            .expect("xDS startup sender dropped");
+    }
+
+    pub async fn wait_for_freshness_monitor_exit(&mut self) {
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            self.freshness_monitor_exited.wait_for(|exited| *exited),
+        )
+        .await
+        .expect("timed out waiting for xDS freshness monitor to exit")
+        .expect("xDS freshness monitor exit sender dropped");
+    }
+
+    pub async fn wait_for_synced(&mut self, reason: &str) -> u64 {
+        self.wait_for_state(
+            |state| state.kind() == xds::XdsConnectionStateKind::Synced,
+            reason,
+        )
+        .await
+        .freshness_epoch()
+    }
+
+    pub async fn wait_for_synced_after(&mut self, previous_epoch: u64, reason: &str) -> u64 {
+        self.wait_for_state(
+            |state| {
+                state.kind() == xds::XdsConnectionStateKind::Synced
+                    && state.freshness_epoch() != previous_epoch
+            },
+            reason,
+        )
+        .await
+        .freshness_epoch()
+    }
+
+    pub async fn wait_for_connected_at_epoch(&mut self, epoch: u64, reason: &str) {
+        self.wait_for_state(
+            |state| {
+                state.kind() == xds::XdsConnectionStateKind::Connected
+                    && state.freshness_epoch() == epoch
+            },
+            reason,
+        )
+        .await;
+    }
+
+    pub fn freshness_observation_count(&self) -> u64 {
+        *self.freshness_observations.borrow()
+    }
+
+    pub async fn wait_for_freshness_observation_after(
+        &mut self,
+        previous_count: u64,
+        reason: &str,
+    ) -> u64 {
+        *tokio::time::timeout(
+            Duration::from_secs(2),
+            self.freshness_observations
+                .wait_for(|count| *count > previous_count),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {reason}"))
+        .expect("xDS freshness observation sender dropped")
+    }
+
+    async fn wait_for_state(
+        &mut self,
+        mut predicate: impl FnMut(xds::XdsConnectionState) -> bool,
+        reason: &str,
+    ) -> xds::XdsConnectionState {
+        *tokio::time::timeout(
+            Duration::from_secs(2),
+            self.state.wait_for(|state| predicate(*state)),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {reason}"))
+        .expect("xDS connection state sender dropped")
+    }
+}
+
 pub async fn with_app<F, FO>(cfg: config::Config, f: F)
 where
     F: AsyncFn(TestApp) -> FO,

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -15,7 +15,7 @@
 use crate::config::{ConfigSource, ProxyMode};
 use crate::rbac::Authorization;
 use crate::state::service::{Endpoint, Service, Visibility};
-use crate::state::workload::{HealthStatus, Workload, gatewayaddress};
+use crate::state::workload::{HealthStatus, NamespacedHostname, Workload, gatewayaddress};
 use crate::strng::Strng;
 use crate::test_helpers::app::TestApp;
 use crate::test_helpers::netns::{Namespace, Resolver};

--- a/src/test_helpers/xds.rs
+++ b/src/test_helpers/xds.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::error::Error as StdError;
+use std::io;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -26,13 +28,13 @@ use hyper::server::conn::http2;
 use hyper_util::rt::TokioIo;
 use itertools::Itertools;
 use prometheus_client::registry::Registry;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Response, Status, Streaming};
 use tracing::{debug, error, info};
 
 use super::{hyper_tower, test_config_with_port_xds_addr_and_root_cert};
-use crate::config::RootCert;
+use crate::config::{self, RootCert};
 use crate::hyper_util::TokioExecutor;
 use crate::metrics::sub_registry;
 use crate::state::{DemandProxyState, ProxyState};
@@ -47,25 +49,70 @@ use crate::xds::{self, AdsClient, ProxyStateUpdater};
 
 pub struct AdsServer {
     tx: mpsc::Sender<AdsConnection>,
+    server_failure_tx: watch::Sender<Option<String>>,
 }
 
 pub struct AdsConnection {
-    pub tx: mpsc::Sender<Result<DeltaDiscoveryResponse, tonic::Status>>,
-    pub rx: mpsc::Receiver<DeltaDiscoveryRequest>,
+    tx: mpsc::Sender<Result<DeltaDiscoveryResponse, tonic::Status>>,
+    rx: mpsc::Receiver<DeltaDiscoveryRequest>,
+    forwarding_failure: watch::Receiver<Option<String>>,
+    server_failure: watch::Receiver<Option<String>>,
+}
+
+impl AdsConnection {
+    pub async fn recv_request(&mut self) -> Option<DeltaDiscoveryRequest> {
+        self.assert_forwarding_healthy();
+        tokio::select! {
+            req = self.rx.recv() => {
+                self.assert_forwarding_healthy();
+                req
+            }
+            changed = self.forwarding_failure.changed() => {
+                if changed.is_err() {
+                    panic!("ADS forwarding task exited while waiting for request");
+                }
+                self.assert_forwarding_healthy();
+                unreachable!("assert_forwarding_healthy panics when failure is present")
+            }
+            changed = self.server_failure.changed() => {
+                if changed.is_err() {
+                    panic!("ADS server task exited while waiting for request");
+                }
+                self.assert_forwarding_healthy();
+                unreachable!("assert_forwarding_healthy panics when failure is present")
+            }
+        }
+    }
+
+    pub async fn send_response(&mut self, response: Result<DeltaDiscoveryResponse, tonic::Status>) {
+        self.assert_forwarding_healthy();
+        self.tx
+            .send(response)
+            .await
+            .expect("failed to send server response");
+        tokio::task::yield_now().await;
+        self.assert_forwarding_healthy();
+    }
+
+    pub fn assert_forwarding_healthy(&self) {
+        if let Some(err) = self.forwarding_failure.borrow().as_ref() {
+            panic!("ADS forwarding task failed: {err}");
+        }
+        if let Some(err) = self.server_failure.borrow().as_ref() {
+            panic!("ADS server task failed: {err}");
+        }
+    }
 }
 
 impl AdsServer {
-    pub async fn spawn(
-        xds_on_demand: bool,
-    ) -> (
-        mpsc::Receiver<AdsConnection>,
-        AdsClient,
-        DemandProxyState,
-        tokio::sync::watch::Receiver<()>,
-    ) {
+    pub async fn spawn_app_server() -> (mpsc::Receiver<AdsConnection>, config::Config) {
         let (tx, rx) = mpsc::channel(100);
+        let (server_failure_tx, _server_failure_rx) = watch::channel(None);
 
-        let server = AdsServer { tx };
+        let server = AdsServer {
+            tx,
+            server_failure_tx: server_failure_tx.clone(),
+        };
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let server_addr = listener.local_addr().unwrap();
         let certs = tls::mock::generate_test_certs(
@@ -81,6 +128,7 @@ impl AdsServer {
         tokio::spawn(async move {
             while let Some(socket) = tls_stream.next().await {
                 let srv = srv.clone();
+                let server_failure_tx = server_failure_tx.clone();
                 tokio::spawn(async move {
                     if let Err(err) = http2::Builder::new(TokioExecutor)
                         .serve_connection(
@@ -89,11 +137,37 @@ impl AdsServer {
                         )
                         .await
                     {
-                        error!("Error serving connection: {:?}", err);
+                        if is_expected_serve_connection_close(&err) {
+                            debug!("ads_server: serve_connection closed: {:?}", err);
+                        } else {
+                            let failure = format!("serve_connection failed: {err:?}");
+                            error!("ads_server: {failure}");
+                            server_failure_tx.send_replace(Some(failure));
+                        }
                     }
                 });
             }
         });
+
+        let cfg = test_config_with_port_xds_addr_and_root_cert(
+            80,
+            Some(listener_addr_string),
+            Some(root_cert),
+            None,
+        );
+
+        (rx, cfg)
+    }
+
+    pub async fn spawn(
+        xds_on_demand: bool,
+    ) -> (
+        mpsc::Receiver<AdsConnection>,
+        AdsClient,
+        DemandProxyState,
+        tokio::sync::watch::Receiver<()>,
+    ) {
+        let (rx, mut cfg) = Self::spawn_app_server().await;
 
         let mut registry = Registry::default();
         let istio_registry = sub_registry(&mut registry);
@@ -101,12 +175,6 @@ impl AdsServer {
 
         let (block_tx, block_rx) = tokio::sync::watch::channel(());
 
-        let mut cfg = test_config_with_port_xds_addr_and_root_cert(
-            80,
-            Some(listener_addr_string),
-            Some(root_cert),
-            None,
-        );
         cfg.xds_on_demand = xds_on_demand;
 
         let proxy_metrics = Arc::new(crate::proxy::Metrics::new(&mut registry));
@@ -128,6 +196,27 @@ impl AdsServer {
             .build(metrics, block_tx);
 
         (rx, xds_client, dstate, block_rx)
+    }
+}
+
+fn is_expected_serve_connection_close(err: &(dyn StdError + 'static)) -> bool {
+    matches!(
+        find_io_error_kind(err),
+        Some(
+            io::ErrorKind::BrokenPipe
+                | io::ErrorKind::ConnectionReset
+                | io::ErrorKind::UnexpectedEof
+                | io::ErrorKind::NotConnected
+        )
+    )
+}
+
+fn find_io_error_kind(mut err: &(dyn StdError + 'static)) -> Option<io::ErrorKind> {
+    loop {
+        if let Some(io_err) = err.downcast_ref::<io::Error>() {
+            return Some(io_err.kind());
+        }
+        err = err.source()?;
     }
 }
 
@@ -153,10 +242,13 @@ impl AggregatedDiscoveryService for AdsServer {
         let (req_tx, req_rx) = mpsc::channel(128);
 
         let (tx, rx) = mpsc::channel(128);
+        let (failure_tx, failure_rx) = watch::channel(None);
 
         let conn = AdsConnection {
             rx: req_rx,
             tx: resp_tx,
+            forwarding_failure: failure_rx,
+            server_failure: self.server_failure_tx.subscribe(),
         };
 
         self.tx.send(conn).await.unwrap();
@@ -169,14 +261,17 @@ impl AggregatedDiscoveryService for AdsServer {
                             Some(Ok(req)) => {
                                 info!("received request...",);
                                 debug!(" request {:?}...", req);
-                                req_tx.send(req).await.unwrap();
+                                if let Err(e) = req_tx.send(req).await {
+                                    debug!("ads_server: request channel closed - {:?}", e);
+                                    return;
+                                }
                             }
                             Some(Err(e)) => {
-                                info!("ads_server: stream over - {:?}", e);
+                                debug!("ads_server: stream over - {:?}", e);
                                 return;
                             }
                             None => {
-                                info!("ads_server: stream over");
+                                debug!("ads_server: stream over");
                                 return;
                             }
                         }
@@ -189,13 +284,17 @@ impl AggregatedDiscoveryService for AdsServer {
                                 match tx.send(response).await {
                                     Ok(_) => {}
                                     Err(e) => {
-                                        info!("ads_server: send terminated - {:?} ", e);
+                                        let failure = format!(
+                                            "response stream closed while forwarding server response: {e:?}"
+                                        );
+                                        error!("ads_server: {failure}");
+                                        failure_tx.send_replace(Some(failure));
                                         return;
                                     }
                                 }
                             }
                             None => {
-                                info!("ads_server: response channel closed");
+                                debug!("ads_server: response channel closed");
                                 return;
                             }
                         }
@@ -208,5 +307,102 @@ impl AggregatedDiscoveryService for AdsServer {
         Ok(Response::new(
             Box::pin(output_stream) as Self::DeltaAggregatedResourcesStream
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn panic_message(err: tokio::task::JoinError) -> String {
+        let panic = err.into_panic();
+        panic
+            .downcast_ref::<String>()
+            .map(String::to_string)
+            .or_else(|| panic.downcast_ref::<&str>().map(|msg| (*msg).to_string()))
+            .expect("panic should include a string message")
+    }
+
+    #[test]
+    #[should_panic(expected = "ADS server task failed: boom")]
+    fn ads_connection_reports_serve_connection_failure() {
+        let (resp_tx, _resp_rx) = mpsc::channel(1);
+        let (_req_tx, req_rx) = mpsc::channel(1);
+        let (_forwarding_tx, forwarding_failure) = watch::channel(None);
+        let (server_failure_tx, server_failure) = watch::channel(None);
+
+        let conn = AdsConnection {
+            tx: resp_tx,
+            rx: req_rx,
+            forwarding_failure,
+            server_failure,
+        };
+
+        server_failure_tx.send_replace(Some("boom".to_string()));
+        conn.assert_forwarding_healthy();
+    }
+
+    #[tokio::test]
+    async fn ads_connection_recv_request_reports_server_failure_while_waiting() {
+        let (resp_tx, _resp_rx) = mpsc::channel(1);
+        let (_req_tx, req_rx) = mpsc::channel(1);
+        let (_forwarding_tx, forwarding_failure) = watch::channel(None);
+        let (server_failure_tx, server_failure) = watch::channel(None);
+
+        let mut conn = AdsConnection {
+            tx: resp_tx,
+            rx: req_rx,
+            forwarding_failure,
+            server_failure,
+        };
+
+        let recv = tokio::spawn(async move {
+            conn.recv_request().await;
+        });
+
+        tokio::task::yield_now().await;
+        server_failure_tx.send_replace(Some("boom".to_string()));
+
+        let err = tokio::time::timeout(Duration::from_millis(100), recv)
+            .await
+            .expect("recv_request did not report server failure")
+            .expect_err("recv_request returned instead of panicking");
+        assert!(err.is_panic());
+
+        let panic = err.into_panic();
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&str>().copied())
+            .expect("recv_request panic should include a string message");
+        assert!(message.contains("ADS server task failed: boom"));
+    }
+
+    #[tokio::test]
+    async fn ads_connection_recv_request_reports_preexisting_server_failure() {
+        let (resp_tx, _resp_rx) = mpsc::channel(1);
+        let (_req_tx, req_rx) = mpsc::channel(1);
+        let (_forwarding_tx, forwarding_failure) = watch::channel(None);
+        let (_server_failure_tx, server_failure) = watch::channel(Some("boom".to_string()));
+
+        let mut conn = AdsConnection {
+            tx: resp_tx,
+            rx: req_rx,
+            forwarding_failure,
+            server_failure,
+        };
+
+        let recv = tokio::spawn(async move {
+            conn.recv_request().await;
+        });
+
+        let err = tokio::time::timeout(Duration::from_millis(100), recv)
+            .await
+            .expect("recv_request did not report preexisting server failure")
+            .expect_err("recv_request returned instead of panicking");
+        assert!(err.is_panic());
+
+        let message = panic_message(err);
+        assert!(message.contains("ADS server task failed: boom"));
     }
 }

--- a/src/tls/certificate.rs
+++ b/src/tls/certificate.rs
@@ -499,20 +499,25 @@ mod test {
         let tls = TlsAcceptor::from(Arc::new(server));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::task::spawn(async move {
+        let server = tokio::task::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let mut tls = tls.accept(stream).await.unwrap();
-            let _ = tls.write(b"serv").await.unwrap();
+            tls.write_all(b"serv").await.unwrap();
+
+            let mut buf = [0u8; 2];
+            tls.read_exact(&mut buf).await.unwrap();
+            assert_eq!(&buf, b"hi");
         });
 
         let stream = TcpStream::connect(addr).await.unwrap();
         let client = cert2.outbound_connector(vec![id], None).unwrap();
         let mut tls = client.connect(stream).await.unwrap();
 
-        let _ = tls.write(b"hi").await.unwrap();
+        tls.write_all(b"hi").await.unwrap();
         let mut buf = [0u8; 4];
         tls.read_exact(&mut buf).await.unwrap();
         assert_eq!(&buf, b"serv");
+        server.await.unwrap();
     }
 
     /// Outbound client must abort TLS when the peer's leaf cert appears in the loaded CRL (i.e. is revoked).

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -48,6 +48,7 @@ use crate::{tls, xds};
 use self::service::discovery::v3::DeltaDiscoveryRequest;
 
 mod client;
+pub(crate) mod freshness_monitor;
 pub mod metrics;
 mod types;
 

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -13,19 +13,19 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
-use std::{fmt, mem};
 
+use prometheus_client::metrics::gauge::Gauge;
 use prost::{DecodeError, EncodeError};
 use prost_types::value::Kind;
 use prost_types::{Struct, Value};
 use serde_json;
 use split_iter::Splittable;
 use thiserror::Error;
-use tokio::sync::mpsc;
-use tokio::sync::oneshot;
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue};
 use tracing::{Instrument, debug, error, info, info_span, warn};
 
@@ -49,6 +49,7 @@ const NAME: &str = "NAME";
 const NAMESPACE: &str = "NAMESPACE";
 const EMPTY_STR: &str = "";
 const ISTIO_METAJSON_PREFIX: &str = "ISTIO_METAJSON_";
+const MAX_REJECTED_WATCHED_RESOURCES_PER_TYPE: usize = 1024;
 
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
 pub struct ResourceKey {
@@ -418,8 +419,103 @@ impl Config {
     }
 
     pub fn build(self, metrics: Metrics, block_ready: tokio::sync::watch::Sender<()>) -> AdsClient {
-        AdsClient::new(self, metrics, block_ready)
+        let (connection_state_tx, _) = tokio::sync::watch::channel(
+            XdsConnectionState::initializing().with_transitioned_at(tokio::time::Instant::now()),
+        );
+        let (connection_state_events_tx, _) = broadcast::channel(64);
+        AdsClient::new(
+            self,
+            metrics,
+            block_ready,
+            connection_state_tx,
+            connection_state_events_tx,
+        )
     }
+}
+
+/// Tracks the xDS connection state for readiness and freshness reporting.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct XdsConnectionState {
+    kind: XdsConnectionStateKind,
+    freshness_epoch: u64,
+    transitioned_at: Option<tokio::time::Instant>,
+}
+
+impl XdsConnectionState {
+    pub(crate) const fn initializing() -> Self {
+        Self {
+            kind: XdsConnectionStateKind::Initializing,
+            freshness_epoch: 0,
+            transitioned_at: None,
+        }
+    }
+
+    pub(crate) const fn connected(freshness_epoch: u64) -> Self {
+        Self {
+            kind: XdsConnectionStateKind::Connected,
+            freshness_epoch,
+            transitioned_at: None,
+        }
+    }
+
+    pub(crate) const fn synced(freshness_epoch: u64) -> Self {
+        Self {
+            kind: XdsConnectionStateKind::Synced,
+            freshness_epoch,
+            transitioned_at: None,
+        }
+    }
+
+    pub(crate) const fn disconnected(freshness_epoch: u64) -> Self {
+        Self {
+            kind: XdsConnectionStateKind::Disconnected,
+            freshness_epoch,
+            transitioned_at: None,
+        }
+    }
+
+    pub(crate) const fn kind(self) -> XdsConnectionStateKind {
+        self.kind
+    }
+
+    pub(crate) const fn freshness_epoch(self) -> u64 {
+        self.freshness_epoch
+    }
+
+    pub(crate) fn with_transitioned_at(mut self, transitioned_at: tokio::time::Instant) -> Self {
+        self.transitioned_at = Some(transitioned_at);
+        self
+    }
+
+    pub(crate) fn transitioned_at(self) -> tokio::time::Instant {
+        self.transitioned_at
+            .unwrap_or_else(tokio::time::Instant::now)
+    }
+}
+
+impl PartialEq for XdsConnectionState {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind && self.freshness_epoch == other.freshness_epoch
+    }
+}
+
+impl Eq for XdsConnectionState {}
+
+/// Coarse xDS connection state for readiness and freshness reporting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum XdsConnectionStateKind {
+    /// Initial state before first successful connection.
+    Initializing,
+    /// gRPC stream is established but is not currently fresh. This covers both
+    /// pre-ACK streams and streams with a watched-type NACK outstanding. NOT a
+    /// freshness signal: served state may be stale from before the disconnect.
+    Connected,
+    /// At least one DeltaDiscoveryResponse has been ACKed on the current stream,
+    /// and no watched-type NACK is outstanding. Indicates the control plane has
+    /// begun re-asserting state after the (re)connect.
+    Synced,
+    /// Disconnected from xDS server.
+    Disconnected,
 }
 
 /// AdsClient provides a (mostly) generic DeltaAggregatedResources XDS client.
@@ -440,8 +536,30 @@ pub struct AdsClient {
     pub(crate) metrics: Metrics,
     block_ready: Option<tokio::sync::watch::Sender<()>>,
 
+    /// Broadcasts the current xDS connection state for readiness and freshness tracking.
+    connection_state_tx: tokio::sync::watch::Sender<XdsConnectionState>,
+    connection_state_events_tx: broadcast::Sender<XdsConnectionState>,
+    freshness_epoch: u64,
+
     connection_id: u32,
+    watched_type_urls: HashSet<Strng>,
+    rejected_watched_resources: HashSet<ResourceKey>,
+    overflowed_rejected_watched_types: HashSet<Strng>,
     types_to_expect: HashSet<String>,
+
+    /// Tracks when the current disconnect period started, for duration metrics.
+    disconnect_start: Option<tokio::time::Instant>,
+
+    /// Set to `true` inside `run_internal` once a gRPC stream has been
+    /// established; consulted by `run_loop` after `run_internal` returns to
+    /// decide whether to start a disconnect-duration timer. Reset on every
+    /// loop iteration.
+    reached_connected: bool,
+
+    #[cfg(test)]
+    retry_sleep_gate: Option<RetrySleepGate>,
+    #[cfg(test)]
+    connected_state_publish_hook: Option<Box<dyn FnMut(Option<i64>) + Send>>,
 }
 
 /// Demanded allows awaiting for an on-demand XDS resource
@@ -466,15 +584,74 @@ pub struct Demander {
 
 #[derive(Debug)]
 enum XdsSignal {
-    Ack,
-    Nack,
+    Ack {
+        resources: Vec<ResourceKey>,
+    },
+    AckIgnored,
+    Nack {
+        rejected: Vec<ResourceKey>,
+        accepted: Vec<ResourceKey>,
+    },
+}
+
+#[derive(Debug)]
+struct HandledXdsResponse {
+    type_url: String,
+    nonce: String,
+    signal: XdsSignal,
+    error: Option<String>,
+}
+
+#[cfg(test)]
+struct RetrySleepGate {
+    started: oneshot::Sender<()>,
+    proceed: oneshot::Receiver<()>,
+}
+
+struct XdsUpGuard {
+    up: Option<Gauge>,
+    config_fresh: Option<Gauge>,
+}
+
+fn xds_header_value_for_log(_: &AsciiMetadataValue) -> &'static str {
+    "<redacted>"
+}
+
+impl XdsUpGuard {
+    fn connected(up: Option<Gauge>, config_fresh: Option<Gauge>) -> Self {
+        if let Some(up) = &up {
+            up.set(1);
+        }
+        Self { up, config_fresh }
+    }
+}
+
+impl Drop for XdsUpGuard {
+    fn drop(&mut self) {
+        if let Some(up) = &self.up {
+            up.set(0);
+        }
+        if let Some(config_fresh) = &self.config_fresh {
+            config_fresh.set(0);
+        }
+    }
+}
+
+impl XdsSignal {
+    fn rejected_resources(&self) -> &[ResourceKey] {
+        match self {
+            XdsSignal::Nack { rejected, .. } => rejected,
+            _ => &[],
+        }
+    }
 }
 
 impl Display for XdsSignal {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            XdsSignal::Ack => "ACK",
-            XdsSignal::Nack => "NACK",
+            XdsSignal::Ack { .. } => "ACK",
+            XdsSignal::AckIgnored => "ACK_IGNORED",
+            XdsSignal::Nack { .. } => "NACK",
         })
     }
 }
@@ -500,7 +677,13 @@ impl AdsClient {
         !r.resource_names_subscribe.is_empty()
     }
 
-    fn new(config: Config, metrics: Metrics, block_ready: tokio::sync::watch::Sender<()>) -> Self {
+    fn new(
+        config: Config,
+        metrics: Metrics,
+        block_ready: tokio::sync::watch::Sender<()>,
+        connection_state_tx: tokio::sync::watch::Sender<XdsConnectionState>,
+        connection_state_events_tx: broadcast::Sender<XdsConnectionState>,
+    ) -> Self {
         let (tx, rx) = mpsc::channel(100);
         let state = State {
             known_resources: Default::default(),
@@ -514,13 +697,30 @@ impl AdsClient {
             .filter(|e| !Self::is_initial_request_on_demand(e)) // is_empty implies not ondemand
             .map(|e| e.type_url.clone())
             .collect();
+        let watched_type_urls = config
+            .initial_requests
+            .iter()
+            .map(|e| strng::new(&e.type_url))
+            .collect();
         AdsClient {
             config,
             state,
             metrics,
             block_ready: Some(block_ready),
+            connection_state_tx,
+            connection_state_events_tx,
+            freshness_epoch: 0,
             connection_id: 0,
+            watched_type_urls,
+            rejected_watched_resources: HashSet::new(),
+            overflowed_rejected_watched_types: HashSet::new(),
             types_to_expect,
+            disconnect_start: None,
+            reached_connected: false,
+            #[cfg(test)]
+            retry_sleep_gate: None,
+            #[cfg(test)]
+            connected_state_publish_hook: None,
         }
     }
 
@@ -535,8 +735,227 @@ impl AdsClient {
         }
     }
 
+    /// Returns a receiver that tracks the current xDS connection state.
+    pub(crate) fn connection_state_receiver(
+        &self,
+    ) -> tokio::sync::watch::Receiver<XdsConnectionState> {
+        self.connection_state_tx.subscribe()
+    }
+
+    pub(crate) fn connection_state_event_sender(&self) -> broadcast::Sender<XdsConnectionState> {
+        self.connection_state_events_tx.clone()
+    }
+
+    #[cfg(test)]
+    fn pause_before_next_retry_sleep_for_test(
+        &mut self,
+    ) -> (oneshot::Receiver<()>, oneshot::Sender<()>) {
+        let (started_tx, started_rx) = oneshot::channel();
+        let (proceed_tx, proceed_rx) = oneshot::channel();
+        self.retry_sleep_gate = Some(RetrySleepGate {
+            started: started_tx,
+            proceed: proceed_rx,
+        });
+        (started_rx, proceed_tx)
+    }
+
+    #[cfg(test)]
+    fn capture_up_gauge_when_connected_published_for_test(
+        &mut self,
+    ) -> oneshot::Receiver<Option<i64>> {
+        let (tx, rx) = oneshot::channel();
+        let mut tx = Some(tx);
+        self.connected_state_publish_hook = Some(Box::new(move |up| {
+            if let Some(tx) = tx.take() {
+                let _ = tx.send(up);
+            }
+        }));
+        rx
+    }
+
+    #[cfg(test)]
+    async fn wait_before_retry_sleep_for_test(&mut self) {
+        if let Some(gate) = self.retry_sleep_gate.take() {
+            let _ = gate.started.send(());
+            let _ = gate.proceed.await;
+        }
+    }
+
+    fn publish_connection_state(&mut self, kind: XdsConnectionStateKind) {
+        // Use `send_replace` instead of `send` so the watch's stored value
+        // advances even when there are currently no subscribers. With plain
+        // `send`, a subscriber that connects after startup would observe the
+        // initial `Initializing` value until the next transition.
+        if kind == XdsConnectionStateKind::Synced {
+            self.freshness_epoch = self.freshness_epoch.wrapping_add(1);
+        }
+        let state = match kind {
+            XdsConnectionStateKind::Initializing => XdsConnectionState::initializing(),
+            XdsConnectionStateKind::Connected => {
+                XdsConnectionState::connected(self.freshness_epoch)
+            }
+            XdsConnectionStateKind::Synced => XdsConnectionState::synced(self.freshness_epoch),
+            XdsConnectionStateKind::Disconnected => {
+                XdsConnectionState::disconnected(self.freshness_epoch)
+            }
+        };
+        let current_state = *self.connection_state_tx.borrow();
+        let transitioned_at = if current_state == state {
+            current_state.transitioned_at()
+        } else {
+            tokio::time::Instant::now()
+        };
+        let state = state.with_transitioned_at(transitioned_at);
+        if let Some(config_fresh) = &self.metrics.config_fresh {
+            config_fresh.set(i64::from(kind == XdsConnectionStateKind::Synced));
+        }
+        self.connection_state_tx.send_replace(state);
+        let _ = self.connection_state_events_tx.send(state);
+        #[cfg(test)]
+        if kind == XdsConnectionStateKind::Connected
+            && let Some(hook) = &mut self.connected_state_publish_hook
+        {
+            hook(self.metrics.up.as_ref().map(|up| up.get()));
+        }
+    }
+
+    fn remove_accepted_watched_resources(&mut self, resources: &[ResourceKey]) {
+        for resource in resources {
+            if self.is_watched_resource(resource) {
+                self.rejected_watched_resources.remove(resource);
+            }
+        }
+    }
+
+    fn is_watched_resource(&self, resource: &ResourceKey) -> bool {
+        self.watched_type_urls.contains(&resource.type_url)
+    }
+
+    fn has_watched_resources(&self, resources: &[ResourceKey]) -> bool {
+        resources
+            .iter()
+            .any(|resource| self.is_watched_resource(resource))
+    }
+
+    fn should_collect_accepted_resources(&self, type_url: &Strng) -> bool {
+        self.watched_type_urls.contains(type_url)
+            && self
+                .rejected_watched_resources
+                .iter()
+                .any(|resource| &resource.type_url == type_url)
+    }
+
+    fn has_outstanding_watched_rejections(&self) -> bool {
+        !self.rejected_watched_resources.is_empty()
+            || !self.overflowed_rejected_watched_types.is_empty()
+    }
+
+    fn response_resource_keys(
+        response: &DeltaDiscoveryResponse,
+        type_url: Strng,
+    ) -> Vec<ResourceKey> {
+        response
+            .resources
+            .iter()
+            .map(|resource| ResourceKey {
+                name: strng::new(&resource.name),
+                type_url: type_url.clone(),
+            })
+            .chain(response.removed_resources.iter().map(|name| ResourceKey {
+                name: strng::new(name),
+                type_url: type_url.clone(),
+            }))
+            .collect()
+    }
+
+    fn record_watched_rejections(&mut self, signal: &XdsSignal) {
+        match signal {
+            XdsSignal::Nack { rejected, accepted } => {
+                self.remove_accepted_watched_resources(accepted);
+                for resource in rejected {
+                    if self.is_watched_resource(resource) {
+                        self.track_rejected_watched_resource(resource);
+                    }
+                }
+            }
+            XdsSignal::Ack { .. } | XdsSignal::AckIgnored => {}
+        }
+    }
+
+    fn track_rejected_watched_resource(&mut self, resource: &ResourceKey) {
+        if self
+            .overflowed_rejected_watched_types
+            .contains(&resource.type_url)
+        {
+            return;
+        }
+        if self.rejected_watched_resources.contains(resource) {
+            return;
+        }
+        let retained_for_type = self
+            .rejected_watched_resources
+            .iter()
+            .filter(|retained| retained.type_url == resource.type_url)
+            .count();
+        if retained_for_type >= MAX_REJECTED_WATCHED_RESOURCES_PER_TYPE {
+            warn!(
+                type_url = %resource.type_url,
+                limit = MAX_REJECTED_WATCHED_RESOURCES_PER_TYPE,
+                "too many rejected watched resources retained; failing closed for this type until restart"
+            );
+            self.rejected_watched_resources
+                .retain(|retained| retained.type_url != resource.type_url);
+            self.overflowed_rejected_watched_types
+                .insert(resource.type_url.clone());
+            return;
+        }
+        self.rejected_watched_resources.insert(resource.clone());
+    }
+
+    fn record_successful_watched_ack(&mut self, signal: &XdsSignal) {
+        if let XdsSignal::Ack { resources } = signal {
+            self.remove_accepted_watched_resources(resources);
+        }
+    }
+
+    fn maybe_unblock_initial_sync(&mut self) {
+        if self.types_to_expect.is_empty()
+            && !self.has_outstanding_watched_rejections()
+            && let Some(block_ready) = self.block_ready.take()
+        {
+            block_ready.send_replace(());
+        }
+    }
+
+    fn demote_synced_on_watched_nack(
+        &mut self,
+        signal: &XdsSignal,
+        synced_on_this_stream: &mut bool,
+    ) {
+        if self.has_watched_resources(signal.rejected_resources()) && *synced_on_this_stream {
+            *synced_on_this_stream = false;
+            self.publish_connection_state(XdsConnectionStateKind::Connected);
+        }
+    }
+
     async fn run_loop(&mut self, backoff: Duration) -> Duration {
-        match self.run_internal().await {
+        // `reached_connected` is set inside `run_internal` once the gRPC stream
+        // is established. We must sample it AFTER `run_internal` returns and
+        // BEFORE we publish `Disconnected`, otherwise the watch we'd inspect
+        // already reflects the Disconnected we publish at the tail of the
+        // previous iteration.
+        self.reached_connected = false;
+        let result = self.run_internal().await;
+        let was_connected = self.reached_connected;
+        self.publish_connection_state(XdsConnectionStateKind::Disconnected);
+        // `xds_up` is cleared by `XdsUpGuard::drop` inside `run_internal`,
+        // which also covers task cancellation; do not duplicate the write here.
+        // Only start the disconnect timer if we were actually connected; otherwise
+        // initial-connect retries pollute the disconnect_duration histogram.
+        if was_connected && self.disconnect_start.is_none() {
+            self.disconnect_start = Some(tokio::time::Instant::now());
+        }
+        match result {
             Err(e @ Error::Connection(_, _)) => {
                 // For connection errors, we add backoff
                 let backoff = std::cmp::min(MAX_BACKOFF, backoff * 2);
@@ -546,52 +965,62 @@ impl AdsClient {
                 );
                 self.metrics
                     .increment(&ConnectionTerminationReason::ConnectionError);
+                #[cfg(test)]
+                self.wait_before_retry_sleep_for_test().await;
                 tokio::time::sleep(backoff).await;
                 backoff
             }
             Err(ref e @ Error::GrpcStatus(ref status)) => {
                 let err_detail = e.to_string();
-                let backoff = if status.code() == tonic::Code::Unknown
+                let is_transient = status.code() == tonic::Code::Unknown
                     || status.code() == tonic::Code::Cancelled
                     || status.code() == tonic::Code::DeadlineExceeded
                     || (status.code() == tonic::Code::Unavailable
                         && status.message().contains("transport is closing"))
                     || (status.code() == tonic::Code::Unavailable
-                        && status.message().contains("received prior goaway"))
-                {
+                        && status.message().contains("received prior goaway"));
+                let backoff = if is_transient {
+                    INITIAL_BACKOFF
+                } else {
+                    // For gRPC errors, we add backoff.
+                    std::cmp::min(MAX_BACKOFF, backoff * 2)
+                };
+                if is_transient {
                     debug!(
                         "XDS client terminated: {}, retrying in {:?}",
                         err_detail, backoff
                     );
                     self.metrics
                         .increment(&ConnectionTerminationReason::Reconnect);
-                    INITIAL_BACKOFF
                 } else {
                     warn!(
                         "XDS client error: {}, retrying in {:?}",
                         err_detail, backoff
                     );
                     self.metrics.increment(&ConnectionTerminationReason::Error);
-                    // For gRPC errors, we add backoff
-                    std::cmp::min(MAX_BACKOFF, backoff * 2)
-                };
+                }
+                #[cfg(test)]
+                self.wait_before_retry_sleep_for_test().await;
                 tokio::time::sleep(backoff).await;
                 backoff
             }
             Err(e) => {
-                // For other errors, we connect immediately
-                // TODO: we may need more nuance here; if we fail due to invalid initial request we may overload
-                // But we want to reconnect from MaxConnectionAge immediately.
-                warn!("XDS client error: {}, retrying", e);
+                let backoff = std::cmp::min(MAX_BACKOFF, backoff * 2);
+                warn!("XDS client error: {}, retrying in {:?}", e, backoff);
                 self.metrics.increment(&ConnectionTerminationReason::Error);
-                // Reset backoff
-                INITIAL_BACKOFF
+                #[cfg(test)]
+                self.wait_before_retry_sleep_for_test().await;
+                tokio::time::sleep(backoff).await;
+                backoff
             }
             Ok(_) => {
                 self.metrics
                     .increment(&ConnectionTerminationReason::Complete);
                 warn!("XDS client complete");
                 // Reset backoff
+                #[cfg(test)]
+                self.wait_before_retry_sleep_for_test().await;
+                tokio::time::sleep(INITIAL_BACKOFF).await;
                 INITIAL_BACKOFF
             }
         }
@@ -658,10 +1087,7 @@ impl AdsClient {
         let mut req = tonic::Request::new(outbound);
         self.config.xds_headers.iter().for_each(|(k, v)| {
             req.metadata_mut().insert(k.clone(), v.clone());
-
-            if let Ok(v_str) = v.to_str() {
-                debug!("XDS header added: {}={}", k, v_str);
-            }
+            debug!("XDS header added: {}={}", k, xds_header_value_for_log(v));
         });
 
         let ads_connection = AggregatedDiscoveryServiceClient::new(tls_grpc_channel)
@@ -675,6 +1101,22 @@ impl AdsClient {
         debug!("connected established");
 
         info!("Stream established");
+        let _xds_up_guard =
+            XdsUpGuard::connected(self.metrics.up.clone(), self.metrics.config_fresh.clone());
+        self.publish_connection_state(XdsConnectionStateKind::Connected);
+        self.reached_connected = true;
+        if let Some(start) = self.disconnect_start.take()
+            && let Some(disconnect_duration) = &self.metrics.disconnect_duration
+        {
+            disconnect_duration.observe(start.elapsed().as_secs_f64());
+        }
+        // Publish `Synced` once the current stream has a usable ACK and no
+        // watched type is currently rejected. A later watched-type NACK moves
+        // the stream back to `Connected` until that type ACKs successfully.
+        // This is stronger than raw transport reachability while avoiding a
+        // per-type re-ACK requirement that can keep freshness false for watched
+        // types that are empty or quiet after reconnect.
+        let mut synced_on_this_stream = false;
         loop {
             tokio::select! {
                 _demand_event = self.state.demand.recv() => {
@@ -690,25 +1132,48 @@ impl AdsClient {
                     if !self.types_to_expect.is_empty() {
                         received_type = Some(msg.type_url.clone())
                     }
-                    if let XdsSignal::Ack = self.handle_stream_event(msg, &discovery_req_tx).await?
-                        && let Some(received_type) = received_type {
-                            self.types_to_expect.remove(&received_type);
-                            if self.types_to_expect.is_empty() {
-                                mem::drop(mem::take(&mut self.block_ready));
+                    // NACK-only streams intentionally do not publish `Synced`: a control plane
+                    // that is reachable but only sending unusable config should not restore
+                    // freshness after reconnect.
+                    let handled = self.handle_response(msg);
+                    self.demote_synced_on_watched_nack(&handled.signal, &mut synced_on_this_stream);
+
+                    let signal = Self::send_response(handled, &discovery_req_tx).await?;
+                    match signal {
+                        XdsSignal::Ack { .. } => {
+                            self.record_successful_watched_ack(&signal);
+                            if let Some(received_type) = received_type {
+                                self.types_to_expect.remove(&received_type);
                             }
-                        };
+                            if !synced_on_this_stream
+                                && self.types_to_expect.is_empty()
+                                && !self.has_outstanding_watched_rejections()
+                            {
+                                synced_on_this_stream = true;
+                                self.publish_connection_state(XdsConnectionStateKind::Synced);
+                            }
+                            self.maybe_unblock_initial_sync();
+                        }
+                        XdsSignal::Nack { .. } => {}
+                        XdsSignal::AckIgnored => {}
+                    }
                 }
             }
         }
     }
 
-    async fn handle_stream_event(
-        &mut self,
-        response: DeltaDiscoveryResponse,
-        send: &mpsc::Sender<DeltaDiscoveryRequest>,
-    ) -> Result<XdsSignal, Error> {
+    fn handle_response(&mut self, response: DeltaDiscoveryResponse) -> HandledXdsResponse {
         let type_url = response.type_url.clone();
         let nonce = response.nonce.clone();
+        let type_url_key = strng::new(&type_url);
+        let response_resources = if self.should_collect_accepted_resources(&type_url_key) {
+            Some(Self::response_resource_keys(
+                &response,
+                type_url_key.clone(),
+            ))
+        } else {
+            None
+        };
         self.metrics.record(&response, ());
         debug!(
             type_url = type_url, // this is a borrow, it's OK
@@ -716,41 +1181,83 @@ impl AdsClient {
             removes = response.removed_resources.len(),
             "received response"
         );
-        let handler_response: Result<(), Vec<RejectedConfig>> =
-            match self.config.handlers.get(&strng::new(&type_url)) {
-                Some(h) => h.handle(&mut self.state, response),
-                None => {
-                    error!(%type_url, "unknown type");
-                    // TODO: this will just send another discovery request, to server. We should
-                    // either send one with an error or not send one at all.
-                    Ok(())
+        let (response_type, error) = match self.config.handlers.get(&type_url_key) {
+            Some(h) => match h.handle(&mut self.state, response) {
+                Err(rejects) => {
+                    let rejected: Vec<ResourceKey> = rejects
+                        .iter()
+                        .map(|reject| ResourceKey {
+                            name: reject.name.clone(),
+                            type_url: type_url_key.clone(),
+                        })
+                        .collect();
+                    let rejected_names: HashSet<Strng> = rejected
+                        .iter()
+                        .map(|resource| resource.name.clone())
+                        .collect();
+                    let accepted = response_resources
+                        .as_ref()
+                        .map(|resources| {
+                            resources
+                                .iter()
+                                .filter(|resource| !rejected_names.contains(&resource.name))
+                                .cloned()
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let error = rejects
+                        .into_iter()
+                        .map(|reject| reject.to_string())
+                        .collect::<Vec<String>>()
+                        .join("; ");
+                    (XdsSignal::Nack { rejected, accepted }, Some(error))
                 }
-            };
-
-        let (response_type, error) = match handler_response {
-            Err(rejects) => {
-                let error = rejects
-                    .into_iter()
-                    .map(|reject| reject.to_string())
-                    .collect::<Vec<String>>()
-                    .join("; ");
-                (XdsSignal::Nack, Some(error))
+                Ok(()) => (
+                    XdsSignal::Ack {
+                        resources: response_resources.unwrap_or_default(),
+                    },
+                    None,
+                ),
+            },
+            None => {
+                error!(%type_url, "unknown type");
+                (XdsSignal::AckIgnored, None)
             }
-            _ => (XdsSignal::Ack, None),
         };
 
-        match response_type {
-            XdsSignal::Nack => error!(
+        self.record_watched_rejections(&response_type);
+
+        HandledXdsResponse {
+            type_url,
+            nonce,
+            signal: response_type,
+            error,
+        }
+    }
+
+    async fn send_response(
+        handled: HandledXdsResponse,
+        send: &mpsc::Sender<DeltaDiscoveryRequest>,
+    ) -> Result<XdsSignal, Error> {
+        let HandledXdsResponse {
+            type_url,
+            nonce,
+            signal,
+            error,
+        } = handled;
+
+        match &signal {
+            XdsSignal::Nack { .. } => error!(
                 type_url=type_url,
                 nonce,
-                "type"=?response_type,
-                error=error,
+                "type"=%signal,
+                error=error.as_deref(),
                 "sending response",
             ),
             _ => debug!(
                 type_url=type_url,
                 nonce,
-                "type"=?response_type,
+                "type"=%signal,
                 "sending response",
             ),
         };
@@ -766,7 +1273,7 @@ impl AdsClient {
         })
         .await
         .map_err(|e| Error::RequestFailure(Box::new(e)))
-        .map(|_| response_type)
+        .map(|_| signal)
     }
 
     async fn handle_demand_event(
@@ -840,15 +1347,12 @@ pub enum AdsError {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::{IpAddr, Ipv4Addr},
-        time::SystemTime,
-    };
+    use std::net::{IpAddr, Ipv4Addr};
 
+    use futures_util::FutureExt;
     use prost::Message;
     use prost_types::Any;
     use textnonce::TextNonce;
-    use tokio::time::sleep;
 
     use crate::xds::ADDRESS_TYPE;
     use crate::xds::istio::security::Authorization as XdsAuthorization;
@@ -862,21 +1366,45 @@ mod tests {
     use crate::state::{DemandProxyState, workload};
     use crate::test_helpers::{
         helpers::{self},
-        test_default_workload,
-        xds::AdsServer,
+        test_config, test_default_workload,
+        xds::{AdsConnection, AdsServer},
     };
+    use crate::{app, identity};
 
     use super::*;
 
-    const POLL_RATE: Duration = Duration::from_millis(2);
-    const TEST_TIMEOUT: Duration = Duration::from_millis(100);
+    struct FailingCertProvider;
+
+    #[async_trait::async_trait]
+    impl tls::ControlPlaneClientCertProvider for FailingCertProvider {
+        async fn fetch_cert(
+            &self,
+            _alt_hostname: Option<String>,
+        ) -> Result<rustls::ClientConfig, tls::Error> {
+            Err(tls::Error::InvalidRootCert(
+                "test root certificate failure".to_string(),
+            ))
+        }
+    }
+
+    #[test]
+    fn test_xds_header_log_value_is_redacted() {
+        let value = AsciiMetadataValue::from_static("bearer-secret-token");
+
+        let rendered = xds_header_value_for_log(&value);
+
+        assert_eq!(rendered, "<redacted>");
+        assert!(
+            !rendered.contains("bearer-secret-token"),
+            "xDS header log value must not expose configured header contents"
+        );
+    }
 
     async fn verify_address(
         ip: IpAddr,
         expected_address: Option<XdsAddress>,
         source: &DemandProxyState,
     ) {
-        let start_time = SystemTime::now();
         let converted = match expected_address {
             Some(a) => match a.r#type {
                 Some(XdsType::Workload(w)) => Some(Workload::try_from(w).unwrap()),
@@ -885,17 +1413,41 @@ mod tests {
             },
             _ => None,
         };
-        // this is a borrow, Ok not to clone
-        let mut matched = false;
         let ip_network_addr = NetworkAddress {
             network: strng::EMPTY,
             address: ip,
         };
-        while start_time.elapsed().unwrap() < TEST_TIMEOUT && !matched {
-            sleep(POLL_RATE).await;
-            let wl = source.fetch_workload_by_address(&ip_network_addr);
-            matched = wl.await.as_deref() == converted.as_ref(); // Option<Workload> is Ok to compare without needing to unwrap
-        }
+        let observed = source.fetch_workload_by_address(&ip_network_addr).await;
+        assert!(
+            observed.as_deref() == converted.as_ref(),
+            "workload address mismatch for {ip}; expected {converted:?}, observed {observed:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "workload address mismatch")]
+    async fn test_verify_address_panics_on_mismatch() {
+        let (_conn_receiver, _client, state, _) = AdsServer::spawn(false).await;
+        verify_address(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            Some(XdsAddress {
+                r#type: Some(XdsType::Workload(XdsWorkload {
+                    name: "missing".to_string(),
+                    namespace: "default".to_string(),
+                    addresses: vec![Ipv4Addr::LOCALHOST.octets().to_vec().into()],
+                    tunnel_protocol: 0,
+                    trust_domain: "local".to_string(),
+                    service_account: "default".to_string(),
+                    node: "default".to_string(),
+                    workload_type: WorkloadType::Deployment.into(),
+                    workload_name: "".to_string(),
+                    native_tunnel: true,
+                    ..Default::default()
+                })),
+            }),
+            &state,
+        )
+        .await;
     }
 
     fn get_auth(i: usize) -> ProtoResource {
@@ -927,6 +1479,18 @@ mod tests {
             cache_control: None,
         }
     }
+
+    fn get_invalid_auth(i: usize) -> ProtoResource {
+        let mut resource = get_auth(i);
+        let auth = XdsAuthorization {
+            action: i32::MAX,
+            ..XdsAuthorization::decode(resource.resource.as_ref().unwrap().value.as_slice())
+                .expect("test auth resource must decode")
+        };
+        resource.resource.as_mut().unwrap().value = auth.encode_to_vec();
+        resource
+    }
+
     fn get_address(i: usize, addr: std::net::IpAddr) -> ProtoResource {
         let octets = match addr {
             IpAddr::V4(v4) => v4.octets().to_vec(),
@@ -962,6 +1526,845 @@ mod tests {
         }
     }
 
+    fn get_invalid_address(i: usize, addr: std::net::IpAddr) -> ProtoResource {
+        let mut resource = get_address(i, addr);
+        let mut address = XdsAddress::decode(resource.resource.as_ref().unwrap().value.as_slice())
+            .expect("test address resource must decode");
+        let Some(XdsType::Workload(workload)) = &mut address.r#type else {
+            panic!("test address resource must contain a workload")
+        };
+        workload.tunnel_protocol = i32::MAX;
+        resource.resource.as_mut().unwrap().value = address.encode_to_vec();
+        resource
+    }
+
+    fn test_resources_for_type(type_url: &str) -> Vec<ProtoResource> {
+        if type_url == &*ADDRESS_TYPE {
+            vec![get_address(0, "1.2.3.4".parse().unwrap())]
+        } else if type_url == &*AUTHORIZATION_TYPE {
+            vec![get_auth(0)]
+        } else {
+            panic!("unexpected request type {type_url}");
+        }
+    }
+
+    async fn send_test_response_with_nonce(conn: &mut AdsConnection, type_url: &str) -> String {
+        let nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: test_resources_for_type(type_url),
+            nonce: nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: type_url.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        nonce
+    }
+
+    async fn send_test_response(conn: &mut AdsConnection, type_url: &str) {
+        let _ = send_test_response_with_nonce(conn, type_url).await;
+    }
+
+    async fn recv_request_with_nonce(
+        conn: &mut AdsConnection,
+        nonce: &str,
+    ) -> DeltaDiscoveryRequest {
+        loop {
+            let req = tokio::time::timeout(Duration::from_secs(2), conn.recv_request())
+                .await
+                .unwrap_or_else(|_| panic!("timed out waiting for xDS request with nonce {nonce}"))
+                .expect("channel closed");
+            if req.response_nonce == nonce {
+                return req;
+            }
+        }
+    }
+
+    async fn recv_ads_connection(
+        conn_receiver: &mut tokio::sync::mpsc::Receiver<AdsConnection>,
+        reason: &str,
+    ) -> AdsConnection {
+        tokio::time::timeout(Duration::from_secs(2), conn_receiver.recv())
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for {reason}"))
+            .expect("ADS connection channel closed")
+    }
+
+    async fn prime_initial_sync(conn: &mut AdsConnection) {
+        let mut addr_sent = false;
+        let mut auth_sent = false;
+        while !(addr_sent && auth_sent) {
+            let req = tokio::time::timeout(Duration::from_secs(2), conn.recv_request())
+                .await
+                .expect("timed out waiting for initial xDS request")
+                .expect("channel closed");
+            if req.type_url.as_str() == &*ADDRESS_TYPE && !addr_sent {
+                send_test_response(conn, &ADDRESS_TYPE).await;
+                addr_sent = true;
+            } else if req.type_url.as_str() == &*AUTHORIZATION_TYPE && !auth_sent {
+                send_test_response(conn, &AUTHORIZATION_TYPE).await;
+                auth_sent = true;
+            }
+        }
+    }
+
+    async fn prime_initial_sync_after_request(
+        conn: &mut AdsConnection,
+        first_req: DeltaDiscoveryRequest,
+    ) {
+        let mut addr_sent = false;
+        let mut auth_sent = false;
+        send_initial_sync_response_for_request(conn, first_req, &mut addr_sent, &mut auth_sent)
+            .await;
+        while !(addr_sent && auth_sent) {
+            let req = tokio::time::timeout(Duration::from_secs(2), conn.recv_request())
+                .await
+                .expect("timed out waiting for initial xDS request")
+                .expect("channel closed");
+            send_initial_sync_response_for_request(conn, req, &mut addr_sent, &mut auth_sent).await;
+        }
+    }
+
+    async fn send_initial_sync_response_for_request(
+        conn: &mut AdsConnection,
+        req: DeltaDiscoveryRequest,
+        addr_sent: &mut bool,
+        auth_sent: &mut bool,
+    ) {
+        if req.type_url.as_str() == &*ADDRESS_TYPE && !*addr_sent {
+            send_test_response(conn, &ADDRESS_TYPE).await;
+            *addr_sent = true;
+        } else if req.type_url.as_str() == &*AUTHORIZATION_TYPE && !*auth_sent {
+            send_test_response(conn, &AUTHORIZATION_TYPE).await;
+            *auth_sent = true;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_watched_type_nack_suppresses_later_synced_until_same_type_acks() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+
+        let client_loop = tokio::spawn(async move {
+            let _next_backoff = client.run_loop(Duration::from_millis(250)).await;
+        });
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for Connected state")
+        .expect("sender dropped");
+
+        let rejected_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![get_invalid_auth(0)],
+            nonce: rejected_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let rejected_ack = recv_request_with_nonce(&mut conn, &rejected_nonce).await;
+        assert!(
+            rejected_ack.error_detail.is_some(),
+            "invalid authorization update should be NACKed"
+        );
+
+        let address_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![get_address(0, "1.2.3.4".parse().unwrap())],
+            nonce: address_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: ADDRESS_TYPE.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let address_ack = recv_request_with_nonce(&mut conn, &address_nonce).await;
+        assert!(
+            address_ack.error_detail.is_none(),
+            "valid address update should be ACKed"
+        );
+        assert_eq!(
+            conn_state_rx.borrow().kind(),
+            XdsConnectionStateKind::Connected,
+            "ACK for a different watched type must not publish Synced while authorization is rejected"
+        );
+
+        let unrelated_auth_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![get_auth(1)],
+            nonce: unrelated_auth_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let unrelated_auth_ack = recv_request_with_nonce(&mut conn, &unrelated_auth_nonce).await;
+        assert!(
+            unrelated_auth_ack.error_detail.is_none(),
+            "valid authorization update should be ACKed"
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(
+            conn_state_rx.borrow().kind(),
+            XdsConnectionStateKind::Connected,
+            "ACK for an unrelated authorization resource must not publish Synced while rejected authorization remains stale"
+        );
+
+        let remove_rejected_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![],
+            nonce: remove_rejected_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec!["foo0".to_string()],
+        }))
+        .await;
+        let remove_rejected_ack = recv_request_with_nonce(&mut conn, &remove_rejected_nonce).await;
+        assert!(
+            remove_rejected_ack.error_detail.is_none(),
+            "removal for rejected authorization should be ACKed"
+        );
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Synced),
+        )
+        .await
+        .expect("timed out waiting for Synced after rejected authorization removed")
+        .expect("sender dropped");
+
+        abort_ads_run_loop_for_test(client_loop).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_startup_ready_waits_for_rejected_watched_resource_to_clear() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, client, _state, mut block_rx) = AdsServer::spawn(false).await;
+        let client_task = spawn_ads_client_for_test(client);
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        let rejected_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![get_invalid_auth(0)],
+            nonce: rejected_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let rejected_ack = recv_request_with_nonce(&mut conn, &rejected_nonce).await;
+        assert!(
+            rejected_ack.error_detail.is_some(),
+            "invalid authorization update should be NACKed"
+        );
+
+        let address_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![get_address(0, "1.2.3.4".parse().unwrap())],
+            nonce: address_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: ADDRESS_TYPE.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let address_ack = recv_request_with_nonce(&mut conn, &address_nonce).await;
+        assert!(
+            address_ack.error_detail.is_none(),
+            "valid address update should be ACKed"
+        );
+        assert!(
+            !block_rx.has_changed().unwrap_or(true),
+            "startup readiness must remain blocked while any expected type is still unsynced"
+        );
+
+        let unrelated_auth_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![get_auth(1)],
+            nonce: unrelated_auth_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let unrelated_auth_ack = recv_request_with_nonce(&mut conn, &unrelated_auth_nonce).await;
+        assert!(
+            unrelated_auth_ack.error_detail.is_none(),
+            "valid authorization update should be ACKed"
+        );
+        assert!(
+            !block_rx.has_changed().unwrap_or(true),
+            "startup readiness must remain blocked while a watched NACK remains outstanding"
+        );
+
+        let remove_rejected_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![],
+            nonce: remove_rejected_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec!["foo0".to_string()],
+        }))
+        .await;
+        let remove_rejected_ack = recv_request_with_nonce(&mut conn, &remove_rejected_nonce).await;
+        assert!(
+            remove_rejected_ack.error_detail.is_none(),
+            "removal for rejected authorization should be ACKed"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), block_rx.changed())
+                .await
+                .expect("timed out waiting for startup readiness to unblock")
+                .is_ok(),
+            "startup readiness should unblock after the rejected watched resource is cleared"
+        );
+
+        abort_ads_client_for_test(client_task).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_startup_freshness_waits_for_all_initial_watched_types() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, mut client, _state, mut block_rx) = AdsServer::spawn(false).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+        let config_fresh = client
+            .metrics
+            .config_fresh
+            .as_ref()
+            .expect("remote xDS test client should export xds_config_fresh")
+            .clone();
+
+        let client_loop = tokio::spawn(async move {
+            let _next_backoff = client.run_loop(Duration::from_millis(250)).await;
+        });
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for Connected state")
+        .expect("sender dropped");
+
+        let first_req = tokio::time::timeout(Duration::from_secs(2), conn.recv_request())
+            .await
+            .expect("timed out waiting for first initial xDS request")
+            .expect("channel closed");
+        let first_type = first_req.type_url;
+        assert!(
+            first_type == *ADDRESS_TYPE || first_type == *AUTHORIZATION_TYPE,
+            "unexpected initial xDS request type: {first_type}"
+        );
+        let second_type = if first_type == *ADDRESS_TYPE {
+            AUTHORIZATION_TYPE.to_string()
+        } else {
+            ADDRESS_TYPE.to_string()
+        };
+
+        let first_nonce = send_test_response_with_nonce(&mut conn, &first_type).await;
+        let first_ack = recv_request_with_nonce(&mut conn, &first_nonce).await;
+        assert!(
+            first_ack.error_detail.is_none(),
+            "first initial watched type should be ACKed"
+        );
+
+        let probe_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![],
+            nonce: probe_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: "type.googleapis.com/unknown.Type".to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let probe_ack = recv_request_with_nonce(&mut conn, &probe_nonce).await;
+        assert!(
+            probe_ack.error_detail.is_none(),
+            "unknown xDS type probe should receive an ACK_IGNORED response"
+        );
+        assert_eq!(
+            conn_state_rx.borrow().kind(),
+            XdsConnectionStateKind::Connected,
+            "partial startup sync must remain Connected"
+        );
+        assert_eq!(
+            config_fresh.get(),
+            0,
+            "partial startup sync must not set xds_config_fresh"
+        );
+        assert!(
+            !block_rx.has_changed().unwrap_or(true),
+            "partial startup sync must not unblock readiness"
+        );
+
+        let second_nonce = send_test_response_with_nonce(&mut conn, &second_type).await;
+        let second_ack = recv_request_with_nonce(&mut conn, &second_nonce).await;
+        assert!(
+            second_ack.error_detail.is_none(),
+            "second initial watched type should be ACKed"
+        );
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Synced),
+        )
+        .await
+        .expect("timed out waiting for Synced after all initial watched types ACKed")
+        .expect("sender dropped");
+        assert_eq!(config_fresh.get(), 1);
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), block_rx.changed())
+                .await
+                .expect("timed out waiting for startup readiness to unblock")
+                .is_ok(),
+            "startup readiness should unblock after all initial watched types ACK"
+        );
+
+        abort_ads_run_loop_for_test(client_loop).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_watched_type_nack_survives_reconnect_until_same_type_acks() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, client, _state, _block) = AdsServer::spawn(false).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+        let client_task = spawn_ads_client_for_test(client);
+
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for Connected state")
+        .expect("sender dropped");
+
+        let rejected_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![get_invalid_auth(0)],
+            nonce: rejected_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let rejected_ack = recv_request_with_nonce(&mut conn, &rejected_nonce).await;
+        assert!(
+            rejected_ack.error_detail.is_some(),
+            "invalid authorization update should be NACKed"
+        );
+
+        conn.send_response(Err(tonic::Status::aborted("simulated disconnect")))
+            .await;
+
+        let mut reconnect = tokio::time::timeout(Duration::from_secs(2), conn_receiver.recv())
+            .await
+            .expect("timed out waiting for reconnect")
+            .expect("connection receiver closed");
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for reconnect Connected state")
+        .expect("sender dropped");
+
+        let address_nonce = TextNonce::new().to_string();
+        reconnect
+            .send_response(Ok(DeltaDiscoveryResponse {
+                resources: vec![get_address(0, "1.2.3.4".parse().unwrap())],
+                nonce: address_nonce.clone(),
+                system_version_info: "1.0.0".to_string(),
+                type_url: ADDRESS_TYPE.to_string(),
+                removed_resources: vec![],
+            }))
+            .await;
+        let address_ack = recv_request_with_nonce(&mut reconnect, &address_nonce).await;
+        assert!(
+            address_ack.error_detail.is_none(),
+            "valid address update should be ACKed"
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(
+            conn_state_rx.borrow().kind(),
+            XdsConnectionStateKind::Connected,
+            "ACK for a different watched type after reconnect must not publish Synced while authorization remains rejected"
+        );
+
+        let unrelated_auth_nonce = TextNonce::new().to_string();
+        reconnect
+            .send_response(Ok(DeltaDiscoveryResponse {
+                resources: vec![get_auth(1)],
+                nonce: unrelated_auth_nonce.clone(),
+                system_version_info: "1.0.0".to_string(),
+                type_url: AUTHORIZATION_TYPE.to_string(),
+                removed_resources: vec![],
+            }))
+            .await;
+        let unrelated_auth_ack =
+            recv_request_with_nonce(&mut reconnect, &unrelated_auth_nonce).await;
+        assert!(
+            unrelated_auth_ack.error_detail.is_none(),
+            "valid authorization update should be ACKed"
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(
+            conn_state_rx.borrow().kind(),
+            XdsConnectionStateKind::Connected,
+            "ACK for an unrelated authorization after reconnect must not publish Synced while rejected authorization remains stale"
+        );
+
+        let remove_rejected_nonce = TextNonce::new().to_string();
+        reconnect
+            .send_response(Ok(DeltaDiscoveryResponse {
+                resources: vec![],
+                nonce: remove_rejected_nonce.clone(),
+                system_version_info: "1.0.0".to_string(),
+                type_url: AUTHORIZATION_TYPE.to_string(),
+                removed_resources: vec!["foo0".to_string()],
+            }))
+            .await;
+        let remove_rejected_ack =
+            recv_request_with_nonce(&mut reconnect, &remove_rejected_nonce).await;
+        assert!(
+            remove_rejected_ack.error_detail.is_none(),
+            "removal for rejected authorization should be ACKed"
+        );
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Synced),
+        )
+        .await
+        .expect("timed out waiting for Synced after rejected authorization removed")
+        .expect("sender dropped");
+
+        abort_ads_client_for_test(client_task).await;
+    }
+
+    #[tokio::test]
+    async fn test_watched_type_nack_survives_failed_response_send() {
+        helpers::initialize_telemetry();
+
+        let (_conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let (closed_tx, closed_rx) = mpsc::channel(1);
+        drop(closed_rx);
+
+        let handled = client.handle_response(DeltaDiscoveryResponse {
+            resources: vec![get_invalid_auth(0)],
+            nonce: TextNonce::new().to_string(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec![],
+        });
+        let result = AdsClient::send_response(handled, &closed_tx).await;
+
+        assert!(
+            matches!(result, Err(Error::RequestFailure(_))),
+            "closed outbound request channel should fail the NACK send: {result:?}"
+        );
+        assert!(
+            client.rejected_watched_resources.contains(&ResourceKey {
+                name: "foo0".into(),
+                type_url: AUTHORIZATION_TYPE,
+            }),
+            "watched NACK should be retained even when the response send fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watched_ack_does_not_clear_rejection_when_response_send_fails() {
+        helpers::initialize_telemetry();
+
+        let (_conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+
+        let rejected = client.handle_response(DeltaDiscoveryResponse {
+            resources: vec![get_invalid_auth(0)],
+            nonce: TextNonce::new().to_string(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec![],
+        });
+        assert!(
+            matches!(rejected.signal, XdsSignal::Nack { .. }),
+            "invalid authorization update should classify as NACK"
+        );
+        assert!(
+            client.rejected_watched_resources.contains(&ResourceKey {
+                name: "foo0".into(),
+                type_url: AUTHORIZATION_TYPE,
+            }),
+            "watched NACK should be retained before the clearing ACK"
+        );
+
+        let clearing_ack = client.handle_response(DeltaDiscoveryResponse {
+            resources: vec![],
+            nonce: TextNonce::new().to_string(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec!["foo0".to_string()],
+        });
+        let (closed_tx, closed_rx) = mpsc::channel(1);
+        drop(closed_rx);
+        let result = AdsClient::send_response(clearing_ack, &closed_tx).await;
+
+        assert!(
+            matches!(result, Err(Error::RequestFailure(_))),
+            "closed outbound request channel should fail the clearing ACK send: {result:?}"
+        );
+        assert!(
+            client.rejected_watched_resources.contains(&ResourceKey {
+                name: "foo0".into(),
+                type_url: AUTHORIZATION_TYPE,
+            }),
+            "watched rejection must survive when its clearing ACK cannot be queued"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watched_type_nack_demotes_before_backpressured_response_send() {
+        helpers::initialize_telemetry();
+
+        let (_conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let conn_state_rx = client.connection_state_receiver();
+        client.publish_connection_state(XdsConnectionStateKind::Synced);
+        let mut synced_on_this_stream = true;
+
+        let (full_tx, _full_rx) = mpsc::channel(1);
+        full_tx
+            .send(DeltaDiscoveryRequest::default())
+            .await
+            .expect("test should fill outbound request channel");
+
+        let response = DeltaDiscoveryResponse {
+            resources: vec![get_invalid_auth(0)],
+            nonce: TextNonce::new().to_string(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec![],
+        };
+
+        let handled = client.handle_response(response);
+        assert!(
+            matches!(handled.signal, XdsSignal::Nack { .. }),
+            "invalid watched authorization update should classify as NACK"
+        );
+        assert!(
+            client.has_watched_resources(handled.signal.rejected_resources()),
+            "watched NACK must be visible before queueing the outbound NACK"
+        );
+        client.demote_synced_on_watched_nack(&handled.signal, &mut synced_on_this_stream);
+        assert!(
+            !synced_on_this_stream,
+            "watched NACK must clear the stream-local synced marker before the outbound NACK is queued"
+        );
+        assert_eq!(
+            conn_state_rx.borrow().kind(),
+            XdsConnectionStateKind::Connected,
+            "watched NACK must publish non-fresh state before the outbound NACK is queued"
+        );
+
+        assert!(
+            AdsClient::send_response(handled, &full_tx)
+                .now_or_never()
+                .is_none(),
+            "outbound request channel should remain backpressured"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watched_ack_skips_resource_collection_without_rejections() {
+        helpers::initialize_telemetry();
+
+        let (_conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let handled = client.handle_response(DeltaDiscoveryResponse {
+            resources: vec![get_auth(0)],
+            nonce: TextNonce::new().to_string(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: AUTHORIZATION_TYPE.to_string(),
+            removed_resources: vec!["foo-deleted".to_string()],
+        });
+
+        let XdsSignal::Ack { resources } = handled.signal else {
+            panic!("valid watched authorization update should classify as ACK");
+        };
+        assert!(
+            resources.is_empty(),
+            "ACK without rejected watched resources should not collect response resources"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watched_ack_collects_resources_only_for_rejected_type() {
+        helpers::initialize_telemetry();
+
+        let (_conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        client.rejected_watched_resources.insert(ResourceKey {
+            name: "foo0".into(),
+            type_url: AUTHORIZATION_TYPE,
+        });
+
+        assert!(
+            client.should_collect_accepted_resources(&AUTHORIZATION_TYPE),
+            "ACKs for the rejected watched type must collect accepted resources"
+        );
+        assert!(
+            !client.should_collect_accepted_resources(&ADDRESS_TYPE),
+            "ACKs for unrelated watched types must not collect accepted resources"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watched_rejections_are_bounded_and_remain_fail_closed_after_overflow() {
+        helpers::initialize_telemetry();
+
+        let (_conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let rejected = (0..=MAX_REJECTED_WATCHED_RESOURCES_PER_TYPE)
+            .map(|index| ResourceKey {
+                name: format!("foo{index}").into(),
+                type_url: AUTHORIZATION_TYPE,
+            })
+            .collect();
+        client.record_watched_rejections(&XdsSignal::Nack {
+            rejected,
+            accepted: Vec::new(),
+        });
+
+        assert!(
+            client.rejected_watched_resources.len() <= MAX_REJECTED_WATCHED_RESOURCES_PER_TYPE,
+            "watched rejection retention must be bounded"
+        );
+        assert!(
+            client.has_outstanding_watched_rejections(),
+            "overflowed watched rejections must still keep freshness fail-closed"
+        );
+        assert!(
+            !client.should_collect_accepted_resources(&AUTHORIZATION_TYPE),
+            "overflowed watched type discarded exact keys, so later ACKs cannot prove recovery"
+        );
+
+        client.record_successful_watched_ack(&XdsSignal::Ack {
+            resources: vec![ResourceKey {
+                name: "foo-recovered".into(),
+                type_url: AUTHORIZATION_TYPE,
+            }],
+        });
+
+        assert!(
+            client.has_outstanding_watched_rejections(),
+            "unrelated accepted resources cannot prove overflowed watched rejections recovered"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_duplicate_connection_state_preserves_original_transition_time() {
+        helpers::initialize_telemetry();
+
+        let (_conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let conn_state_rx = client.connection_state_receiver();
+
+        client.publish_connection_state(XdsConnectionStateKind::Synced);
+        client.publish_connection_state(XdsConnectionStateKind::Disconnected);
+        let first_disconnected_at = conn_state_rx.borrow().transitioned_at();
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        client.publish_connection_state(XdsConnectionStateKind::Disconnected);
+
+        assert_eq!(
+            conn_state_rx.borrow().transitioned_at(),
+            first_disconnected_at,
+            "duplicate same-epoch Disconnected publishes must not replace the outage start"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_on_demand_nack_demotes_synced_state() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, client, _state, _block) = AdsServer::spawn(true).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+        let client_task = spawn_ads_client_for_test(client);
+
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+        prime_initial_sync(&mut conn).await;
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Synced),
+        )
+        .await
+        .expect("timed out waiting for initial Synced state")
+        .expect("sender dropped");
+
+        let rejected_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![get_invalid_address(10, "10.0.0.10".parse().unwrap())],
+            nonce: rejected_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: ADDRESS_TYPE.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+        let rejected_ack = recv_request_with_nonce(&mut conn, &rejected_nonce).await;
+        assert!(
+            rejected_ack.error_detail.is_some(),
+            "invalid on-demand address update should be NACKed"
+        );
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            conn_state_rx.borrow().kind(),
+            XdsConnectionStateKind::Connected,
+            "on-demand address NACK must demote freshness"
+        );
+
+        abort_ads_client_for_test(client_task).await;
+    }
+
+    fn spawn_ads_client_for_test(client: AdsClient) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            match client.run().await {
+                Ok(()) => {}
+                Err(e) => {
+                    panic!("xDS client unexpectedly exited: {e}");
+                }
+            }
+        })
+    }
+
+    async fn abort_task_for_test<T>(task: tokio::task::JoinHandle<T>, task_name: &str) {
+        assert!(
+            !task.is_finished(),
+            "{task_name} task exited before test cleanup"
+        );
+        task.abort();
+        match task.await {
+            Err(err) if err.is_cancelled() => {}
+            Ok(_) => panic!("{task_name} task exited before cancellation"),
+            Err(err) if err.is_panic() => {
+                panic!("{task_name} task panicked before cancellation: {err:?}")
+            }
+            Err(err) => panic!("{task_name} task failed before cancellation: {err:?}"),
+        }
+    }
+
+    async fn abort_ads_client_for_test(client_task: tokio::task::JoinHandle<()>) {
+        abort_task_for_test(client_task, "xDS client").await;
+    }
+
+    async fn abort_ads_run_loop_for_test(client_task: tokio::task::JoinHandle<()>) {
+        abort_task_for_test(client_task, "xDS run loop").await;
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_that_caches_are_warm_before_unblocked() {
         helpers::initialize_telemetry();
@@ -969,13 +2372,9 @@ mod tests {
         // Setup fake xds server
         let (mut conn_receiver, client, state, mut block) = AdsServer::spawn(false).await;
 
-        tokio::spawn(async move {
-            if let Err(e) = client.run().await {
-                info!("workload manager: {}", e);
-            }
-        });
+        let client_task = spawn_ads_client_for_test(client);
 
-        let mut conn = conn_receiver.recv().await.unwrap();
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
 
         let mut auth_seen = false;
         let mut addr_seen = false;
@@ -1022,9 +2421,14 @@ mod tests {
                     // but allow port 81
                     let rbac_res = state.assert_rbac(&rbac_ctx).await;
                     assert!(rbac_res.is_ok());
-                    return;
-                }
-                req = conn.rx.recv() => {
+                    assert!(
+                        !client_task.is_finished(),
+                        "xDS client task exited before caches were verified"
+                    );
+                        abort_ads_client_for_test(client_task).await;
+                        return;
+                    }
+                req = conn.recv_request() => {
                     req.unwrap()
                 }
             };
@@ -1038,7 +2442,7 @@ mod tests {
                     type_url: AUTHORIZATION_TYPE.to_string(),
                     removed_resources: vec![],
                 });
-                conn.tx.send(response).await.unwrap();
+                conn.send_response(response).await;
                 auth_seen = true;
             } else if req.type_url == ADDRESS_TYPE && !addr_seen {
                 let response = Ok(DeltaDiscoveryResponse {
@@ -1048,7 +2452,7 @@ mod tests {
                     type_url: ADDRESS_TYPE.to_string(),
                     removed_resources: vec![],
                 });
-                conn.tx.send(response).await.unwrap();
+                conn.send_response(response).await;
                 addr_seen = true;
             }
         }
@@ -1061,13 +2465,9 @@ mod tests {
         // Setup fake xds server
         let (mut conn_receiver, client, _, _) = AdsServer::spawn(true).await;
 
-        tokio::spawn(async move {
-            if let Err(e) = client.run().await {
-                info!("workload manager: {}", e);
-            }
-        });
+        let client_task = spawn_ads_client_for_test(client);
 
-        let mut conn = conn_receiver.recv().await.unwrap();
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
 
         let mut auth_seen = false;
         let mut addr_seen = false;
@@ -1080,7 +2480,7 @@ mod tests {
                 _ = &mut timer => {
                     panic!("expected requests were not received");
                 }
-                req = conn.rx.recv() => {
+                req = conn.recv_request() => {
                     req.unwrap()
                 }
             };
@@ -1097,6 +2497,11 @@ mod tests {
             }
 
             if auth_seen && addr_seen {
+                assert!(
+                    !client_task.is_finished(),
+                    "xDS client task exited before on-demand requests were verified"
+                );
+                abort_ads_client_for_test(client_task).await;
                 return;
             }
         }
@@ -1192,14 +2597,10 @@ mod tests {
 
         let demander = client.demander().unwrap();
 
-        tokio::spawn(async move {
-            if let Err(e) = client.run().await {
-                info!("workload manager: {}", e);
-            }
-        });
+        let client_task = spawn_ads_client_for_test(client);
         let result = demander.demand(ADDRESS_TYPE, "foo0".into()).await;
 
-        let mut conn = conn_receiver.recv().await.unwrap();
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
 
         let timer = tokio::time::sleep(std::time::Duration::from_secs(5));
         futures::pin_mut!(timer);
@@ -1209,7 +2610,7 @@ mod tests {
                 _ = &mut timer => {
                     panic!("expected requests were not received");
                 }
-                req = conn.rx.recv() => {
+                req = conn.recv_request() => {
                     req.unwrap()
                 }
             };
@@ -1234,7 +2635,7 @@ mod tests {
                     removed_resources: vec![],
                 });
 
-                tokio::spawn(async move { conn.tx.send(response).await });
+                conn.send_response(response).await;
 
                 // wait for on demand to be notified. this means that the cache was updated with
                 // our resource if it exists (and in our case we know it exists).
@@ -1250,6 +2651,11 @@ mod tests {
                         None,
                     )
                     .expect("demander return but resource not in cache");
+                assert!(
+                    !client_task.is_finished(),
+                    "xDS client task exited before on-demand cache coherency was verified"
+                );
+                abort_ads_client_for_test(client_task).await;
                 return;
             }
         }
@@ -1261,9 +2667,11 @@ mod tests {
 
         // TODO: Load this from a file?
         let ip: Ipv4Addr = "127.0.0.1".parse().unwrap();
+        let workload_uid = "default/1.1.1.1".to_string();
         let mut resources = vec![];
         let addresses = vec![XdsAddress {
             r#type: Some(XdsType::Workload(XdsWorkload {
+                uid: workload_uid.clone(),
                 name: "1.1.1.1".to_string(),
                 namespace: "default".to_string(),
                 addresses: vec![ip.octets().to_vec().into()],
@@ -1280,7 +2688,7 @@ mod tests {
         for addr in addresses.clone().iter() {
             match &addr.r#type {
                 Some(XdsType::Workload(w)) => resources.push(ProtoResource {
-                    name: w.name.clone(),
+                    name: w.uid.clone(),
                     aliases: vec![],
                     version: "0.0.1".to_string(),
                     resource: Some(Any {
@@ -1295,9 +2703,10 @@ mod tests {
             }
         }
 
+        let initial_nonce = TextNonce::new().to_string();
         let initial_response = Ok(DeltaDiscoveryResponse {
             resources,
-            nonce: TextNonce::new().to_string(),
+            nonce: initial_nonce.clone(),
             system_version_info: "1.0.0".to_string(),
             type_url: ADDRESS_TYPE.to_string(),
             removed_resources: vec![],
@@ -1305,47 +2714,39 @@ mod tests {
 
         let abort_response = Err(tonic::Status::aborted("Aborting for test."));
 
+        let remove_nonce = TextNonce::new().to_string();
         let removed_resource_response: Result<DeltaDiscoveryResponse, tonic::Status> =
             Ok(DeltaDiscoveryResponse {
                 resources: vec![],
-                nonce: TextNonce::new().to_string(),
+                nonce: remove_nonce.clone(),
                 system_version_info: "1.0.0".to_string(),
                 type_url: ADDRESS_TYPE.to_string(),
-                removed_resources: vec!["127.0.0.1".into()],
+                removed_resources: vec![workload_uid],
             });
 
         // Setup fake xds server
         let (mut conn_receiver, client, state, _) = AdsServer::spawn(false).await;
 
-        tokio::spawn(async move {
-            if let Err(e) = client.run().await {
-                info!("workload manager: {}", e);
-            }
-        });
+        let client_task = spawn_ads_client_for_test(client);
 
-        let conn = conn_receiver.recv().await.unwrap();
+        let mut conn = recv_ads_connection(&mut conn_receiver, "first ADS connection").await;
 
-        conn.tx
-            .send(initial_response)
-            .await
-            .expect("failed to send server response");
-        sleep(Duration::from_millis(50)).await;
+        conn.send_response(initial_response).await;
+        recv_request_with_nonce(&mut conn, &initial_nonce).await;
         verify_address(IpAddr::V4(ip), Some(addresses[0].clone()), &state).await;
-        conn.tx
-            .send(abort_response)
-            .await
-            .expect("failed to send server response");
-        sleep(Duration::from_millis(50)).await;
+        conn.send_response(abort_response).await;
         verify_address(IpAddr::V4(ip), Some(addresses[0].clone()), &state).await;
 
         // original connection should close and client re-connect
-        let conn = conn_receiver.recv().await.unwrap();
-        conn.tx
-            .send(removed_resource_response)
-            .await
-            .expect("failed to send server response");
-        sleep(Duration::from_millis(50)).await;
+        let mut conn = recv_ads_connection(&mut conn_receiver, "second ADS connection").await;
+        conn.send_response(removed_resource_response).await;
+        recv_request_with_nonce(&mut conn, &remove_nonce).await;
         verify_address(IpAddr::V4(ip), None, &state).await;
+        assert!(
+            !client_task.is_finished(),
+            "xDS client task exited before add/abort/remove verification completed"
+        );
+        abort_ads_client_for_test(client_task).await;
     }
 
     #[test]
@@ -1403,5 +2804,662 @@ mod tests {
         // JSON null
         v = serde_json::json!(());
         assert_eq!(Config::json_to_value(v).kind.unwrap(), NullValue(0));
+    }
+
+    /// Verifies that the xDS connection state signal correctly transitions:
+    /// Initializing -> Connected (on stream established) -> Disconnected (on error/abort)
+    /// -> Connected (on reconnect).
+    ///
+    /// This is the foundation for xDS freshness metrics: app.rs watches this
+    /// signal and records sustained non-fresh periods after startup.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_xds_connection_state_signals() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+
+        assert_eq!(*conn_state_rx.borrow(), XdsConnectionState::initializing());
+
+        // Run a single loop iteration first so the test can observe
+        // `Disconnected` without racing the client's next reconnect attempt.
+        let first_loop = tokio::spawn(async move {
+            let next_backoff = client.run_loop(Duration::from_millis(250)).await;
+            (client, next_backoff)
+        });
+
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for Connected state")
+        .expect("sender dropped");
+
+        assert_eq!(*conn_state_rx.borrow(), XdsConnectionState::connected(0));
+
+        conn.send_response(Err(tonic::Status::aborted("simulated disconnect")))
+            .await;
+
+        wait_for_xds_state(
+            &mut conn_state_rx,
+            |s| s.kind() == XdsConnectionStateKind::Disconnected,
+            "Disconnected state after simulated disconnect",
+        )
+        .await;
+
+        assert_eq!(*conn_state_rx.borrow(), XdsConnectionState::disconnected(0));
+        let (client, backoff) = first_loop.await.expect("first xDS run loop panicked");
+        assert_eq!(*conn_state_rx.borrow(), XdsConnectionState::disconnected(0));
+
+        let second_loop = tokio::spawn(async move {
+            let mut client = client;
+            let _next_backoff = client.run_loop(backoff).await;
+        });
+        let mut conn2 = recv_ads_connection(&mut conn_receiver, "reconnected ADS connection").await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for re-Connected state")
+        .expect("sender dropped");
+
+        assert_eq!(*conn_state_rx.borrow(), XdsConnectionState::connected(0));
+
+        prime_initial_sync(&mut conn2).await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Synced),
+        )
+        .await
+        .expect("timed out waiting for Synced state after reconnect ACK")
+        .expect("sender dropped");
+        assert_eq!(*conn_state_rx.borrow(), XdsConnectionState::synced(1));
+
+        abort_ads_run_loop_for_test(second_loop).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_xds_up_cleared_when_run_loop_task_is_cancelled() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+        let up = client
+            .metrics
+            .up
+            .as_ref()
+            .expect("remote xDS test client should export xds_up")
+            .clone();
+
+        assert_eq!(up.get(), 0);
+
+        let client_loop = tokio::spawn(async move {
+            let _next_backoff = client.run_loop(Duration::from_millis(250)).await;
+        });
+        let _conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for Connected state")
+        .expect("sender dropped");
+
+        assert_eq!(up.get(), 1);
+
+        abort_ads_run_loop_for_test(client_loop).await;
+        assert_eq!(
+            up.get(),
+            0,
+            "xDS stream gauge must clear when the connected client task is cancelled"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_xds_up_set_before_connected_state_is_published() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let up_at_connected = client.capture_up_gauge_when_connected_published_for_test();
+
+        let client_loop = tokio::spawn(async move {
+            let _next_backoff = client.run_loop(Duration::from_millis(250)).await;
+        });
+        let _conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        let up_at_connected = tokio::time::timeout(Duration::from_secs(2), up_at_connected)
+            .await
+            .expect("timed out waiting for Connected state publish")
+            .expect("Connected state publish hook dropped");
+        assert_eq!(
+            up_at_connected,
+            Some(1),
+            "xDS stream gauge must be raised before publishing Connected state"
+        );
+
+        abort_ads_run_loop_for_test(client_loop).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_xds_config_fresh_cleared_when_run_loop_task_is_cancelled() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+        let config_fresh = client
+            .metrics
+            .config_fresh
+            .as_ref()
+            .expect("remote xDS test client should export xds_config_fresh")
+            .clone();
+
+        assert_eq!(config_fresh.get(), 0);
+
+        let client_loop = tokio::spawn(async move {
+            let _next_backoff = client.run_loop(Duration::from_millis(250)).await;
+        });
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        prime_initial_sync(&mut conn).await;
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Synced),
+        )
+        .await
+        .expect("timed out waiting for Synced state")
+        .expect("sender dropped");
+
+        assert_eq!(config_fresh.get(), 1);
+
+        abort_ads_run_loop_for_test(client_loop).await;
+        assert_eq!(
+            config_fresh.get(),
+            0,
+            "xDS freshness gauge must clear when the synced client task is cancelled"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_tls_setup_error_sleeps_before_retrying() {
+        helpers::initialize_telemetry();
+
+        let (_conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        client.config.tls_builder = Box::new(FailingCertProvider);
+
+        let retry = tokio::spawn(async move { client.run_loop(Duration::from_millis(250)).await });
+        tokio::task::yield_now().await;
+
+        assert!(
+            !retry.is_finished(),
+            "TLS setup failure returned before any retry delay elapsed"
+        );
+
+        tokio::time::advance(Duration::from_millis(500)).await;
+        let next_backoff = tokio::time::timeout(Duration::from_secs(1), retry)
+            .await
+            .expect("TLS setup failure did not return after retry delay")
+            .expect("retry task panicked");
+
+        assert_eq!(next_backoff, Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn test_clean_stream_completion_sleeps_before_retrying() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+        let (retry_sleep_started, allow_retry_sleep) =
+            client.pause_before_next_retry_sleep_for_test();
+
+        let retry = tokio::spawn(async move { client.run_loop(Duration::from_millis(250)).await });
+        let conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for Connected state")
+        .expect("sender dropped");
+
+        drop(conn);
+
+        tokio::time::timeout(Duration::from_secs(2), retry_sleep_started)
+            .await
+            .expect("timed out waiting for retry sleep to start")
+            .expect("retry sleep gate dropped before clean stream completion");
+        assert_eq!(
+            conn_state_rx.borrow().kind(),
+            XdsConnectionStateKind::Disconnected,
+            "clean stream completion must publish Disconnected before retry sleep"
+        );
+        tokio::time::pause();
+        tokio::task::yield_now().await;
+
+        assert!(
+            !retry.is_finished(),
+            "clean ADS stream completion returned before any retry delay elapsed"
+        );
+
+        allow_retry_sleep
+            .send(())
+            .expect("retry sleep task exited before test released it");
+        tokio::task::yield_now().await;
+        assert!(
+            !retry.is_finished(),
+            "clean ADS stream completion returned before virtual retry delay elapsed"
+        );
+
+        tokio::time::advance(INITIAL_BACKOFF + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            retry.is_finished(),
+            "clean ADS stream completion did not return after retry delay elapsed"
+        );
+        let next_backoff = retry.await.expect("retry task panicked");
+
+        assert_eq!(next_backoff, INITIAL_BACKOFF);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_unknown_xds_type_does_not_publish_synced() {
+        helpers::initialize_telemetry();
+
+        let (mut conn_receiver, mut client, _state, _block) = AdsServer::spawn(false).await;
+        let mut conn_state_rx = client.connection_state_receiver();
+
+        let client_loop = tokio::spawn(async move {
+            let _next_backoff = client.run_loop(Duration::from_millis(250)).await;
+        });
+        let mut conn = recv_ads_connection(&mut conn_receiver, "initial ADS connection").await;
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state_rx.wait_for(|s| s.kind() == XdsConnectionStateKind::Connected),
+        )
+        .await
+        .expect("timed out waiting for Connected state")
+        .expect("sender dropped");
+
+        let unknown_nonce = TextNonce::new().to_string();
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![],
+            nonce: unknown_nonce.clone(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: "type.googleapis.com/unknown.Type".to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+
+        let ack = recv_request_with_nonce(&mut conn, &unknown_nonce).await;
+        assert!(
+            ack.error_detail.is_none(),
+            "unknown xDS type should receive an ACK_IGNORED response"
+        );
+
+        abort_ads_run_loop_for_test(client_loop).await;
+        assert_eq!(
+            *conn_state_rx.borrow(),
+            XdsConnectionState::connected(0),
+            "unknown xDS type must not publish Synced after the response is processed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_app_reports_freshness_without_rearming_readiness_after_disconnect() {
+        helpers::initialize_telemetry();
+        let (mut conn_receiver, cfg) = AdsServer::spawn_app_server().await;
+
+        let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let app = app::build_with_cert(Arc::new(cfg), cert_manager)
+            .await
+            .unwrap();
+        let shutdown = app.shutdown.trigger().clone();
+        let readiness_address = app.readiness_address;
+        let metrics_address = app.metrics_address;
+        let mut xds_connection_state = app
+            .xds_connection_state
+            .clone()
+            .expect("remote xDS app should expose connection state");
+        let mut xds_startup = app.xds_startup.clone();
+        let app_task = tokio::spawn(app.wait_termination());
+
+        let mut conn = tokio::time::timeout(Duration::from_secs(2), conn_receiver.recv())
+            .await
+            .expect("timed out waiting for initial app xDS connection")
+            .expect("channel closed");
+
+        prime_initial_sync(&mut conn).await;
+        wait_for_startup_sync(&mut xds_startup).await;
+        wait_for_xds_state(
+            &mut xds_connection_state,
+            |s| s.kind() == XdsConnectionStateKind::Synced,
+            "initial app xDS sync",
+        )
+        .await;
+        wait_for_readiness(readiness_address, true, "initial app readiness").await;
+        wait_for_metric(
+            metrics_address,
+            "initial xDS freshness duration metric",
+            |metrics| {
+                metric_value_u64(metrics, "istio_xds_config_fresh ") == Some(1)
+                    && metric_value_u64(
+                        metrics,
+                        "istio_xds_config_non_fresh_duration_seconds_count ",
+                    )
+                    .unwrap_or_default()
+                        >= 1
+            },
+        )
+        .await;
+        let initial_duration_count = metric_value_u64(
+            &metrics_request(metrics_address).await,
+            "istio_xds_config_non_fresh_duration_seconds_count ",
+        )
+        .unwrap_or_default();
+        let synced_epoch = xds_connection_state.borrow().freshness_epoch();
+
+        conn.send_response(Err(tonic::Status::aborted("simulated disconnect")))
+            .await;
+
+        let mut reconnect = tokio::time::timeout(Duration::from_secs(2), conn_receiver.recv())
+            .await
+            .expect("timed out waiting for reconnect")
+            .expect("channel closed");
+        let first_reconnect_req =
+            tokio::time::timeout(Duration::from_secs(2), reconnect.recv_request())
+                .await
+                .expect("timed out waiting for reconnect's first xDS request")
+                .expect("channel closed before reconnect's first xDS request");
+        readiness_request(readiness_address)
+            .await
+            .expect("xDS freshness metrics must not re-arm readiness");
+        wait_for_metric(metrics_address, "xDS non-fresh metric", |metrics| {
+            metrics.lines().any(|l| l == "istio_xds_config_fresh 0")
+        })
+        .await;
+
+        let metrics = metrics_request(metrics_address).await;
+        assert!(
+            metrics.lines().any(|l| l == "istio_xds_config_fresh 0"),
+            "freshness gauge should reflect the unACKed reconnect:\n{metrics}"
+        );
+        assert!(
+            !metrics.contains("istio_xds_config_non_fresh_over_threshold"),
+            "ztunnel should not export a built-in xDS non-fresh threshold gauge:\n{metrics}"
+        );
+        assert!(
+            !metrics.contains("istio_xds_config_non_fresh_threshold_exceeded"),
+            "ztunnel should not export a built-in xDS non-fresh threshold counter:\n{metrics}"
+        );
+
+        prime_initial_sync_after_request(&mut reconnect, first_reconnect_req).await;
+        wait_for_xds_state(
+            &mut xds_connection_state,
+            |s| s.kind() == XdsConnectionStateKind::Synced && s.freshness_epoch() != synced_epoch,
+            "post-reconnect xDS ACK",
+        )
+        .await;
+        wait_for_metric(
+            metrics_address,
+            "xDS freshness duration metric",
+            |metrics| {
+                metric_value_u64(metrics, "istio_xds_config_fresh ") == Some(1)
+                    && metric_value_u64(
+                        metrics,
+                        "istio_xds_config_non_fresh_duration_seconds_count ",
+                    )
+                    .unwrap_or_default()
+                        > initial_duration_count
+            },
+        )
+        .await;
+
+        shutdown.shutdown_now().await;
+        app_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_app_without_remote_xds_does_not_export_remote_stream_metrics() {
+        helpers::initialize_telemetry();
+        let cfg = test_config();
+
+        let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let app = app::build_with_cert(Arc::new(cfg), cert_manager)
+            .await
+            .unwrap();
+        let shutdown = app.shutdown.trigger().clone();
+        let metrics_address = app.metrics_address;
+        let app_task = tokio::spawn(app.wait_termination());
+
+        let metrics = metrics_request(metrics_address).await;
+
+        shutdown.shutdown_now().await;
+        app_task.await.unwrap().unwrap();
+
+        assert!(
+            !metrics.lines().any(|l| l.starts_with("istio_xds_up ")),
+            "no-remote xDS config must not export a disconnected xDS stream gauge:\n{metrics}"
+        );
+        assert!(
+            !metrics
+                .lines()
+                .any(|l| l.starts_with("istio_xds_config_fresh ")),
+            "no-remote xDS config must not export xDS freshness stream gauge:\n{metrics}"
+        );
+        assert!(
+            !metrics.contains("istio_xds_disconnect_duration_seconds"),
+            "no-remote xDS config must not export remote xDS disconnect histogram:\n{metrics}"
+        );
+        assert!(
+            !metrics
+                .lines()
+                .any(|l| l.starts_with("istio_xds_config_non_fresh_over_threshold ")),
+            "no-remote xDS config must not export xDS non-fresh threshold gauge:\n{metrics}"
+        );
+        assert!(
+            !metrics
+                .lines()
+                .any(|l| l.starts_with("istio_xds_config_non_fresh_threshold_exceeded_total ")),
+            "no-remote xDS config must not export xDS non-fresh threshold counter:\n{metrics}"
+        );
+        assert!(
+            !metrics.contains("istio_xds_config_non_fresh_duration_seconds"),
+            "no-remote xDS config must not export xDS non-fresh duration histogram:\n{metrics}"
+        );
+        assert!(
+            !metrics
+                .lines()
+                .any(|l| l.starts_with("istio_xds_monitor_sender_dropped_total ")),
+            "no-remote xDS config must not export xDS monitor sender-drop counter:\n{metrics}"
+        );
+        assert!(
+            !metrics
+                .lines()
+                .any(|l| l.starts_with("istio_xds_monitor_events_lagged_total ")),
+            "no-remote xDS config must not export xDS monitor lag counter:\n{metrics}"
+        );
+    }
+
+    /// Regression test for the bug where `was_connected` was sampled from the
+    /// connection-state watch BEFORE `run_internal()` ran, which on every
+    /// iteration after the first read back `Disconnected` (just published at
+    /// the tail of the previous iteration) and so never started the
+    /// `disconnect_start` timer. The result was that
+    /// `xds_disconnect_duration_seconds` never received any observations.
+    /// Asserts the histogram count goes above zero after one full
+    /// connect → disconnect → reconnect cycle.
+    #[tokio::test]
+    async fn test_disconnect_duration_histogram_observed_after_reconnect() {
+        helpers::initialize_telemetry();
+        let (mut conn_receiver, cfg) = AdsServer::spawn_app_server().await;
+
+        let cert_manager = identity::mock::new_secret_manager(Duration::from_secs(10));
+        let app = app::build_with_cert(Arc::new(cfg), cert_manager)
+            .await
+            .unwrap();
+        let shutdown = app.shutdown.trigger().clone();
+        let metrics_address = app.metrics_address;
+        let app_task = tokio::spawn(app.wait_termination());
+
+        // First connection: drive an ACK so we transition Initializing →
+        // Connected → Synced. Without an ACK on this stream, `reached_connected`
+        // would still be set (it flips on stream establishment), but driving a
+        // real ACK matches production behavior more closely.
+        let mut conn = tokio::time::timeout(Duration::from_secs(2), conn_receiver.recv())
+            .await
+            .expect("timed out waiting for initial xDS connection")
+            .expect("channel closed");
+
+        prime_initial_sync(&mut conn).await;
+
+        // Force a disconnect, then accept (and immediately reject) a few
+        // reconnect attempts to give the server-side drop a chance to flow
+        // through `run_loop` and observe a sample on the histogram.
+        conn.send_response(Err(tonic::Status::aborted("simulated disconnect")))
+            .await;
+
+        // Accept and immediately allow one full reconnect; the sample is
+        // recorded at the start of the NEW stream (`disconnect_start.take()`),
+        // so we need at least one successful re-establishment for the count
+        // to advance.
+        let mut conn2 = tokio::time::timeout(Duration::from_secs(5), conn_receiver.recv())
+            .await
+            .expect("timed out waiting for reconnect")
+            .expect("channel closed");
+        // Drain one request to keep the stream alive long enough for the
+        // sample to flush before we tear down.
+        tokio::time::timeout(Duration::from_secs(2), conn2.recv_request())
+            .await
+            .expect("timed out waiting for reconnect's first xDS request")
+            .expect("channel closed before reconnect's first xDS request");
+
+        // Read /metrics until the histogram count becomes non-zero. The full metric name
+        // includes the istio_ prefix and the _seconds_count suffix.
+        wait_for_metric(
+            metrics_address,
+            "disconnect duration histogram count",
+            |metrics| {
+                metrics
+                    .lines()
+                    .find(|l| l.starts_with("istio_xds_disconnect_duration_seconds_count "))
+                    .and_then(|line| {
+                        line.strip_prefix("istio_xds_disconnect_duration_seconds_count ")
+                    })
+                    .and_then(|rest| rest.trim().parse::<u64>().ok())
+                    .is_some_and(|n| n > 0)
+            },
+        )
+        .await;
+
+        shutdown.shutdown_now().await;
+        app_task.await.unwrap().unwrap();
+    }
+
+    async fn wait_for_startup_sync(xds_startup: &mut tokio::sync::watch::Receiver<()>) {
+        tokio::time::timeout(Duration::from_secs(2), xds_startup.changed())
+            .await
+            .expect("timed out waiting for app startup xDS sync")
+            .expect("xDS startup sender dropped");
+    }
+
+    async fn wait_for_xds_state(
+        conn_state: &mut tokio::sync::watch::Receiver<XdsConnectionState>,
+        mut predicate: impl FnMut(XdsConnectionState) -> bool,
+        reason: &str,
+    ) {
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            conn_state.wait_for(|s| predicate(*s)),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {reason}"))
+        .expect("xDS connection state sender dropped");
+    }
+
+    async fn wait_for_readiness(addr: std::net::SocketAddr, ready: bool, reason: &str) {
+        let mut last_result = None;
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let result = readiness_request(addr).await;
+                let matches = result.is_ok() == ready;
+                last_result = Some(format!("{result:?}"));
+                if matches {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("timed out waiting for {reason}; last readiness result: {last_result:?}")
+        });
+    }
+
+    async fn wait_for_metric(
+        addr: std::net::SocketAddr,
+        reason: &str,
+        mut predicate: impl FnMut(&str) -> bool,
+    ) {
+        let mut last_metrics = String::new();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                last_metrics = metrics_request(addr).await;
+                if predicate(&last_metrics) {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("timed out waiting for {reason}; last metrics:\n{last_metrics}")
+        });
+    }
+
+    fn metric_value_u64(metrics: &str, line_prefix: &str) -> Option<u64> {
+        metrics
+            .lines()
+            .find(|line| line.starts_with(line_prefix))
+            .and_then(|line| line.strip_prefix(line_prefix))
+            .and_then(|value| value.trim().parse::<u64>().ok())
+    }
+
+    async fn readiness_request(addr: std::net::SocketAddr) -> anyhow::Result<()> {
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(format!("http://localhost:{}/healthz/ready", addr.port()))
+            .body(http_body_util::Empty::<bytes::Bytes>::new())
+            .unwrap();
+        let client = crate::hyper_util::pooling_client();
+        let resp = client.request(req).await?;
+        if resp.status() == http::StatusCode::OK {
+            Ok(())
+        } else {
+            anyhow::bail!("readiness status {}", resp.status())
+        }
+    }
+
+    async fn metrics_request(addr: std::net::SocketAddr) -> String {
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(format!("http://{addr}/metrics"))
+            .body(http_body_util::Empty::<bytes::Bytes>::new())
+            .unwrap();
+        let client = crate::hyper_util::pooling_client();
+        let body = client.request(req).await.unwrap().into_body();
+        let body = http_body_util::BodyExt::collect(body)
+            .await
+            .unwrap()
+            .to_bytes();
+        String::from_utf8(body.to_vec()).unwrap()
     }
 }

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -2524,7 +2524,7 @@ mod tests {
 
         // The initial connection claims no retained resources.
         for _ in 0..2 {
-            let req = conn.rx.recv().await.unwrap();
+            let req = conn.recv_request().await.unwrap();
             assert!(req.initial_resource_versions.is_empty());
         }
 
@@ -2548,9 +2548,9 @@ mod tests {
             type_url: ADDRESS_TYPE.to_string(),
             removed_resources: vec![],
         });
-        conn.tx.send(response).await.unwrap();
+        conn.send_response(response).await;
 
-        let nack = conn.rx.recv().await.unwrap();
+        let nack = conn.recv_request().await.unwrap();
         assert_eq!(nack.type_url, ADDRESS_TYPE.to_string());
         assert!(nack.error_detail.is_some());
 
@@ -2569,7 +2569,7 @@ mod tests {
                 _ = &mut timer => {
                     panic!("expected requests were not received");
                 }
-                req = conn.rx.recv() => {
+                req = conn.recv_request() => {
                     req.unwrap()
                 }
             };

--- a/src/xds/freshness_monitor.rs
+++ b/src/xds/freshness_monitor.rs
@@ -1,0 +1,952 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::broadcast;
+use tracing::{error, info, warn};
+
+use crate::readiness;
+
+use super::{XdsConnectionMonitorMetrics, XdsConnectionState, XdsConnectionStateKind};
+
+pub(crate) const XDS_MONITOR_DEAD_TASK: &str = "xds monitor dead";
+
+#[derive(Clone)]
+pub(crate) struct XdsStartupReadinessGate {
+    inner: Arc<Mutex<XdsStartupReadinessGateInner>>,
+}
+
+struct XdsStartupReadinessGateInner {
+    task: Option<readiness::BlockReady>,
+}
+
+impl XdsStartupReadinessGate {
+    pub(crate) fn new(_ready: readiness::Ready, initial_task: readiness::BlockReady) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(XdsStartupReadinessGateInner {
+                task: Some(initial_task),
+            })),
+        }
+    }
+
+    fn clear(&self) {
+        let task = self.inner.lock().unwrap().task.take();
+        drop(task);
+    }
+
+    fn replace_held_with(&self, name: &str) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        let Some(task) = inner.task.take() else {
+            return false;
+        };
+        inner.task = Some(task.replace_with(name));
+        true
+    }
+}
+
+async fn park_monitor_dead(_gate: XdsStartupReadinessGate) -> ! {
+    std::future::pending().await
+}
+
+async fn fail_startup_for_sender_drop(
+    gate: XdsStartupReadinessGate,
+    metrics: XdsConnectionMonitorMetrics,
+) -> ! {
+    error!("xDS startup signal sender dropped before initial sync");
+    metrics.sender_dropped.inc();
+    gate.replace_held_with(XDS_MONITOR_DEAD_TASK);
+    park_monitor_dead(gate).await
+}
+
+async fn fail_startup_for_monitor_exit(gate: XdsStartupReadinessGate) -> ! {
+    error!("xDS freshness monitor exited before initial sync");
+    gate.replace_held_with(XDS_MONITOR_DEAD_TASK);
+    park_monitor_dead(gate).await
+}
+
+/// Replaces a still-held startup readiness blocker with `xds monitor dead` and
+/// parks forever. If startup readiness was already cleared, the panic is logged
+/// but readiness is not re-armed.
+pub(crate) async fn park_monitor_dead_after_panic(gate: XdsStartupReadinessGate) -> ! {
+    error!("xDS freshness monitor task panicked");
+    gate.replace_held_with(XDS_MONITOR_DEAD_TASK);
+    park_monitor_dead(gate).await
+}
+
+fn current_state(
+    conn_state_rx: &mut tokio::sync::watch::Receiver<XdsConnectionState>,
+) -> XdsConnectionState {
+    *conn_state_rx.borrow_and_update()
+}
+
+enum FreshnessEvent {
+    Fresh(XdsConnectionState),
+    NonFresh(XdsConnectionState),
+    ResyncedFresh(XdsConnectionState),
+    ResyncedNonFresh(XdsConnectionState),
+    Closed,
+}
+
+enum ConnectionStateEvent {
+    State(XdsConnectionState),
+    Resynced(XdsConnectionState),
+    Closed,
+}
+
+struct XdsFreshnessMonitor {
+    initial_state: XdsConnectionState,
+    conn_state_rx: tokio::sync::watch::Receiver<XdsConnectionState>,
+    conn_state_events_rx: broadcast::Receiver<XdsConnectionState>,
+    metrics: XdsConnectionMonitorMetrics,
+}
+
+impl XdsFreshnessMonitor {
+    fn new(
+        initial_state: XdsConnectionState,
+        conn_state_rx: tokio::sync::watch::Receiver<XdsConnectionState>,
+        conn_state_events_rx: broadcast::Receiver<XdsConnectionState>,
+        metrics: XdsConnectionMonitorMetrics,
+    ) -> Self {
+        Self {
+            initial_state,
+            conn_state_rx,
+            conn_state_events_rx,
+            metrics,
+        }
+    }
+
+    fn current_state(&mut self) -> XdsConnectionState {
+        current_state(&mut self.conn_state_rx)
+    }
+
+    async fn recv_connection_state(&mut self) -> ConnectionStateEvent {
+        match self.conn_state_events_rx.recv().await {
+            Ok(state) => ConnectionStateEvent::State(state),
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                warn!(
+                    skipped,
+                    "xDS freshness monitor lagged connection-state events"
+                );
+                self.metrics.events_lagged.inc_by(skipped);
+                self.conn_state_events_rx = self.conn_state_events_rx.resubscribe();
+                ConnectionStateEvent::Resynced(self.current_state())
+            }
+            Err(broadcast::error::RecvError::Closed) => ConnectionStateEvent::Closed,
+        }
+    }
+
+    async fn wait_for_non_synced_state(
+        &mut self,
+        current_state: &mut XdsConnectionState,
+    ) -> Option<XdsConnectionState> {
+        loop {
+            if current_state.kind() != XdsConnectionStateKind::Synced {
+                return Some(*current_state);
+            }
+            *current_state = match self.recv_connection_state().await {
+                ConnectionStateEvent::State(state) | ConnectionStateEvent::Resynced(state) => state,
+                ConnectionStateEvent::Closed => return None,
+            };
+        }
+    }
+
+    async fn wait_for_freshness_after(&mut self, freshness_epoch: u64) -> FreshnessEvent {
+        loop {
+            let (state, resynced) = match self.recv_connection_state().await {
+                ConnectionStateEvent::State(state) => (state, false),
+                ConnectionStateEvent::Resynced(state) => (state, true),
+                ConnectionStateEvent::Closed => return FreshnessEvent::Closed,
+            };
+            if state.freshness_epoch() == freshness_epoch {
+                continue;
+            }
+            match state.kind() {
+                XdsConnectionStateKind::Synced if resynced => {
+                    return FreshnessEvent::ResyncedFresh(state);
+                }
+                XdsConnectionStateKind::Synced => return FreshnessEvent::Fresh(state),
+                _ if resynced => return FreshnessEvent::ResyncedNonFresh(state),
+                _ => return FreshnessEvent::NonFresh(state),
+            }
+        }
+    }
+
+    fn record_completed_non_fresh(
+        &mut self,
+        non_fresh_started_at: tokio::time::Instant,
+        non_fresh_ended_at: tokio::time::Instant,
+    ) -> std::time::Duration {
+        let total_non_fresh = non_fresh_ended_at.saturating_duration_since(non_fresh_started_at);
+        self.metrics
+            .non_fresh_duration
+            .observe(total_non_fresh.as_secs_f64());
+        #[cfg(any(test, feature = "testing"))]
+        self.metrics.record_non_fresh_observation_for_test();
+        total_non_fresh
+    }
+
+    fn restore_freshness(
+        &mut self,
+        non_fresh_started_at: tokio::time::Instant,
+        non_fresh_ended_at: tokio::time::Instant,
+    ) {
+        let total_non_fresh =
+            self.record_completed_non_fresh(non_fresh_started_at, non_fresh_ended_at);
+        info!(
+            total_non_fresh_ms = total_non_fresh.as_millis() as u64,
+            "xDS freshness restored"
+        );
+    }
+
+    fn sender_dropped(&mut self) {
+        error!("xDS freshness monitor input sender dropped");
+        self.metrics.sender_dropped.inc();
+    }
+
+    async fn run(mut self) {
+        let mut current_state = self.initial_state;
+        'monitor: loop {
+            let Some(non_fresh_state) = self.wait_for_non_synced_state(&mut current_state).await
+            else {
+                self.sender_dropped();
+                return;
+            };
+            let mut non_fresh_started_at = non_fresh_state.transitioned_at();
+            let mut non_fresh_started_epoch = non_fresh_state.freshness_epoch();
+
+            loop {
+                let event = self.wait_for_freshness_after(non_fresh_started_epoch).await;
+
+                match event {
+                    FreshnessEvent::Fresh(state) => {
+                        self.restore_freshness(non_fresh_started_at, state.transitioned_at());
+                        current_state = state;
+                        continue 'monitor;
+                    }
+                    FreshnessEvent::ResyncedFresh(state) => {
+                        info!("xDS freshness monitor resynced to fresh state after skipped epochs");
+                        current_state = state;
+                        continue 'monitor;
+                    }
+                    FreshnessEvent::NonFresh(state) => {
+                        let total_non_fresh = self.record_completed_non_fresh(
+                            non_fresh_started_at,
+                            state.transitioned_at(),
+                        );
+                        info!(
+                            total_non_fresh_ms = total_non_fresh.as_millis() as u64,
+                            "xDS freshness epoch advanced before another non-fresh state"
+                        );
+                        non_fresh_started_at = state.transitioned_at();
+                        non_fresh_started_epoch = state.freshness_epoch();
+                    }
+                    FreshnessEvent::ResyncedNonFresh(state) => {
+                        info!(
+                            "xDS freshness monitor resynced to non-fresh state after skipped fresh epoch"
+                        );
+                        non_fresh_started_at = state.transitioned_at();
+                        non_fresh_started_epoch = state.freshness_epoch();
+                    }
+                    FreshnessEvent::Closed => {
+                        self.sender_dropped();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Updates xDS freshness metrics from the xDS connection state stream.
+pub(crate) async fn run_freshness_monitor(
+    initial_state: XdsConnectionState,
+    conn_state_rx: tokio::sync::watch::Receiver<XdsConnectionState>,
+    conn_state_events_rx: broadcast::Receiver<XdsConnectionState>,
+    metrics: XdsConnectionMonitorMetrics,
+) {
+    XdsFreshnessMonitor::new(initial_state, conn_state_rx, conn_state_events_rx, metrics)
+        .run()
+        .await;
+}
+
+/// Starts the freshness metrics monitor and independently waits for startup xDS
+/// sync before clearing readiness. The monitor reports xDS freshness facts, but
+/// it does not re-arm readiness after startup.
+pub(crate) async fn run_xds_monitor_task(
+    xds_connection_initial_state: Option<XdsConnectionState>,
+    xds_connection_state_rx: Option<tokio::sync::watch::Receiver<XdsConnectionState>>,
+    xds_connection_state_events_rx: Option<broadcast::Receiver<XdsConnectionState>>,
+    mut xds_rx_for_task: tokio::sync::watch::Receiver<()>,
+    readiness_gate: XdsStartupReadinessGate,
+    xds_monitor_metrics: Option<XdsConnectionMonitorMetrics>,
+) {
+    match xds_connection_state_rx {
+        Some(conn_state_rx) => {
+            let initial_state = xds_connection_initial_state
+                .expect("remote xDS freshness monitor requires initial state");
+            let xds_monitor_metrics =
+                xds_monitor_metrics.expect("remote xDS freshness monitor requires metrics");
+            let conn_state_events_rx = xds_connection_state_events_rx
+                .expect("remote xDS freshness monitor requires connection-state events");
+            let startup_metrics = xds_monitor_metrics.clone();
+            let monitor = run_freshness_monitor(
+                initial_state,
+                conn_state_rx,
+                conn_state_events_rx,
+                xds_monitor_metrics,
+            );
+            tokio::pin!(monitor);
+
+            tokio::select! {
+                biased;
+                changed = xds_rx_for_task.changed() => {
+                    if changed.is_err() {
+                        fail_startup_for_sender_drop(readiness_gate, startup_metrics).await;
+                    }
+                    readiness_gate.clear();
+                }
+                () = &mut monitor => {
+                    fail_startup_for_monitor_exit(readiness_gate).await;
+                }
+            }
+
+            monitor.await;
+        }
+        None => {
+            // No remote xDS client owns this startup signal in local-only
+            // mode; sender drop means local config loading already completed
+            // or build would have returned an error.
+            let _ = xds_rx_for_task.changed().await;
+            readiness_gate.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus_client::registry::Registry;
+
+    use super::*;
+    use crate::readiness;
+    use crate::xds::XdsConnectionState;
+
+    #[tokio::test]
+    async fn test_startup_sender_drop_blocks_readiness_permanently() {
+        let ready = readiness::Ready::new();
+        let state_mgr_task = ready.register_task("state manager");
+        let gate = XdsStartupReadinessGate::new(ready.clone(), state_mgr_task);
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
+        let (_state_tx, _state_events_tx, conn_state_rx, conn_state_events_rx) =
+            state_channels(XdsConnectionState::initializing());
+
+        drop(xds_tx);
+        let initial_state = *conn_state_rx.borrow();
+        let monitor = tokio::spawn(run_xds_monitor_task(
+            Some(initial_state),
+            Some(conn_state_rx),
+            Some(conn_state_events_rx),
+            xds_rx,
+            gate,
+            Some(metrics),
+        ));
+
+        tokio::task::yield_now().await;
+        let pending = ready.pending();
+        assert!(
+            pending.contains(XDS_MONITOR_DEAD_TASK),
+            "xDS monitor dead readiness task was not registered after startup sender drop"
+        );
+        assert!(
+            !pending.contains("state manager"),
+            "state manager blocker was not replaced after startup sender drop"
+        );
+        assert_sender_dropped_total(&registry, 1);
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test]
+    async fn test_startup_signal_wins_when_monitor_exits_at_same_time() {
+        for _ in 0..64 {
+            let ready = readiness::Ready::new();
+            let state_mgr_task = ready.register_task("state manager");
+            let gate = XdsStartupReadinessGate::new(ready.clone(), state_mgr_task);
+            let mut registry = Registry::default();
+            let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+            let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
+            let (state_tx, state_events_tx, state_rx, state_events_rx) =
+                state_channels(XdsConnectionState::initializing());
+
+            xds_tx.send_replace(());
+            drop(state_tx);
+            drop(state_events_tx);
+
+            let initial_state = *state_rx.borrow();
+            let monitor = tokio::spawn(run_xds_monitor_task(
+                Some(initial_state),
+                Some(state_rx),
+                Some(state_events_rx),
+                xds_rx,
+                gate,
+                Some(metrics),
+            ));
+
+            tokio::task::yield_now().await;
+            assert!(
+                ready.pending().is_empty(),
+                "startup signal must clear readiness when monitor exit is also ready"
+            );
+            if monitor.is_finished() {
+                monitor.await.expect("xDS monitor task panicked");
+            } else {
+                abort_monitor_for_test(monitor).await;
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_monitor_records_startup_non_fresh_duration_without_policy_metrics() {
+        let ready = readiness::Ready::new();
+        let state_mgr_task = ready.register_task("state manager");
+        let gate = XdsStartupReadinessGate::new(ready.clone(), state_mgr_task);
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels(XdsConnectionState::initializing());
+
+        let initial_state = *state_rx.borrow();
+        let monitor = tokio::spawn(run_xds_monitor_task(
+            Some(initial_state),
+            Some(state_rx),
+            Some(state_events_rx),
+            xds_rx,
+            gate,
+            Some(metrics),
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+        tokio::task::yield_now().await;
+
+        assert_pending_tasks(&ready, &["state manager"]);
+        assert_metric_absent(&registry, "xds_config_non_fresh_over_threshold");
+        assert_metric_absent(&registry, "xds_config_non_fresh_threshold_exceeded");
+
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(1));
+        xds_tx.send_replace(());
+        tokio::task::yield_now().await;
+
+        assert!(ready.pending().is_empty());
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 1);
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test]
+    async fn test_panic_path_does_not_rearm_readiness_after_startup() {
+        let ready = readiness::Ready::new();
+        let state_mgr_task = ready.register_task("state manager");
+        let gate = XdsStartupReadinessGate::new(ready.clone(), state_mgr_task);
+
+        gate.clear();
+        let monitor = tokio::spawn(park_monitor_dead_after_panic(gate));
+
+        tokio::task::yield_now().await;
+        assert!(
+            ready.pending().is_empty(),
+            "post-startup monitor panic must not re-arm readiness"
+        );
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test]
+    async fn test_panic_path_replaces_startup_blocker_before_startup() {
+        let ready = readiness::Ready::new();
+        let state_mgr_task = ready.register_task("state manager");
+        let gate = XdsStartupReadinessGate::new(ready.clone(), state_mgr_task);
+
+        let monitor = tokio::spawn(park_monitor_dead_after_panic(gate));
+
+        tokio::task::yield_now().await;
+        assert_pending_tasks(&ready, &[XDS_MONITOR_DEAD_TASK]);
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_keeps_readiness_ready_while_non_fresh() {
+        let ready = readiness::Ready::new();
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels(XdsConnectionState::synced(1));
+        gate_after_startup(&ready);
+
+        let initial_state = *state_rx.borrow();
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            ready.pending().is_empty(),
+            "freshness monitor must not re-arm readiness after startup"
+        );
+        assert_metric_absent(&registry, "xds_config_non_fresh_over_threshold");
+        assert_metric_absent(&registry, "xds_config_non_fresh_threshold_exceeded");
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_records_duration_on_restored_freshness() {
+        let ready = readiness::Ready::new();
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels(XdsConnectionState::synced(1));
+        gate_after_startup(&ready);
+
+        let initial_state = *state_rx.borrow();
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+        tokio::task::yield_now().await;
+
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(2));
+        tokio::task::yield_now().await;
+
+        assert!(ready.pending().is_empty());
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 1);
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_records_coalesced_disconnect_sync() {
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels(XdsConnectionState::synced(1));
+
+        let initial_state = *state_rx.borrow();
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(2));
+        tokio::task::yield_now().await;
+
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 1);
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_tracks_duration() {
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels(XdsConnectionState::synced(1));
+
+        let initial_state = *state_rx.borrow();
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(60)).await;
+        tokio::task::yield_now().await;
+        assert_metric_absent(&registry, "xds_config_non_fresh_over_threshold");
+        assert_metric_absent(&registry, "xds_config_non_fresh_threshold_exceeded");
+
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(2));
+        tokio::task::yield_now().await;
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 1);
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test]
+    async fn test_freshness_monitor_sender_drop_after_startup_records_sender_drop_only() {
+        let ready = readiness::Ready::new();
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels(XdsConnectionState::synced(1));
+        gate_after_startup(&ready);
+
+        drop(state_tx);
+        drop(state_events_tx);
+
+        let initial_state = *state_rx.borrow();
+        run_freshness_monitor(initial_state, state_rx, state_events_rx, metrics).await;
+
+        assert!(
+            ready.pending().is_empty(),
+            "freshness monitor input closure after startup must not re-arm readiness"
+        );
+        assert_metric_line(&registry, "xds_monitor_sender_dropped_total", 1);
+        assert_metric_line(&registry, "xds_monitor_events_lagged_total", 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_lag_uses_lag_metric_and_resyncs_snapshot() {
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels_with_capacity(XdsConnectionState::synced(1), 1);
+        let initial_state = *state_rx.borrow();
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(2));
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(2),
+        );
+        tokio::task::yield_now().await;
+
+        assert_metric_line(&registry, "xds_monitor_events_lagged_total", 1);
+        assert_metric_line(&registry, "xds_monitor_sender_dropped_total", 0);
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 0);
+
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(3));
+        tokio::task::yield_now().await;
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 1);
+        let sum = metric_value_f64(&registry, "xds_config_non_fresh_duration_seconds_sum")
+            .expect("duration histogram sum must be exported");
+        assert!(
+            sum.abs() < f64::EPSILON,
+            "lag recovery must not record skipped fresh time as non-fresh duration, got {sum}"
+        );
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_lag_resynced_fresh_drops_ambiguous_duration() {
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels_with_capacity(XdsConnectionState::synced(1), 1);
+        let initial_state = *state_rx.borrow();
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(2));
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(2),
+        );
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(3));
+        tokio::task::yield_now().await;
+
+        assert_metric_line(&registry, "xds_monitor_events_lagged_total", 2);
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 0);
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_lag_does_not_replay_stale_retained_events() {
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels_with_capacity(XdsConnectionState::synced(1), 2);
+
+        let initial_state = *state_rx.borrow();
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(2));
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(2),
+        );
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(3));
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_metric_line(&registry, "xds_monitor_events_lagged_total", 2);
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 0);
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_starts_from_ordered_initial_state() {
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let initial_state =
+            XdsConnectionState::initializing().with_transitioned_at(tokio::time::Instant::now());
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels_with_capacity(initial_state, 16);
+
+        tokio::time::advance(std::time::Duration::from_secs(5)).await;
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::connected(0),
+        );
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(1));
+        tokio::time::advance(std::time::Duration::from_secs(5)).await;
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 1);
+        let sum = metric_value_f64(&registry, "xds_config_non_fresh_duration_seconds_sum")
+            .expect("duration histogram sum must be exported");
+        assert!(
+            (sum - 15.0).abs() < f64::EPSILON,
+            "duration histogram should process retained states in publish order, got {sum}"
+        );
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_monitor_uses_publish_time_for_queued_duration() {
+        let mut registry = Registry::default();
+        let metrics = crate::xds::XdsConnectionMonitorMetrics::new(&mut registry);
+        let initial_state = XdsConnectionState::synced(1);
+        let (state_tx, state_events_tx, state_rx, state_events_rx) =
+            state_channels_with_capacity(initial_state, 16);
+
+        send_state(
+            &state_tx,
+            &state_events_tx,
+            XdsConnectionState::disconnected(1),
+        );
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+        send_state(&state_tx, &state_events_tx, XdsConnectionState::synced(2));
+        tokio::time::advance(std::time::Duration::from_secs(60)).await;
+
+        let monitor = tokio::spawn(run_freshness_monitor(
+            initial_state,
+            state_rx,
+            state_events_rx,
+            metrics,
+        ));
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_metric_line(&registry, "xds_config_non_fresh_duration_seconds_count", 1);
+        let sum = metric_value_f64(&registry, "xds_config_non_fresh_duration_seconds_sum")
+            .expect("duration histogram sum must be exported");
+        assert!(
+            (sum - 10.0).abs() < f64::EPSILON,
+            "duration histogram should use xDS publish time, got {sum}"
+        );
+
+        abort_monitor_for_test(monitor).await;
+    }
+
+    fn state_channels(
+        initial_state: XdsConnectionState,
+    ) -> (
+        tokio::sync::watch::Sender<XdsConnectionState>,
+        broadcast::Sender<XdsConnectionState>,
+        tokio::sync::watch::Receiver<XdsConnectionState>,
+        broadcast::Receiver<XdsConnectionState>,
+    ) {
+        state_channels_with_capacity(initial_state, 16)
+    }
+
+    fn state_channels_with_capacity(
+        initial_state: XdsConnectionState,
+        event_capacity: usize,
+    ) -> (
+        tokio::sync::watch::Sender<XdsConnectionState>,
+        broadcast::Sender<XdsConnectionState>,
+        tokio::sync::watch::Receiver<XdsConnectionState>,
+        broadcast::Receiver<XdsConnectionState>,
+    ) {
+        let (state_tx, state_rx) = tokio::sync::watch::channel(initial_state);
+        let (state_events_tx, state_events_rx) = broadcast::channel(event_capacity);
+        (state_tx, state_events_tx, state_rx, state_events_rx)
+    }
+
+    fn send_state(
+        state_tx: &tokio::sync::watch::Sender<XdsConnectionState>,
+        state_events_tx: &broadcast::Sender<XdsConnectionState>,
+        state: XdsConnectionState,
+    ) {
+        let state = state.with_transitioned_at(tokio::time::Instant::now());
+        state_tx.send_replace(state);
+        state_events_tx
+            .send(state)
+            .expect("test connection-state event receiver should be alive");
+    }
+
+    async fn abort_monitor_for_test<T>(monitor: tokio::task::JoinHandle<T>) {
+        assert!(
+            !monitor.is_finished(),
+            "xDS monitor task exited before test cleanup"
+        );
+        monitor.abort();
+        match monitor.await {
+            Err(err) if err.is_cancelled() => {}
+            Ok(_) => panic!("xDS monitor task exited before cancellation"),
+            Err(err) if err.is_panic() => {
+                panic!("xDS monitor task panicked before cancellation: {err:?}")
+            }
+            Err(err) => panic!("xDS monitor task failed before cancellation: {err:?}"),
+        }
+    }
+
+    fn gate_after_startup(ready: &readiness::Ready) -> XdsStartupReadinessGate {
+        let startup_task = ready.register_task("state manager");
+        let gate = XdsStartupReadinessGate::new(ready.clone(), startup_task);
+        gate.clear();
+        gate
+    }
+
+    fn assert_sender_dropped_total(registry: &Registry, expected: u64) {
+        assert_metric_line(registry, "xds_monitor_sender_dropped_total", expected);
+    }
+
+    fn assert_metric_line(registry: &Registry, metric: &str, expected: u64) {
+        let mut encoded = String::new();
+        prometheus_client::encoding::text::encode(&mut encoded, registry).unwrap();
+        let expected_line = format!("{metric} {expected}");
+        assert!(
+            encoded.lines().any(|line| line == expected_line),
+            "expected metric line `{expected_line}`, got:\n{encoded}"
+        );
+    }
+
+    fn assert_metric_absent(registry: &Registry, metric: &str) {
+        let mut encoded = String::new();
+        prometheus_client::encoding::text::encode(&mut encoded, registry).unwrap();
+        assert!(
+            !encoded.contains(metric),
+            "did not expect metric `{metric}`, got:\n{encoded}"
+        );
+    }
+
+    fn metric_value_f64(registry: &Registry, metric: &str) -> Option<f64> {
+        let mut encoded = String::new();
+        prometheus_client::encoding::text::encode(&mut encoded, registry).unwrap();
+        let prefix = format!("{metric} ");
+        encoded
+            .lines()
+            .find_map(|line| line.strip_prefix(&prefix))
+            .and_then(|value| value.parse().ok())
+    }
+
+    fn assert_pending_tasks(ready: &readiness::Ready, expected: &[&str]) {
+        let pending = ready.pending();
+        let expected: std::collections::HashSet<String> =
+            expected.iter().map(|task| task.to_string()).collect();
+        assert_eq!(
+            pending, expected,
+            "readiness pending tasks did not match expected set"
+        );
+    }
+}

--- a/src/xds/metrics.rs
+++ b/src/xds/metrics.rs
@@ -15,6 +15,8 @@
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::histogram::Histogram;
 use prometheus_client::registry::{Registry, Unit};
 
 use crate::metrics::Recorder;
@@ -25,6 +27,9 @@ pub struct Metrics {
     pub connection_terminations: Family<ConnectionTermination, Counter>,
     pub message_types: Family<TypeUrl, Counter>,
     pub total_messages_size: Family<TypeUrl, Counter>,
+    pub up: Option<Gauge>,
+    pub config_fresh: Option<Gauge>,
+    pub disconnect_duration: Option<Histogram>,
 }
 
 #[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
@@ -47,6 +52,10 @@ pub struct TypeUrl {
 
 impl Metrics {
     pub fn new(registry: &mut Registry) -> Self {
+        Self::new_with_remote_xds(registry, true)
+    }
+
+    pub fn new_with_remote_xds(registry: &mut Registry, remote_xds_configured: bool) -> Self {
         let connection_terminations = Family::default();
         registry.register(
             "xds_connection_terminations",
@@ -71,10 +80,49 @@ impl Metrics {
             total_messages_size.clone(),
         );
 
+        let up = remote_xds_configured.then(|| {
+            let up = Gauge::default();
+            registry.register(
+                "xds_up",
+                "Whether the xDS gRPC stream is currently connected (1) or not (0); this is not Prometheus scrape liveness (unstable)",
+                up.clone(),
+            );
+            up
+        });
+
+        let config_fresh = remote_xds_configured.then(|| {
+            let config_fresh = Gauge::default();
+            registry.register(
+                "xds_config_fresh",
+                "Whether the current xDS stream has ACKed usable config and has no watched-resource rejection outstanding (1) or not (0) (unstable)",
+                config_fresh.clone(),
+            );
+            config_fresh
+        });
+
+        let disconnect_duration = remote_xds_configured.then(|| {
+            let disconnect_duration = Histogram::new(
+                [
+                    0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+                    600.0, 1800.0, 3600.0, 7200.0, 14400.0, 43200.0, 86400.0,
+                ],
+            );
+            registry.register_with_unit(
+                "xds_disconnect_duration",
+                "Duration of completed xDS disconnections, observed when a new xDS stream is established (unstable)",
+                Unit::Seconds,
+                disconnect_duration.clone(),
+            );
+            disconnect_duration
+        });
+
         Self {
             connection_terminations,
             message_types: message_count,
             total_messages_size,
+            up,
+            config_fresh,
+            disconnect_duration,
         }
     }
 }
@@ -105,5 +153,154 @@ impl Recorder<DeltaDiscoveryResponse, ()> for Metrics {
         self.total_messages_size
             .get_or_create(&type_url)
             .inc_by(total_message_size);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus_client::encoding::text::encode;
+
+    use super::*;
+
+    #[test]
+    fn disconnect_duration_help_describes_completed_disconnects() {
+        let mut registry = Registry::default();
+        let _metrics = Metrics::new(&mut registry);
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        assert!(
+            encoded.contains(
+                "# HELP xds_disconnect_duration_seconds Duration of completed xDS disconnections, observed when a new xDS stream is established (unstable)"
+            ),
+            "disconnect-duration HELP text should describe completed disconnect semantics:\n{encoded}"
+        );
+    }
+
+    #[test]
+    fn config_fresh_help_describes_synced_semantics() {
+        let mut registry = Registry::default();
+        let _metrics = Metrics::new(&mut registry);
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        assert!(
+            encoded.contains(
+                "# HELP xds_config_fresh Whether the current xDS stream has ACKed usable config and has no watched-resource rejection outstanding (1) or not (0) (unstable)"
+            ),
+            "config-fresh HELP text should describe Synced semantics:\n{encoded}"
+        );
+    }
+
+    #[test]
+    fn monitor_sender_dropped_help_describes_monitor_senders() {
+        let mut registry = Registry::default();
+        let _metrics = XdsConnectionMonitorMetrics::new(&mut registry);
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        assert!(
+            encoded.contains(
+                "# HELP xds_monitor_sender_dropped Total number of times an xDS monitor input sender dropped (unstable)"
+            ),
+            "sender-drop HELP text should describe the monitor input senders:\n{encoded}"
+        );
+    }
+
+    #[test]
+    fn monitor_events_lagged_help_describes_skipped_events() {
+        let mut registry = Registry::default();
+        let _metrics = XdsConnectionMonitorMetrics::new(&mut registry);
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        assert!(
+            encoded.contains(
+                "# HELP xds_monitor_events_lagged Total number of xDS connection-state events skipped because the freshness monitor receiver lagged (unstable)"
+            ),
+            "lag HELP text should describe skipped monitor events:\n{encoded}"
+        );
+    }
+
+    #[test]
+    fn monitor_metrics_do_not_export_policy_threshold_series() {
+        let mut registry = Registry::default();
+        let _metrics = XdsConnectionMonitorMetrics::new(&mut registry);
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        assert!(
+            !encoded.contains("xds_config_non_fresh_over_threshold"),
+            "freshness monitor metrics should expose facts, not policy threshold gauges:\n{encoded}"
+        );
+        assert!(
+            !encoded.contains("xds_config_non_fresh_threshold_exceeded"),
+            "freshness monitor metrics should expose facts, not policy threshold counters:\n{encoded}"
+        );
+        assert!(
+            !encoded.contains("XDS_NON_FRESH_THRESHOLD"),
+            "freshness monitor metric HELP should not mention removed threshold config:\n{encoded}"
+        );
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct XdsConnectionMonitorMetrics {
+    pub(crate) non_fresh_duration: Histogram,
+    pub(crate) sender_dropped: Counter,
+    pub(crate) events_lagged: Counter,
+    #[cfg(any(test, feature = "testing"))]
+    non_fresh_observation_tx: tokio::sync::watch::Sender<u64>,
+}
+
+impl XdsConnectionMonitorMetrics {
+    pub(crate) fn new(registry: &mut Registry) -> Self {
+        let non_fresh_duration = Histogram::new([
+            0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0,
+            3600.0, 7200.0, 14400.0, 43200.0, 86400.0,
+        ]);
+        registry.register_with_unit(
+            "xds_config_non_fresh_duration",
+            "Duration of completed periods where xDS was non-fresh (unstable)",
+            Unit::Seconds,
+            non_fresh_duration.clone(),
+        );
+        let sender_dropped = Counter::default();
+        registry.register(
+            "xds_monitor_sender_dropped",
+            "Total number of times an xDS monitor input sender dropped (unstable)",
+            sender_dropped.clone(),
+        );
+        let events_lagged = Counter::default();
+        registry.register(
+            "xds_monitor_events_lagged",
+            "Total number of xDS connection-state events skipped because the freshness monitor receiver lagged (unstable)",
+            events_lagged.clone(),
+        );
+        #[cfg(any(test, feature = "testing"))]
+        let (non_fresh_observation_tx, _) = tokio::sync::watch::channel(0);
+        Self {
+            non_fresh_duration,
+            sender_dropped,
+            events_lagged,
+            #[cfg(any(test, feature = "testing"))]
+            non_fresh_observation_tx,
+        }
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) fn non_fresh_observation_receiver(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.non_fresh_observation_tx.subscribe()
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) fn record_non_fresh_observation_for_test(&self) {
+        let next = (*self.non_fresh_observation_tx.borrow()).wrapping_add(1);
+        self.non_fresh_observation_tx.send_replace(next);
     }
 }

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -558,3 +558,261 @@ async fn admin_shutdown(addr: SocketAddr) {
     let resp = client.request(req).await.expect("admin shutdown request");
     assert_eq!(resp.status(), hyper::StatusCode::OK);
 }
+
+mod xds_freshness_metrics {
+    //! End-to-end tests for the xDS freshness metric surface. These drive a
+    //! real ztunnel against the in-process ADS test server and assert behavior
+    //! through `/healthz/ready` and `/metrics`.
+
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use textnonce::TextNonce;
+    use ztunnel::identity::mock::new_secret_manager;
+    use ztunnel::test_helpers::app::XdsTestSignals;
+    use ztunnel::test_helpers::helpers::initialize_telemetry;
+    use ztunnel::test_helpers::xds::{AdsConnection, AdsServer};
+    use ztunnel::xds::service::discovery::v3::{DeltaDiscoveryRequest, DeltaDiscoveryResponse};
+    use ztunnel::xds::{ADDRESS_TYPE, AUTHORIZATION_TYPE};
+
+    async fn ack_each_watched_type(conn: &mut AdsConnection) {
+        let mut addr_acked = false;
+        let mut auth_acked = false;
+        while !(addr_acked && auth_acked) {
+            let req = tokio::time::timeout(Duration::from_secs(2), conn.recv_request())
+                .await
+                .expect("timed out waiting for xDS request")
+                .expect("ADS request channel closed");
+            if req.type_url == *ADDRESS_TYPE && !addr_acked {
+                send_empty_response(conn, &ADDRESS_TYPE).await;
+                addr_acked = true;
+            } else if req.type_url == *AUTHORIZATION_TYPE && !auth_acked {
+                send_empty_response(conn, &AUTHORIZATION_TYPE).await;
+                auth_acked = true;
+            }
+        }
+    }
+
+    async fn send_empty_response(conn: &mut AdsConnection, type_url: &str) {
+        conn.send_response(Ok(DeltaDiscoveryResponse {
+            resources: vec![],
+            nonce: TextNonce::new().to_string(),
+            system_version_info: "1.0.0".to_string(),
+            type_url: type_url.to_string(),
+            removed_resources: vec![],
+        }))
+        .await;
+    }
+
+    async fn ack_watched_request(conn: &mut AdsConnection, req: &DeltaDiscoveryRequest) {
+        match req.type_url.as_str() {
+            t if t == &*ADDRESS_TYPE => send_empty_response(conn, &ADDRESS_TYPE).await,
+            t if t == &*AUTHORIZATION_TYPE => send_empty_response(conn, &AUTHORIZATION_TYPE).await,
+            other => panic!("unexpected reconnect xDS request type {other}"),
+        }
+    }
+
+    async fn readiness_status(addr: SocketAddr) -> hyper::StatusCode {
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(format!("http://localhost:{}/healthz/ready", addr.port()))
+            .body(http_body_util::Empty::<bytes::Bytes>::new())
+            .unwrap();
+        let client =
+            ::hyper_util::client::legacy::Client::builder(::hyper_util::rt::TokioExecutor::new())
+                .build_http();
+        client
+            .request(req)
+            .await
+            .expect("readiness request")
+            .status()
+    }
+
+    async fn metrics_text(addr: SocketAddr) -> String {
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(format!("http://{addr}/metrics"))
+            .body(http_body_util::Empty::<bytes::Bytes>::new())
+            .unwrap();
+        let client =
+            ::hyper_util::client::legacy::Client::builder(::hyper_util::rt::TokioExecutor::new())
+                .build_http();
+        let body = client
+            .request(req)
+            .await
+            .expect("metrics request")
+            .into_body();
+        let body = http_body_util::BodyExt::collect(body)
+            .await
+            .expect("metrics body")
+            .to_bytes();
+        String::from_utf8(body.to_vec()).expect("metrics body utf-8")
+    }
+
+    fn metric_value_u64(metrics: &str, line_prefix: &str) -> Option<u64> {
+        metrics
+            .lines()
+            .find(|l| l.starts_with(line_prefix))
+            .and_then(|l| l.strip_prefix(line_prefix))
+            .and_then(|rest| rest.trim().parse::<u64>().ok())
+    }
+
+    async fn wait_for_readiness(readiness_address: SocketAddr, ready: bool, reason: &str) {
+        let mut last_status = None;
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = readiness_status(readiness_address).await;
+                last_status = Some(status);
+                if (status == hyper::StatusCode::OK) == ready {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("timed out waiting for {reason}; last readiness status: {last_status:?}")
+        });
+    }
+
+    fn assert_no_policy_threshold_metrics(metrics: &str) {
+        assert!(
+            !metrics.contains("istio_xds_config_non_fresh_over_threshold"),
+            "ztunnel should not export a built-in xDS non-fresh threshold gauge:\n{metrics}"
+        );
+        assert!(
+            !metrics.contains("istio_xds_config_non_fresh_threshold_exceeded"),
+            "ztunnel should not export a built-in xDS non-fresh threshold counter:\n{metrics}"
+        );
+    }
+
+    async fn assert_readiness_ready_with_freshness_metrics(
+        readiness_address: SocketAddr,
+        metrics_address: SocketAddr,
+        reason: &str,
+    ) {
+        assert_eq!(
+            readiness_status(readiness_address).await,
+            hyper::StatusCode::OK,
+            "readiness became unhealthy while {reason}"
+        );
+
+        let metrics = metrics_text(metrics_address).await;
+        assert_eq!(
+            metric_value_u64(&metrics, "istio_xds_config_fresh "),
+            Some(0),
+            "freshness gauge should be 0 while {reason}:\n{metrics}"
+        );
+        assert_no_policy_threshold_metrics(&metrics);
+    }
+
+    #[tokio::test]
+    async fn records_freshness_facts_without_rearming_readiness() {
+        initialize_telemetry();
+
+        let (mut conn_receiver, cfg) = AdsServer::spawn_app_server().await;
+
+        let cert_manager = new_secret_manager(Duration::from_secs(10));
+        let app = ztunnel::app::build_with_cert(Arc::new(cfg), cert_manager)
+            .await
+            .expect("ztunnel builds");
+        let shutdown = app.shutdown.trigger().clone();
+        let readiness_address = app.readiness_address;
+        let metrics_address = app.metrics_address;
+        let mut xds_signals =
+            XdsTestSignals::from_bound(&app).expect("remote xDS app exposes test signals");
+        let app_task = tokio::spawn(app.wait_termination());
+
+        let mut conn = tokio::time::timeout(Duration::from_secs(5), conn_receiver.recv())
+            .await
+            .expect("timed out waiting for initial xDS connection")
+            .expect("ADS connection channel closed");
+        let initial_observation_count = xds_signals.freshness_observation_count();
+        ack_each_watched_type(&mut conn).await;
+        xds_signals.wait_for_startup_sync().await;
+        let synced_epoch = xds_signals.wait_for_synced("initial xDS sync").await;
+        wait_for_readiness(readiness_address, true, "initial readiness").await;
+        xds_signals
+            .wait_for_freshness_observation_after(
+                initial_observation_count,
+                "initial xDS freshness duration metric",
+            )
+            .await;
+        let metrics = metrics_text(metrics_address).await;
+        assert_eq!(
+            metric_value_u64(&metrics, "istio_xds_config_fresh "),
+            Some(1),
+            "freshness gauge should be 1 after initial sync:\n{metrics}"
+        );
+        assert!(
+            metric_value_u64(
+                &metrics,
+                "istio_xds_config_non_fresh_duration_seconds_count ",
+            )
+            .unwrap_or_default()
+                >= 1,
+            "freshness duration histogram should include initial sync:\n{metrics}"
+        );
+        assert_no_policy_threshold_metrics(&metrics);
+        let initial_duration_count = metric_value_u64(
+            &metrics,
+            "istio_xds_config_non_fresh_duration_seconds_count ",
+        )
+        .unwrap_or_default();
+
+        conn.send_response(Err(tonic::Status::aborted("simulated disconnect")))
+            .await;
+        let mut reconnect = tokio::time::timeout(Duration::from_secs(5), conn_receiver.recv())
+            .await
+            .expect("timed out waiting for reconnect")
+            .expect("ADS connection channel closed");
+        xds_signals
+            .wait_for_connected_at_epoch(synced_epoch, "raw reconnect before ACK")
+            .await;
+        let first_req = tokio::time::timeout(Duration::from_secs(5), reconnect.recv_request())
+            .await
+            .expect("timed out waiting for reconnect's first request")
+            .expect("ADS request channel closed");
+
+        assert_readiness_ready_with_freshness_metrics(
+            readiness_address,
+            metrics_address,
+            "reconnect remains unACKed",
+        )
+        .await;
+
+        let reconnect_observation_count = xds_signals.freshness_observation_count();
+        ack_watched_request(&mut reconnect, &first_req).await;
+        xds_signals
+            .wait_for_synced_after(synced_epoch, "post-reconnect xDS ACK")
+            .await;
+        xds_signals
+            .wait_for_freshness_observation_after(
+                reconnect_observation_count,
+                "xDS freshness restoration metric",
+            )
+            .await;
+        let metrics = metrics_text(metrics_address).await;
+        assert_eq!(
+            metric_value_u64(&metrics, "istio_xds_config_fresh "),
+            Some(1),
+            "freshness gauge should be 1 after reconnect ACK:\n{metrics}"
+        );
+        assert!(
+            metric_value_u64(
+                &metrics,
+                "istio_xds_config_non_fresh_duration_seconds_count ",
+            )
+            .unwrap_or_default()
+                > initial_duration_count,
+            "freshness duration histogram should record reconnect restoration:\n{metrics}"
+        );
+        assert_no_policy_threshold_metrics(&metrics);
+
+        shutdown.shutdown_now().await;
+        app_task
+            .await
+            .expect("app task joins")
+            .expect("app exits clean");
+    }
+}


### PR DESCRIPTION
## Summary

This keeps ztunnel readiness as a startup gate and exposes xDS freshness
through metrics instead of changing `/healthz/ready` after startup.

After the initial xDS sync completes, `/healthz/ready` remains ready during
later xDS disconnects or non-fresh periods. Operators can use the metric
surface to distinguish raw stream connectivity, current config freshness,
completed disconnect duration, and completed non-fresh duration. Sustained
freshness policy belongs in dashboards, alerts, or external controllers.

## Problem

Ztunnel readiness is currently a startup gate. Once initial xDS sync completes,
`/healthz/ready` stays healthy even if ztunnel later loses contact with istiod
long enough for workload, service, policy, or certificate state to become
stale.

Using Kubernetes readiness for that steady-state signal overloads a pod
scheduling contract. Ztunnel is not a normal Service endpoint, but readiness
still has Kubernetes meaning, so xDS freshness is better exposed as telemetry
that an external controller can interpret.

## Solution

This change separates raw transport connectivity from config freshness:

- `Connected` means the xDS gRPC stream is open, but usable config has not yet
  been ACKed on that stream.
- `Synced` means ztunnel successfully handled and ACKed a response on the
  current stream, with no watched-resource rejection outstanding. During
  startup, `Synced` is delayed until all expected watched xDS types have ACKed.
- `Disconnected` means the stream ended or failed.

The xDS client publishes the latest state through a
`tokio::sync::watch::Receiver<XdsConnectionState>` and publishes transitions
through a bounded broadcast channel. The freshness monitor starts immediately,
records completed non-`Synced` periods, and independently waits for the
existing initial sync gate before clearing readiness. It does not register a
readiness blocker after startup.

Each published state carries a producer-side transition timestamp. Completed
non-fresh duration is calculated from those transition timestamps, so queued
events are timed from when xDS changed state rather than when the monitor task
was scheduled to process them.

## Configuration

This PR does not add a ztunnel freshness threshold configuration.

The previous prototype used `XDS_UNHEALTHY_THRESHOLD`, but that name implied
readiness would become unhealthy. A later `XDS_NON_FRESH_THRESHOLD` shape was
also removed because it still placed alert policy in ztunnel. Ztunnel now
reports facts; operators set the policy on the alert/dashboard side.

For example, a Prometheus alert can use `istio_xds_config_fresh == 0` with
`for: 5m`. A dashboard can use range queries such as
`max_over_time(istio_xds_config_fresh[5m]) == 0` when it wants to show
continuous non-fresh intervals.

## Metrics

This adds:

- `istio_xds_up`
- `istio_xds_config_fresh`
- `istio_xds_disconnect_duration_seconds`
- `istio_xds_config_non_fresh_duration_seconds`
- `istio_xds_monitor_sender_dropped_total`
- `istio_xds_monitor_events_lagged_total`

These cover current xDS stream connectivity, current xDS config freshness,
completed disconnect duration, completed non-fresh duration, monitor input
sender closure, and skipped monitor events. Lagged monitor events are counted
separately from sender drops. On lag, the monitor reconciles from the latest
watch snapshot and continues.

## Behavior

Default behavior:

- Ztunnel waits for initial xDS sync before becoming ready.
- After startup, xDS disconnects do not affect `/healthz/ready`.
- `istio_xds_config_fresh` reports `0` while the current stream is
  disconnected, connected but not ACKed, or has a watched-resource rejection
  outstanding.
- `istio_xds_config_fresh` reports `1` only after a usable ACK on the current
  stream and no watched-resource rejection is outstanding.
- A completed non-fresh period is observed in
  `istio_xds_config_non_fresh_duration_seconds` when freshness is restored.
- If the monitor receiver lags, `istio_xds_monitor_events_lagged_total`
  increments and the monitor reconciles from the current xDS state snapshot.

Remote-xDS startup sender-drop handling remains fail-closed: if the startup xDS
signal sender disappears before initial sync, readiness remains blocked with
`xds monitor dead` and data-plane listeners do not start. Startup-gated
data-plane tasks stay parked until drain instead of returning immediately, so
the readiness server remains available to report the fail-closed state.
Post-startup monitor input closure records
`istio_xds_monitor_sender_dropped_total` and does not re-arm readiness.

If the startup sync signal and monitor input closure are both ready in the same
poll, the startup signal wins and clears the startup readiness gate. That avoids
turning a completed startup sync into a permanent `xds monitor dead` blocker.

## Implementation Notes

The main code paths are:

- `src/xds/client.rs`: publishes `XdsConnectionState` snapshots, tracks
  `Connected`, `Synced`, and `Disconnected`, updates `xds_config_fresh`,
  records watched-resource ACK and NACK state, waits for all expected startup
  watched types before first freshness, publishes `Synced` before clearing the
  startup readiness blocker, only collects accepted watched resources for
  response types with an outstanding rejection, attaches transition timestamps,
  observes disconnect duration after a stream has reached `Connected`, raises
  `istio_xds_up` before publishing `Connected`, and logs the same retry delay
  it will sleep.
- `src/xds/freshness_monitor.rs`: owns startup readiness waiting and completed
  non-fresh duration metrics. Broadcast lag is counted separately from sender
  drop, retained stale backlog is discarded on lag, startup first consumes an
  already-retained broadcast event before falling back to the watch snapshot,
  startup sync wins over a simultaneous monitor exit, and reconciliation happens
  through the watch snapshot.
- `src/xds/metrics.rs`: adds stream and freshness monitor metrics.
- `src/app.rs` and `src/state.rs`: wire the monitor, metrics, connection-state
  watch receiver, transition broadcast, and startup drain handling for
  startup-gated data-plane tasks.
- `src/test_helpers/app.rs`, `src/test_helpers/xds.rs`, and `tests/direct.rs`:
  add in-process xDS integration coverage for freshness and metrics behavior.
  Direct metric assertions wait on a test-only freshness observation signal and
  then scrape `/metrics` once, instead of polling the stats endpoint for metric
  propagation.

## Risk

After startup, freshness restoration is intentionally based on the first
successfully handled and ACKed `DeltaDiscoveryResponse` on the current xDS
stream, with no watched-resource rejection outstanding. Raw transport
reconnection is not enough, and NACKed config does not restore freshness.

ACK-side clearing of a prior watched-resource rejection is applied only after
the outbound ACK has been successfully queued. NACK-side recording and
freshness demotion remain fail-closed before the outbound NACK send.

This does not prove every watched xDS type has been reasserted after reconnect.
A stronger freshness contract could require per-type or per-resource freshness,
but that would need an explicit istiod/ztunnel guarantee that every
freshness-critical type sends a confirmatory response after reconnect, including
quiet or empty types. Without that guarantee, requiring all watched types to ACK
could leave freshness false indefinitely in otherwise healthy clusters.

## Validation

Commands run for this branch:

```bash
cargo fmt -- --check
cargo check --lib --tests
git diff --check upstream/master...HEAD
git diff --check
cargo test --lib app::tests::
cargo test --lib xds::freshness_monitor::
cargo test --lib xds::client::tests::
cargo test --test direct xds_freshness_metrics
```
