### PR TITLE
fix: use match guard instead of nested if in dns to_kube_fqdns

### DIFF
--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -315,12 +315,10 @@ impl Store {
                 // <pod-hostname>.<pod-sub-domain>.<namespace>.svc.<cluster-domain>.
                 out.push(append_name(name.clone(), &self.svc_domain));
             }
-            4 => {
-                if has_domain(name, SVC.deref()) {
-                    // Expand <pod-hostname>.<pod-sub-domain>.<namespace>.svc to
-                    // <pod-hostname>.<pod-sub-domain>.<namespace>.svc.<cluster-domain>.
-                    out.push(append_name(name.clone(), &self.domain));
-                }
+            4 if has_domain(name, SVC.deref()) => {
+                // Expand <pod-hostname>.<pod-sub-domain>.<namespace>.svc to
+                // <pod-hostname>.<pod-sub-domain>.<namespace>.svc.<cluster-domain>.
+                out.push(append_name(name.clone(), &self.domain));
             }
             _ => {
                 // Everything else is either already an FQDN or not a supported


### PR DESCRIPTION
`cargo clippy` fires `clippy::collapsible_match` on the `4 =>` arm in `to_kube_fqdns` (dns/server.rs). the whole arm body was just an `if` with no else, so clippy correctly says to collapse it into a match guard.

behavior is unchanged - when `iter.len() == 4` and `has_domain()` returns false, the `_ =>` arm still fires (no-op). all dns tests pass.

reproduce:
```
cargo clippy
```

output before fix:
```
warning: this `if` can be collapsed into the outer `match`
   --> src/dns/server.rs:319:17
```