### PR TITLE
[release-1.28] add unsafe marker to ctor annotations + bump ctor to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,19 +694,13 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.5.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "link-section",
+ "linktime-proc-macro",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "data-encoding"
@@ -777,21 +771,6 @@ name = "dtoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
-
-[[package]]
-name = "dtor"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1850,6 +1829,18 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1e908a416d6e9f725743b84a36feea40c4c131e805fbc26d61f9f451f36080"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ test-case = "3.3"
 oid-registry = "0.8"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 x509-parser = { version = "0.17", default-features = false, features = ["verify"] }
-ctor = "0.5"
+ctor = "1.0"
 
 [lints.clippy]
 # This rule makes code more confusing

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -54,7 +54,7 @@ const N_RULES: usize = 10;
 const N_POLICIES: usize = 10_000;
 const DUMMY_NETWORK: &str = "198.51.100.0/24";
 
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn initialize_namespace_tests() {
     ztunnel::test_helpers::namespaced::initialize_namespace_tests();
 }

--- a/tests/namespaced.rs
+++ b/tests/namespaced.rs
@@ -56,7 +56,7 @@ mod namespaced {
     const WAYPOINT_MESSAGE: &[u8] = b"waypoint\n";
 
     /// initialize_namespace_tests sets up the namespace tests.
-    #[ctor::ctor]
+    #[ctor::ctor(unsafe)]
     fn initialize_namespace_tests() {
         ztunnel::test_helpers::namespaced::initialize_namespace_tests();
     }


### PR DESCRIPTION
Manual cherry-pick of #1894. The automated cherry-pick (#1895) fails to compile because release-1.28 still has ctor 0.5 which does not support the (unsafe) syntax. Bumps ctor to 1.0 to match release-1.29.