### PR TITLE
fix: socks5 error message shows wrong variable when nmethods is zero

### DIFF
--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -193,10 +193,9 @@ async fn negotiate_socks_connection(
     let nmethods = version[1];
 
     if nmethods == 0 {
-        return Err(SocksError::invalid_protocol(format!(
-            "methods cannot be zero {}",
-            version[0]
-        )));
+        return Err(SocksError::invalid_protocol(
+            "methods cannot be zero".to_string(),
+        ));
     }
 
     // List of supported auth methods


### PR DESCRIPTION
In `negotiate_socks_connection`, when a client sends 0 auth methods the error message was:

```
"methods cannot be zero {}", version[0]
```

`version[0]` is the SOCKS protocol version (always 5), not the method count. So you'd get "methods cannot be zero 5" in the logs - pretty confusing when debugging a bad client.

Looks like a copy-paste from the version check right above it. Fix just drops the format arg since the message already says "cannot be zero" and there's nothing useful to append.

How to reproduce: connect to ztunnel's socks5 port and send `[0x05, 0x00]` (version=5, nmethods=0). Before this fix the warn log says "methods cannot be zero 5".