### PR TITLE
Safer ServiceEntry

### DIFF
--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -104,6 +104,20 @@ message Service {
   // set, `waypoint` remains populated with the primary waypoint so that dataplanes which do
   // not understand this field continue to send all traffic to the primary.
   repeated WeightedWaypoint weighted_waypoints = 13;
+
+  // Visibility controls which clients can resolve and send traffic to a service.
+  enum Visibility {
+    // Visible to every client the control plane serves. This is the default,
+    // and matches the behavior before this field was introduced.
+    PUBLIC = 0;
+    // Visible only to clients in the same namespace as the service.
+    NAMESPACE = 1;
+  }
+
+  // visibility controls which clients this service is resolvable by. When
+  // unset it defaults to PUBLIC. Services that a mesh administrator has scoped
+  // to no visibility at all are simply not sent, so they do not appear here.
+  Visibility visibility = 14;
 }
 
 enum IPFamilies {

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -692,6 +692,7 @@ mod tests {
             ip_families: 0,
             extensions: Default::default(),
             canonical: true,
+            visibility: 0,
         };
 
         let auth = XdsAuthorization {

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -380,6 +380,9 @@ impl Store {
                             .expect("the svc domain must have a trailing '.'");
                         !service.vips.is_empty() || service.hostname.ends_with(domain)
                     })
+                    // Drop services not visible to the client's namespace. If this empties the
+                    // candidate list, we forward upstream as if the service were not in the mesh.
+                    .filter(|service| service.visible_to(&client.namespace))
                     // Get the service matching the client namespace. If no match exists, just
                     // return the first service.
                     .collect();
@@ -950,6 +953,7 @@ mod tests {
     use crate::xds::istio::workload::PortList as XdsPortList;
     use crate::xds::istio::workload::Service as XdsService;
     use crate::xds::istio::workload::Workload as XdsWorkload;
+    use crate::xds::istio::workload::service::Visibility as XdsVisibility;
     use crate::xds::istio::workload::{IpFamilies, NetworkAddress as XdsNetworkAddress};
 
     use crate::proxy::DefaultSocketFactory;
@@ -1208,6 +1212,22 @@ mod tests {
                 name: "success: k8s host - non local namespace - fqdn",
                 host: "example.ns2.svc.cluster.local.",
                 expect_answers: vec![a(n("example.ns2.svc.cluster.local."), ipv4("10.10.10.10"))],
+                ..Default::default()
+            },
+            Case {
+                name: "visibility: namespace-scoped svc in another namespace is forwarded",
+                host: "nslocal.ns2.svc.cluster.local.",
+                expect_authoritative: false, // Forwarded — not visible to the NS1 client.
+                expect_code: ResponseCode::NXDomain,
+                ..Default::default()
+            },
+            Case {
+                name: "visibility: namespace-scoped svc in the client namespace resolves",
+                host: "nslocalsame.ns1.svc.cluster.local.",
+                expect_answers: vec![a(
+                    n("nslocalsame.ns1.svc.cluster.local."),
+                    ipv4("10.10.10.241"),
+                )],
                 ..Default::default()
             },
             Case {
@@ -1722,6 +1742,16 @@ mod tests {
             xds_external_service("www.google.com", &[na(NW1, "1.1.1.1")]),
             xds_service("productpage", NS1, &[na(NW1, "9.9.9.9")]),
             xds_service("example", NS2, &[na(NW1, "10.10.10.10")]),
+            // Namespace-scoped services (ServiceEntry visibility). Client is in NS1: the NS2
+            // one must be invisible (forwarded), the NS1 one resolves normally.
+            with_visibility(
+                XdsVisibility::Namespace,
+                xds_service("nslocal", NS2, &[na(NW1, "10.10.10.240")]),
+            ),
+            with_visibility(
+                XdsVisibility::Namespace,
+                xds_service("nslocalsame", NS1, &[na(NW1, "10.10.10.241")]),
+            ),
             // Service with the same name in another namespace
             // This should not be used if the preferred service namespace is set
             xds_namespaced_external_service("everywhere.io", NS2, &[na(NW1, "10.10.10.110")]),
@@ -1877,6 +1907,11 @@ mod tests {
 
     fn with_canonical(canonical: bool, mut svc: XdsService) -> XdsService {
         svc.canonical = canonical;
+        svc
+    }
+
+    fn with_visibility(visibility: XdsVisibility, mut svc: XdsService) -> XdsService {
+        svc.visibility = visibility as i32;
         svc
     }
 

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -382,7 +382,18 @@ impl Store {
                     })
                     // Drop services not visible to the client's namespace. If this empties the
                     // candidate list, we forward upstream as if the service were not in the mesh.
-                    .filter(|service| service.visible_to(&client.namespace))
+                    .filter(|service| {
+                        let visible = service.visible_to(&client.namespace);
+                        if !visible {
+                            debug!(
+                                hostname = %service.hostname,
+                                service_namespace = %service.namespace,
+                                client_namespace = %client.namespace,
+                                "visibility filtering: service not visible to client namespace"
+                            );
+                        }
+                        visible
+                    })
                     // Get the service matching the client namespace. If no match exists, just
                     // return the first service.
                     .collect();

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -490,8 +490,10 @@ impl Inbound {
         })
     }
 
-    // Selects a service by hostname without the explicit knowledge of the namespace
-    // There is no explicit mapping from hostname to namespace (e.g. foo.com)
+    // A hostname has no namespace (e.g. foo.com), so resolve against the local workload's.
+    // Leak-safe even on inbound, where local_workload is the dst and not the client: the dst may
+    // only handle traffic for a service it can itself see, so long as the rule barring cross-namespace
+    // binding of NAMESPACE-visibility services holds.
     fn find_service_by_hostname(
         state: &DemandProxyState,
         local_workload: &Workload,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -490,10 +490,8 @@ impl Inbound {
         })
     }
 
-    // A hostname has no namespace (e.g. foo.com), so resolve against the local workload's.
-    // Leak-safe even on inbound, where local_workload is the dst and not the client: the dst may
-    // only handle traffic for a service it can itself see, so long as the rule barring cross-namespace
-    // binding of NAMESPACE-visibility services holds.
+    // Select a service by hostname, preferring one in the namespace of the given workload.
+    // The given workload may be in the perspective of outbound or inbound.
     fn find_service_by_hostname(
         state: &DemandProxyState,
         local_workload: &Workload,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -784,7 +784,7 @@ mod tests {
         rbac::Connection,
         state::{
             self, DemandProxyState, WorkloadInfo,
-            service::{Endpoint, EndpointSet, Service},
+            service::{Endpoint, EndpointSet, Service, Visibility},
             workload::{
                 ApplicationTunnel, GatewayAddress, HealthStatus, InboundProtocol, NetworkAddress,
                 NetworkMode, Workload, application_tunnel::Protocol as AppProtocol,
@@ -1025,6 +1025,7 @@ mod tests {
             load_balancer: None,
             ip_families: None,
             canonical: true,
+            visibility: Visibility::Public,
         });
 
         let workloads = vec![

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -458,7 +458,19 @@ impl ServiceStore {
         ns: Option<&Strng>,
     ) -> Option<Arc<Service>> {
         if let Some(services) = self.by_vip.get(vip) {
-            return Some(ServiceMatch::find_best_match(services.iter(), ns, None)?.clone());
+            // When a client namespace is provided, skip services not visible to it so the lookup
+            // misses and the caller falls through to passthrough (as if the VIP were not a mesh
+            // service). With no client namespace (e.g. the inbound path), don't enforce.
+            return Some(
+                ServiceMatch::find_best_match(
+                    services
+                        .iter()
+                        .filter(|s| ns.is_none_or(|n| s.visible_to(n))),
+                    ns,
+                    None,
+                )?
+                .clone(),
+            );
         }
         self.get_best_by_cidr_vip(vip, ns)
     }
@@ -474,6 +486,11 @@ impl ServiceStore {
         let mut best: Option<RankedMatch<'_>> = None;
         for (nc, svc) in &self.by_cidr_vip {
             if nc.network != vip.network || !nc.cidr.contains(&vip.address) {
+                continue;
+            }
+            // Skip services not visible to the client's namespace (see get_best_by_vip); only
+            // enforced when a client namespace is provided.
+            if ns.is_some_and(|n| !svc.visible_to(n)) {
                 continue;
             }
             let rank = CidrMatchRank {
@@ -950,6 +967,40 @@ mod tests {
         assert_eq!(store.num_services(), 0);
         assert!(store.get_by_vip(&nw(shared)).is_none());
         assert!(store.get_by_vip(&nw(only_b)).is_none());
+    }
+
+    #[test]
+    fn namespace_visibility_vip() {
+        let mut store = ServiceStore::default();
+        let ns_a: Strng = "ns-a".into();
+        let ns_b: Strng = "ns-b".into();
+
+        // Exact-VIP path: a NAMESPACE-scoped service.
+        let vip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut nslocal = make_service("nslocal", "ns-a", vec![vip], vec![]);
+        nslocal.visibility = Visibility::Namespace;
+        store.insert(nslocal);
+
+        // Same-namespace client resolves it.
+        assert_eq!(
+            store
+                .get_best_by_vip(&nw(vip), Some(&ns_a))
+                .unwrap()
+                .namespace,
+            ns_a,
+        );
+        // Out-of-namespace client sees no match -> caller falls through to passthrough.
+        assert!(store.get_best_by_vip(&nw(vip), Some(&ns_b)).is_none());
+        // No client namespace (e.g. inbound path) -> visibility is not enforced, so it resolves.
+        assert!(store.get_best_by_vip(&nw(vip), None).is_some());
+
+        // CIDR-VIP path: same behavior.
+        let cidr_vip = IpAddr::V4(Ipv4Addr::new(10, 1, 0, 5));
+        let mut cidr_svc = make_service("cidrlocal", "ns-a", vec![], vec![cidr("10.1.0.0/16")]);
+        cidr_svc.visibility = Visibility::Namespace;
+        store.insert(cidr_svc);
+        assert!(store.get_best_by_vip(&nw(cidr_vip), Some(&ns_a)).is_some());
+        assert!(store.get_best_by_vip(&nw(cidr_vip), Some(&ns_b)).is_none());
     }
 
     #[test]

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -19,7 +19,7 @@ use serde::{Deserializer, Serializer};
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
-use tracing::trace;
+use tracing::{debug, trace};
 
 use xds::istio::workload::Service as XdsService;
 
@@ -463,9 +463,19 @@ impl ServiceStore {
             // service). With no client namespace (e.g. the inbound path), don't enforce.
             return Some(
                 ServiceMatch::find_best_match(
-                    services
-                        .iter()
-                        .filter(|s| ns.is_none_or(|n| s.visible_to(n))),
+                    services.iter().filter(|s| {
+                        let visible = ns.is_none_or(|n| s.visible_to(n));
+                        if !visible {
+                            debug!(
+                                hostname = %s.hostname,
+                                service_namespace = %s.namespace,
+                                client_namespace = ns.map(Strng::as_str).unwrap_or(""),
+                                vip = %vip.address,
+                                "visibility filtering: service not visible to client namespace"
+                            );
+                        }
+                        visible
+                    }),
                     ns,
                     None,
                 )?
@@ -491,6 +501,13 @@ impl ServiceStore {
             // Skip services not visible to the client's namespace (see get_best_by_vip); only
             // enforced when a client namespace is provided.
             if ns.is_some_and(|n| !svc.visible_to(n)) {
+                debug!(
+                    hostname = %svc.hostname,
+                    service_namespace = %svc.namespace,
+                    client_namespace = ns.map(Strng::as_str).unwrap_or(""),
+                    vip = %vip.address,
+                    "visibility filtering: service not visible to client namespace"
+                );
                 continue;
             }
             let rank = CidrMatchRank {

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -68,6 +68,11 @@ pub struct Service {
 
     #[serde(default)]
     pub canonical: bool,
+
+    // Always rendered (no skip_serializing_if) so a service's visibility is visible in a
+    // ztunnel config dump even when it is the default PUBLIC.
+    #[serde(default)]
+    pub visibility: Visibility,
 }
 
 /// WeightedWaypoint is a candidate waypoint plus its relative selection weight, used to shift a
@@ -247,6 +252,35 @@ impl IpFamily {
     }
 }
 
+/// Visibility controls which clients can resolve and route to a service.
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub enum Visibility {
+    /// Visible to every client the control plane serves (default / legacy behavior).
+    #[default]
+    Public,
+    /// Visible only to clients in the same namespace as the service.
+    Namespace,
+}
+
+impl From<xds::istio::workload::service::Visibility> for Visibility {
+    fn from(value: xds::istio::workload::service::Visibility) -> Self {
+        use xds::istio::workload::service::Visibility as XdsVisibility;
+        match value {
+            XdsVisibility::Public => Visibility::Public,
+            XdsVisibility::Namespace => Visibility::Namespace,
+        }
+    }
+}
+
+impl Service {
+    /// visible_to reports whether a client in the given namespace may resolve and route to
+    /// this service. Namespace-scoped services are only visible within their own namespace;
+    /// all others are visible everywhere the control plane serves.
+    pub fn visible_to(&self, client_namespace: &Strng) -> bool {
+        self.visibility != Visibility::Namespace || &self.namespace == client_namespace
+    }
+}
+
 impl Service {
     pub fn namespaced_hostname(&self) -> NamespacedHostname {
         NamespacedHostname {
@@ -375,6 +409,10 @@ impl TryFrom<&XdsService> for Service {
             load_balancer: lb,
             ip_families,
             canonical: s.canonical,
+            // Unknown values fall back to PUBLIC (fail open) rather than dropping the Service.
+            visibility: xds::istio::workload::service::Visibility::try_from(s.visibility)
+                .unwrap_or_default()
+                .into(),
         };
         Ok(svc)
     }
@@ -817,6 +855,7 @@ mod tests {
             load_balancer: None,
             ip_families: None,
             canonical: false,
+            visibility: Visibility::Public,
         }
     }
 
@@ -1153,6 +1192,7 @@ mod tests {
             load_balancer: None,
             ip_families: None,
             canonical: false,
+            visibility: Visibility::Public,
         };
         store.insert(svc);
 

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -458,29 +458,30 @@ impl ServiceStore {
         ns: Option<&Strng>,
     ) -> Option<Arc<Service>> {
         if let Some(services) = self.by_vip.get(vip) {
-            // When a client namespace is provided, skip services not visible to it so the lookup
-            // misses and the caller falls through to passthrough (as if the VIP were not a mesh
-            // service). With no client namespace (e.g. the inbound path), don't enforce.
-            return Some(
-                ServiceMatch::find_best_match(
-                    services.iter().filter(|s| {
-                        let visible = ns.is_none_or(|n| s.visible_to(n));
-                        if !visible {
-                            debug!(
-                                hostname = %s.hostname,
-                                service_namespace = %s.namespace,
-                                client_namespace = ns.map(Strng::as_str).unwrap_or(""),
-                                vip = %vip.address,
-                                "visibility filtering: service not visible to client namespace"
-                            );
-                        }
-                        visible
-                    }),
-                    ns,
-                    None,
-                )?
-                .clone(),
-            );
+            // When a client namespace is provided, skip services not visible to it. If a visible
+            // match remains, return it; if the filter empties the set (or nothing matches), fall
+            // through to the CIDR lookup rather than returning None — a VIP whose services are all
+            // hidden should behave as if it were not an exact-VIP mesh service, and a CIDR VIP may
+            // still match. With no client namespace (e.g. the inbound path), don't enforce.
+            if let Some(m) = ServiceMatch::find_best_match(
+                services.iter().filter(|s| {
+                    let visible = ns.is_none_or(|n| s.visible_to(n));
+                    if !visible {
+                        debug!(
+                            hostname = %s.hostname,
+                            service_namespace = %s.namespace,
+                            client_namespace = ns.map(Strng::as_str).unwrap_or(""),
+                            vip = %vip.address,
+                            "visibility filtering: service not visible to client namespace"
+                        );
+                    }
+                    visible
+                }),
+                ns,
+                None,
+            ) {
+                return Some(m.clone());
+            }
         }
         self.get_best_by_cidr_vip(vip, ns)
     }
@@ -538,7 +539,30 @@ impl ServiceStore {
     // Next, a Service marked `canonical` is prerferred.
     pub fn get_best_by_host(&self, hostname: &Strng, ns: Option<&Strng>) -> Option<Arc<Service>> {
         let services = self.by_host.get(hostname)?;
-        Some(ServiceMatch::find_best_match(services.iter(), ns, None)?.clone())
+        // When a client namespace is provided, skip services not visible to it so a NAMESPACE-scoped
+        // service is not resolvable by hostname from another namespace. The namespace also ranks the
+        // match (find_best_match) — see its doc for the general inbound-selection caveat when several
+        // services share a key (e.g. multiple PUBLIC SEs on one waypoint). With no client namespace,
+        // don't enforce.
+        Some(
+            ServiceMatch::find_best_match(
+                services.iter().filter(|s| {
+                    let visible = ns.is_none_or(|n| s.visible_to(n));
+                    if !visible {
+                        debug!(
+                            hostname = %s.hostname,
+                            service_namespace = %s.namespace,
+                            client_namespace = ns.map(Strng::as_str).unwrap_or(""),
+                            "visibility filtering: service not visible to client namespace"
+                        );
+                    }
+                    visible
+                }),
+                ns,
+                None,
+            )?
+            .clone(),
+        )
     }
 
     pub fn get_by_workload(&self, workload: &Workload) -> Vec<Arc<Service>> {
@@ -824,6 +848,22 @@ impl<'a> From<ServiceMatch<'a>> for Option<&'a Arc<Service>> {
 impl<'a> ServiceMatch<'a> {
     /// Finds the best matching service from an iterator using fold_while.
     /// Short-circuits on Namespace match - the best possible result.
+    /// Picks the best service among candidates sharing a key (VIP, CIDR-VIP, or hostname). Ranking:
+    /// a service in `client_ns` first, then a `canonical` service, then one in `preferred_namespace`,
+    /// then the first seen.
+    ///
+    /// `client_ns` should be the client's namespace, and outbound callers pass it. Inbound callers do
+    /// not: the hostname path passes the serving workload's (dst) namespace and the VIP path passes
+    /// None — neither is the client's, and neither has an intrinsic relation to it. The selection
+    /// matches what the client resolved only when the key is unique or the service is co-located with
+    /// the dst (for application workloads, this is ~invariant); a waypoint may front services in other
+    /// namespaces, so neither holds there and the wrong service's policy / port mapping can be
+    /// applied. In practice this bites only sandwiched third-party waypoints, where ztunnel terminates
+    /// inbound HBONE in front of the proxy: the Istio (Envoy) waypoint terminates HBONE itself, so its
+    /// analogous misselection is an Envoy-config concern rather than this path. The client's namespace
+    /// is available on inbound from the mTLS peer identity (`conn.src_identity`), so these paths could
+    /// pass it instead; inbound passthrough has no identity and cannot (waypoints arguably should not
+    /// accept passthrough).
     pub fn find_best_match(
         mut services: impl Iterator<Item = &'a Arc<Service>>,
         client_ns: Option<&Strng>,
@@ -1018,6 +1058,111 @@ mod tests {
         store.insert(cidr_svc);
         assert!(store.get_best_by_vip(&nw(cidr_vip), Some(&ns_a)).is_some());
         assert!(store.get_best_by_vip(&nw(cidr_vip), Some(&ns_b)).is_none());
+    }
+
+    #[test]
+    fn visibility_filtered_exact_vip_falls_through_to_cidr() {
+        // Regression: when a VIP is present in by_vip but its only service is filtered out by
+        // visibility, the lookup must fall through to the CIDR-VIP path rather than short-circuiting
+        // to None. (A `?` on the exact-VIP match previously returned None and skipped CIDR.)
+        let mut store = ServiceStore::default();
+        let ns_a: Strng = "ns-a".into();
+        let ns_b: Strng = "ns-b".into();
+        let vip = IpAddr::V4(Ipv4Addr::new(10, 2, 0, 5));
+
+        // Exact-VIP service, NAMESPACE-scoped to ns-a.
+        let mut exact = make_service("exactlocal", "ns-a", vec![vip], vec![]);
+        exact.visibility = Visibility::Namespace;
+        store.insert(exact);
+
+        // A PUBLIC service in ns-b whose CIDR-VIP covers the same address.
+        store.insert(make_service(
+            "cidrpublic",
+            "ns-b",
+            vec![],
+            vec![cidr("10.2.0.0/16")],
+        ));
+
+        // Same-namespace client: the visible exact-VIP match wins (checked before CIDR).
+        assert_eq!(
+            store
+                .get_best_by_vip(&nw(vip), Some(&ns_a))
+                .unwrap()
+                .namespace,
+            ns_a,
+        );
+
+        // Cross-namespace client: the exact-VIP service is filtered out, so the lookup must fall
+        // through to the CIDR-VIP and return the PUBLIC service instead of None.
+        assert_eq!(
+            store
+                .get_best_by_vip(&nw(vip), Some(&ns_b))
+                .expect("cross-ns client should fall through to the CIDR-VIP match, not None")
+                .namespace,
+            ns_b,
+        );
+    }
+
+    #[test]
+    fn namespace_visibility_host() {
+        let mut store = ServiceStore::default();
+        let ns_a: Strng = "ns-a".into();
+        let ns_b: Strng = "ns-b".into();
+
+        // NAMESPACE-scoped service, resolvable by hostname.
+        let mut nslocal = make_service("hostlocal", "ns-a", vec![ip(10, 3, 0, 1)], vec![]);
+        nslocal.visibility = Visibility::Namespace;
+        let ns_host = nslocal.hostname.clone();
+        store.insert(nslocal);
+
+        // Same-namespace client resolves it.
+        assert_eq!(
+            store
+                .get_best_by_host(&ns_host, Some(&ns_a))
+                .unwrap()
+                .namespace,
+            ns_a,
+        );
+        // Out-of-namespace client: not visible -> no match (caller gets NoHostname).
+        assert!(store.get_best_by_host(&ns_host, Some(&ns_b)).is_none());
+        // No client namespace (e.g. no verified mTLS peer) -> visibility not enforced.
+        assert!(store.get_best_by_host(&ns_host, None).is_some());
+
+        // A PUBLIC service is resolvable by hostname from any namespace.
+        let pub_svc = make_service("hostpublic", "ns-a", vec![ip(10, 3, 0, 2)], vec![]);
+        let pub_host = pub_svc.hostname.clone();
+        store.insert(pub_svc);
+        assert!(store.get_best_by_host(&pub_host, Some(&ns_b)).is_some());
+
+        // Two services share one hostname across namespaces (SEs may define the same host): a
+        // NAMESPACE service in ns-a and a PUBLIC service in ns-b.
+        let shared_host: Strng = "shared.example.com".into();
+        let mut shared_ns = make_service("sharedlocal", "ns-a", vec![ip(10, 3, 0, 3)], vec![]);
+        shared_ns.hostname = shared_host.clone();
+        shared_ns.visibility = Visibility::Namespace;
+        store.insert(shared_ns);
+        let mut shared_pub = make_service("sharedpublic", "ns-b", vec![ip(10, 3, 0, 4)], vec![]);
+        shared_pub.hostname = shared_host.clone();
+        store.insert(shared_pub);
+
+        // A client in a third namespace: the NAMESPACE candidate is filtered out, so the lookup
+        // returns the surviving PUBLIC service rather than None or the invisible one.
+        let ns_c: Strng = "ns-c".into();
+        assert_eq!(
+            store
+                .get_best_by_host(&shared_host, Some(&ns_c))
+                .expect("cross-ns client should resolve the visible PUBLIC service, not None")
+                .namespace,
+            ns_b,
+        );
+        // A client in ns-a still gets its co-located NAMESPACE service (client_ns ranks first).
+        assert_eq!(
+            store
+                .get_best_by_host(&shared_host, Some(&ns_a))
+                .unwrap()
+                .namespace,
+            ns_a,
+        );
     }
 
     #[test]

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -448,9 +448,10 @@ impl ServiceStore {
     }
 
     /// Returns the "best" [Service] matching the given VIP.
-    /// If a namespace is provided, a Service from that namespace is preferred.
+    /// If a namespace is provided, filter for visibility.
+    /// Next, prefer a Service from that namespace.
     /// Next, a Service marked `canonical` is preferred.
-    /// Falls back to CIDR matching if no exact VIP match: namespace match wins
+    /// Fall back to CIDR matching if no exact VIP match: namespace match wins
     /// over specificity, then longest-prefix, then canonical.
     pub fn get_best_by_vip(
         &self,
@@ -458,11 +459,7 @@ impl ServiceStore {
         ns: Option<&Strng>,
     ) -> Option<Arc<Service>> {
         if let Some(services) = self.by_vip.get(vip) {
-            // When a client namespace is provided, skip services not visible to it. If a visible
-            // match remains, return it; if the filter empties the set (or nothing matches), fall
-            // through to the CIDR lookup rather than returning None — a VIP whose services are all
-            // hidden should behave as if it were not an exact-VIP mesh service, and a CIDR VIP may
-            // still match. With no client namespace (e.g. the inbound path), don't enforce.
+            // only return a service that is visible to the passed in workload's namespace
             if let Some(m) = ServiceMatch::find_best_match(
                 services.iter().filter(|s| {
                     let visible = ns.is_none_or(|n| s.visible_to(n));
@@ -541,9 +538,7 @@ impl ServiceStore {
         let services = self.by_host.get(hostname)?;
         // When a client namespace is provided, skip services not visible to it so a NAMESPACE-scoped
         // service is not resolvable by hostname from another namespace. The namespace also ranks the
-        // match (find_best_match) — see its doc for the general inbound-selection caveat when several
-        // services share a key (e.g. multiple PUBLIC SEs on one waypoint). With no client namespace,
-        // don't enforce.
+        // match (find_best_match).
         Some(
             ServiceMatch::find_best_match(
                 services.iter().filter(|s| {
@@ -851,19 +846,6 @@ impl<'a> ServiceMatch<'a> {
     /// Picks the best service among candidates sharing a key (VIP, CIDR-VIP, or hostname). Ranking:
     /// a service in `client_ns` first, then a `canonical` service, then one in `preferred_namespace`,
     /// then the first seen.
-    ///
-    /// `client_ns` should be the client's namespace, and outbound callers pass it. Inbound callers do
-    /// not: the hostname path passes the serving workload's (dst) namespace and the VIP path passes
-    /// None — neither is the client's, and neither has an intrinsic relation to it. The selection
-    /// matches what the client resolved only when the key is unique or the service is co-located with
-    /// the dst (for application workloads, this is ~invariant); a waypoint may front services in other
-    /// namespaces, so neither holds there and the wrong service's policy / port mapping can be
-    /// applied. In practice this bites only sandwiched third-party waypoints, where ztunnel terminates
-    /// inbound HBONE in front of the proxy: the Istio (Envoy) waypoint terminates HBONE itself, so its
-    /// analogous misselection is an Envoy-config concern rather than this path. The client's namespace
-    /// is available on inbound from the mTLS peer identity (`conn.src_identity`), so these paths could
-    /// pass it instead; inbound passthrough has no identity and cannot (waypoints arguably should not
-    /// accept passthrough).
     pub fn find_best_match(
         mut services: impl Iterator<Item = &'a Arc<Service>>,
         client_ns: Option<&Strng>,

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -1160,6 +1160,7 @@ mod tests {
                     ip_families: 0,
                     extensions: Default::default(),
                     canonical: true,
+                    visibility: 0,
                 },
             )
             .unwrap();
@@ -1198,6 +1199,7 @@ mod tests {
                     ip_families: 0,
                     extensions: Default::default(),
                     canonical: true,
+                    visibility: 0,
                 },
             )
             .unwrap();
@@ -1261,6 +1263,7 @@ mod tests {
                     ip_families: 0,
                     extensions: Default::default(),
                     canonical: true,
+                    visibility: 0,
                 },
             )
             .unwrap();
@@ -1581,6 +1584,7 @@ mod tests {
                     ip_families: 0,
                     extensions: Default::default(),
                     canonical: true,
+                    visibility: 0,
                 },
             )
             .unwrap();
@@ -1611,6 +1615,7 @@ mod tests {
                     ip_families: 0,
                     extensions: Default::default(),
                     canonical: true,
+                    visibility: 0,
                 },
             )
             .unwrap();
@@ -1665,6 +1670,7 @@ mod tests {
             ip_families: 0,
             extensions: Default::default(),
             canonical: true,
+            visibility: 0,
         };
         updater
             .insert_service(
@@ -1689,6 +1695,7 @@ mod tests {
                     ip_families: 0,
                     extensions: Default::default(),
                     canonical: true,
+                    visibility: 0,
                 },
             )
             .unwrap();

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -14,7 +14,7 @@
 
 use crate::config::ConfigSource;
 use crate::config::{self, RootCert};
-use crate::state::service::{Endpoint, EndpointSet, Service};
+use crate::state::service::{Endpoint, EndpointSet, Service, Visibility};
 use crate::state::workload::InboundProtocol::{HBONE, TCP};
 use crate::state::workload::{
     GatewayAddress, NamespacedHostname, NetworkAddress, Workload, gatewayaddress,
@@ -205,6 +205,7 @@ pub fn mock_default_service() -> Service {
         load_balancer: None,
         ip_families: None,
         canonical: true,
+        visibility: Visibility::Public,
     }
 }
 
@@ -302,6 +303,7 @@ fn test_custom_svc(
         load_balancer: None,
         ip_families: None,
         canonical: true,
+        visibility: Visibility::Public,
     })
 }
 

--- a/src/test_helpers/linux.rs
+++ b/src/test_helpers/linux.rs
@@ -14,7 +14,7 @@
 
 use crate::config::{ConfigSource, ProxyMode};
 use crate::rbac::Authorization;
-use crate::state::service::{Endpoint, Service};
+use crate::state::service::{Endpoint, Service, Visibility};
 use crate::state::workload::{HealthStatus, Workload, gatewayaddress};
 use crate::strng::Strng;
 use crate::test_helpers::app::TestApp;
@@ -411,6 +411,7 @@ impl<'a> TestServiceBuilder<'a> {
                 load_balancer: None,
                 ip_families: None,
                 canonical: true,
+                visibility: Visibility::Public,
             },
             manager,
         }


### PR DESCRIPTION
This is the ztunnel implementation of the [Safer ServiceEntry](https://docs.google.com/document/d/17CLPeo1Jzi283GBAutqhXLTa1LZxDili5EIhllmbPn0/edit?usp=sharing) proposal.

The behavior is about filtering during matching and name resolution. A client which has no visibility for a specific WDS service is expected to behave as if the service doesn't exist. There should be no "shadowing" where the existence of a service which isn't directly visible to a client influences how that client's traffic is handled (a synthetic NXDOMAIN introduced when the best resolution of a host is a "not visible" service for instance).

Telemetry at this point is simple DEBUG logging, which emits a message per-service which is not visible at the point of filtering. This may be quite chatty, in an environment where dozens of teams have a namespace-visible `github.com` service entry the result would be many unique services being filtered as "not visible". Likely suitable enough at the debug level though.

An istio/istio PR will be x-linked once filed. This should however be wire and behavior compatible with older versions of istio. When visibility isn't present in the WDS message, the service is "public" visibility preserving the previous behavior.