### PR TITLE
improved wds full push handling

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use bytes::Bytes;
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use profiler::{Output, PProfProfiler};
 use prometheus_client::registry::Registry;
@@ -27,13 +27,15 @@ use tokio::runtime::Runtime;
 use ztunnel::state::workload::{NetworkAddress, Workload};
 use ztunnel::state::{DemandProxyState, ProxyState, ServiceResolutionMode};
 use ztunnel::strng;
-use ztunnel::xds::ProxyStateUpdateMutator;
+use ztunnel::xds::istio::workload::Address as XdsAddress;
 use ztunnel::xds::istio::workload::LoadBalancing;
 use ztunnel::xds::istio::workload::Port;
 use ztunnel::xds::istio::workload::Service as XdsService;
 use ztunnel::xds::istio::workload::Workload as XdsWorkload;
+use ztunnel::xds::istio::workload::address::Type as XdsAddressType;
 use ztunnel::xds::istio::workload::load_balancing;
 use ztunnel::xds::istio::workload::{NetworkAddress as XdsNetworkAddress, PortList};
+use ztunnel::xds::{Handler, ProxyStateUpdateMutator, ProxyStateUpdater, XdsResource, XdsUpdate};
 
 pub fn xds(c: &mut Criterion) {
     use ztunnel::xds::istio::workload::Port;
@@ -290,12 +292,185 @@ fn build_cidr_vip_state(n: usize) -> (Arc<RwLock<ProxyState>>, NetworkAddress, N
     (Arc::new(RwLock::new(state)), miss, hit)
 }
 
+fn one_service(hostname: &str, addr: [u8; 4]) -> XdsService {
+    XdsService {
+        hostname: hostname.to_string(),
+        addresses: vec![XdsNetworkAddress {
+            network: "".to_string(),
+            address: addr.to_vec(),
+            length: None,
+        }],
+        ports: vec![Port {
+            service_port: 80,
+            target_port: 0,
+        }],
+        ..Default::default()
+    }
+}
+
+fn build_workloads(n: usize, svc_for: impl Fn(usize) -> Option<String>) -> Vec<XdsWorkload> {
+    (0..n)
+        .map(|i| {
+            let services = match svc_for(i) {
+                Some(h) => std::collections::HashMap::from([(
+                    h,
+                    PortList {
+                        ports: vec![Port {
+                            service_port: 80,
+                            target_port: 1234,
+                        }],
+                    },
+                )]),
+                None => std::collections::HashMap::new(),
+            };
+            XdsWorkload {
+                uid: format!("cluster1//v1/Pod/default/{i}"),
+                addresses: vec![Bytes::copy_from_slice(&[
+                    127,
+                    0,
+                    (i / 255) as u8,
+                    (i % 255) as u8,
+                ])],
+                services,
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+fn wl_update(w: XdsWorkload) -> XdsUpdate<XdsAddress> {
+    XdsUpdate::Update(XdsResource {
+        name: w.uid.as_str().into(),
+        resource: XdsAddress {
+            r#type: Some(XdsAddressType::Workload(w)),
+        },
+    })
+}
+
+fn svc_update(s: XdsService) -> XdsUpdate<XdsAddress> {
+    XdsUpdate::Update(XdsResource {
+        name: s.hostname.as_str().into(),
+        resource: XdsAddress {
+            r#type: Some(XdsAddressType::Service(s)),
+        },
+    })
+}
+
+// Measures the cost of applying a batch of workloads under the (simulated) write
+// lock, varying how endpoints are distributed across services:
+//   - shared-service:   all N workloads are endpoints of ONE service. Each
+//                        insert_endpoint deep-clones the service's whole
+//                        EndpointSet, so building the service is O(N^2).
+//   - distinct-service: each workload is the sole endpoint of its own service.
+//                        Linear control.
+//   - no-service:       workloads belong to no service; the endpoint path is
+//                        never hit. Isolates conversion + workload-store cost.
+// Throughput is set per-element, so a quadratic shared-service path shows up as a
+// per-insert time that rises with N across the sweep.
+pub fn endpoint_insert(c: &mut Criterion) {
+    let mut g = c.benchmark_group("endpoint_insert");
+    g.measurement_time(Duration::from_secs(3));
+    g.sample_size(10);
+
+    for &n in &[250usize, 1000, 4000] {
+        g.throughput(Throughput::Elements(n as u64));
+
+        let shared = build_workloads(n, |_| Some("/example.com".to_string()));
+        g.bench_function(format!("shared-service/{n}"), |b| {
+            b.iter_batched(
+                || {
+                    let mut state = ProxyState::new(None);
+                    let updater = ProxyStateUpdateMutator::new_no_fetch();
+                    updater
+                        .insert_service(&mut state, one_service("example.com", [127, 0, 0, 3]))
+                        .unwrap();
+                    (state, updater, shared.clone())
+                },
+                |(mut state, updater, wls)| {
+                    for w in wls {
+                        updater.insert_workload(&mut state, w).unwrap();
+                    }
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        let distinct = build_workloads(n, |i| Some(format!("/svc{i}.example.com")));
+        g.bench_function(format!("distinct-service/{n}"), |b| {
+            b.iter_batched(
+                || {
+                    let mut state = ProxyState::new(None);
+                    let updater = ProxyStateUpdateMutator::new_no_fetch();
+                    for i in 0..n {
+                        updater
+                            .insert_service(
+                                &mut state,
+                                one_service(
+                                    &format!("svc{i}.example.com"),
+                                    [127, 1, (i / 255) as u8, (i % 255) as u8],
+                                ),
+                            )
+                            .unwrap();
+                    }
+                    (state, updater, distinct.clone())
+                },
+                |(mut state, updater, wls)| {
+                    for w in wls {
+                        updater.insert_workload(&mut state, w).unwrap();
+                    }
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        let bare = build_workloads(n, |_| None);
+        g.bench_function(format!("no-service/{n}"), |b| {
+            b.iter_batched(
+                || {
+                    let state = ProxyState::new(None);
+                    let updater = ProxyStateUpdateMutator::new_no_fetch();
+                    (state, updater, bare.clone())
+                },
+                |(mut state, updater, wls)| {
+                    for w in wls {
+                        updater.insert_workload(&mut state, w).unwrap();
+                    }
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        // batched-service: same N endpoints on ONE service, but applied as a
+        // single xDS push through Handler<XdsAddress>. The accumulator coalesces
+        // them into one clone + reindex, so this should track the linear
+        // distinct-service curve rather than shared-service's O(N^2).
+        g.bench_function(format!("batched-service/{n}"), |b| {
+            b.iter_batched(
+                || {
+                    let state = Arc::new(RwLock::new(ProxyState::new(None)));
+                    let updater = ProxyStateUpdater::new_no_fetch(state.clone());
+                    let mut batch: Vec<XdsUpdate<XdsAddress>> = Vec::with_capacity(n + 1);
+                    batch.push(svc_update(one_service("example.com", [127, 0, 0, 3])));
+                    batch.extend(shared.iter().cloned().map(wl_update));
+                    (updater, batch)
+                },
+                |(updater, batch)| {
+                    let handler = &updater as &dyn Handler<XdsAddress>;
+                    handler.handle(Box::new(&mut batch.into_iter())).unwrap();
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    g.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default()
         .with_profiler(PProfProfiler::new(100, Output::Protobuf))
         .warm_up_time(Duration::from_millis(1));
-    targets = xds, load_balance, vip_match
+    targets = xds, load_balance, vip_match, endpoint_insert
 }
 
 criterion_main!(benches);

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -104,6 +104,20 @@ impl EndpointSet {
         self.inner.insert(k, Arc::new(v));
     }
 
+    pub fn extend(&mut self, eps: impl IntoIterator<Item = (Strng, Endpoint)>) {
+        for (k, v) in eps {
+            self.inner.insert(k, Arc::new(v));
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
     pub fn contains(&self, key: &Strng) -> bool {
         self.inner.contains_key(key)
     }
@@ -112,8 +126,8 @@ impl EndpointSet {
         self.inner.get(key).map(Arc::as_ref)
     }
 
-    pub fn remove(&mut self, key: &Strng) {
-        self.inner.remove(key);
+    pub fn remove(&mut self, key: &Strng) -> bool {
+        self.inner.remove(key).is_some()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Endpoint> {
@@ -369,6 +383,12 @@ pub struct ServiceStore {
     /// service for a given hostname. However, `ServiceEntry` allows hostnames to be overridden
     /// on a per-namespace basis.
     pub(super) by_host: HashMap<Strng, Vec<Arc<Service>>>,
+
+    /// Counts endpoint-only reindexes (one per service per [Self::apply_endpoints]
+    /// that mutates an existing service). Used by tests to assert that a push
+    /// clones each service at most once, not once per endpoint.
+    #[cfg(test)]
+    endpoint_reindexes: usize,
 }
 
 impl ServiceStore {
@@ -471,62 +491,61 @@ impl ServiceStore {
     }
 
     /// Adds an endpoint for the service VIP.
-    pub fn insert_endpoint(&mut self, service_name: NamespacedHostname, ep: Endpoint) {
-        let ep_uid = ep.workload_uid.clone();
-        if let Some(svc) = self.get_by_namespaced_host(&service_name) {
-            // We may or may not accept the endpoint based on it's health
-            if !svc.should_include_endpoint(ep.status) {
-                trace!(
-                    "service doesn't accept pod with status {:?}, skip",
-                    ep.status
-                );
-                return;
-            }
+    /// Applies a batch of endpoint upserts and removals to a single service with
+    /// a single clone + single reindex (or a single staged-map update when the
+    /// service has not been received yet). The xDS push handler uses this to
+    /// coalesce all of a service's endpoint changes in one push, avoiding the
+    /// O(E²) cost of cloning the service's whole [EndpointSet] per endpoint.
+    ///
+    /// Removals are applied before upserts, so a uid present in both (a
+    /// re-inserted workload) reflects the upsert — or, if the upsert is
+    /// health-filtered out, is correctly left removed.
+    pub fn apply_endpoints(
+        &mut self,
+        service_name: &NamespacedHostname,
+        upserts: HashMap<Strng, Endpoint>,
+        removals: HashSet<Strng>,
+    ) {
+        if let Some(svc) = self.get_by_namespaced_host(service_name) {
             let mut svc = Arc::unwrap_or_clone(svc);
+            let mut changed = false;
 
-            // Clone the service and add the endpoint.
-            svc.endpoints.insert(ep_uid, ep);
+            for uid in &removals {
+                changed |= svc.endpoints.remove(uid);
+            }
 
-            // Update the service.
-            self.insert_endpoint_update(svc);
+            // We may or may not accept an endpoint based on its health.
+            let accepted: Vec<(Strng, Endpoint)> = upserts
+                .into_iter()
+                .filter(|(_, ep)| svc.should_include_endpoint(ep.status))
+                .collect();
+            if !accepted.is_empty() {
+                changed = true;
+                svc.endpoints.extend(accepted);
+            }
+
+            // Single reindex for the whole batch.
+            if changed {
+                self.insert_endpoint_update(svc);
+            }
         } else {
             // We received workload endpoints, but don't have the Service yet.
-            // This can happen due to ordering issues.
-            trace!("pod has service {}, but service not found", service_name);
-
-            // Add a staged entry. This will be added to the service once we receive it.
-            self.staged_services
-                .entry(service_name.clone())
-                .or_default()
-                .insert(ep_uid, ep.clone());
-        }
-    }
-
-    /// Removes entries for the given endpoint address.
-    pub fn remove_endpoint(&mut self, prev_workload: &Workload) {
-        let mut services_to_update = HashSet::new();
-        let workload_uid = &prev_workload.uid;
-        for svc in prev_workload.services.iter() {
-            // Remove the endpoint from the staged services.
-            self.staged_services
-                .entry(svc.clone())
-                .or_default()
-                .remove(workload_uid);
-            if self.staged_services[svc].is_empty() {
-                self.staged_services.remove(svc);
+            // This can happen due to ordering issues. Stage them; they are
+            // health-filtered at flush time (see insert_internal). Apply removals
+            // before upserts, matching the present-service path.
+            if !removals.is_empty()
+                && let Some(staged) = self.staged_services.get_mut(service_name)
+            {
+                staged.retain(|uid, _| !removals.contains(uid));
+                if staged.is_empty() {
+                    self.staged_services.remove(service_name);
+                }
             }
-
-            services_to_update.insert(svc.clone());
-        }
-
-        // Now remove the endpoint from all Services.
-        for svc in &services_to_update {
-            if let Some(svc) = self.get_by_namespaced_host(svc) {
-                let mut svc = Arc::unwrap_or_clone(svc);
-                svc.endpoints.remove(workload_uid);
-
-                // Update the service.
-                self.insert_endpoint_update(svc);
+            if !upserts.is_empty() {
+                self.staged_services
+                    .entry(service_name.clone())
+                    .or_default()
+                    .extend(upserts);
             }
         }
     }
@@ -542,6 +561,10 @@ impl ServiceStore {
     }
 
     fn insert_internal(&mut self, mut service: Service, endpoint_update_only: bool) {
+        #[cfg(test)]
+        if endpoint_update_only {
+            self.endpoint_reindexes += 1;
+        }
         let namespaced_hostname = service.namespaced_hostname();
         // If we're replacing an existing service, remove the old one from all data structures.
         if !endpoint_update_only {
@@ -674,6 +697,11 @@ impl ServiceStore {
     #[cfg(test)]
     pub fn num_staged_services(&self) -> usize {
         self.staged_services.len()
+    }
+
+    #[cfg(test)]
+    pub fn endpoint_reindexes(&self) -> usize {
+        self.endpoint_reindexes
     }
 }
 

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -265,6 +265,41 @@ impl Service {
                 .map(|lb| lb.health_policy == LoadBalancerHealthPolicy::AllowAll)
                 .unwrap_or(false)
     }
+
+    /// Compares two services ignoring `endpoints`. Endpoints are derived from
+    /// workloads (not carried on the XDS Service), so a freshly-converted Service
+    /// always has empty endpoints; this compares only the service's own config to
+    /// detect whether an incoming update actually changes anything.
+    ///
+    /// The destructure makes adding a field a compile error, forcing a decision
+    /// about whether it belongs in this comparison.
+    pub fn config_eq(&self, other: &Service) -> bool {
+        let Service {
+            name,
+            namespace,
+            hostname,
+            vips,
+            cidr_vips,
+            ports,
+            endpoints: _,
+            subject_alt_names,
+            waypoint,
+            load_balancer,
+            ip_families,
+            canonical,
+        } = self;
+        *name == other.name
+            && *namespace == other.namespace
+            && *hostname == other.hostname
+            && *vips == other.vips
+            && *cidr_vips == other.cidr_vips
+            && *ports == other.ports
+            && *subject_alt_names == other.subject_alt_names
+            && *waypoint == other.waypoint
+            && *load_balancer == other.load_balancer
+            && *ip_families == other.ip_families
+            && *canonical == other.canonical
+    }
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize)]

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -508,6 +508,10 @@ impl ServiceStore {
     /// # Arguments
     ///
     /// * `host` - the namespaced hostname.
+    pub fn is_empty(&self) -> bool {
+        self.by_host.is_empty()
+    }
+
     pub fn get_by_namespaced_host(&self, host: &NamespacedHostname) -> Option<Arc<Service>> {
         // Get the list of services that match the hostname. Typically there will only be one, but
         // ServiceEntry allows configuring arbitrary hostnames on a per-namespace basis.

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -900,6 +900,10 @@ impl WorkloadStore {
         self.by_uid.get(uid).cloned()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.by_uid.is_empty()
+    }
+
     // was_last_identity_on_node is a specialized function to help determine if we should clear a certificate.
     // It is called when a workload is removed, with the node and identity of the workload
     pub fn was_last_identity_on_node(&self, node_name: &Strng, identity: &Identity) -> bool {

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -386,11 +386,9 @@ impl Handler<XdsWorkload> for ProxyStateUpdater {
         &self,
         updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsWorkload>>>,
     ) -> Result<(), Vec<RejectedConfig>> {
-        // Phase 1: convert every resource off-lock. A malformed resource only
-        // rejects itself and doesn't abort the batch.
-        let mut prepared = Vec::new();
+        let mut batch = PreparedBatch::default();
         let result = handle_single_resource(updates, |res: XdsUpdate<XdsWorkload>| {
-            prepared.push(match res {
+            batch.push(match res {
                 XdsUpdate::Update(w) => {
                     PreparedUpdate::Workload(PreparedWorkload::try_from_xds(w.resource)?)
                 }
@@ -398,7 +396,15 @@ impl Handler<XdsWorkload> for ProxyStateUpdater {
             });
             Ok(())
         });
-        // Phase 2: take the write lock once and apply the converted batch.
+        // For large batches, drop no-op updates by diffing against
+        // current state under a read lock (shared; doesn't block readers).
+        let prepared = if batch.should_diff() {
+            let state = self.state.read().unwrap();
+            reduce_by_diff(&state, batch.updates)
+        } else {
+            batch.updates
+        };
+        // Take the write lock once and apply the reduced batch.
         let mut state = self.state.write().unwrap();
         self.updater.apply_prepared(&mut state, prepared);
         result
@@ -410,17 +416,23 @@ impl Handler<XdsAddress> for ProxyStateUpdater {
         &self,
         updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsAddress>>>,
     ) -> Result<(), Vec<RejectedConfig>> {
-        // Phase 1: convert every resource off-lock (the expensive proto→internal
-        // work). A malformed resource only rejects itself.
-        let mut prepared = Vec::new();
+        let mut batch = PreparedBatch::default();
         let result = handle_single_resource(updates, |res: XdsUpdate<XdsAddress>| {
-            prepared.push(match res {
+            batch.push(match res {
                 XdsUpdate::Update(w) => PreparedUpdate::try_from_address(w.resource)?,
                 XdsUpdate::Remove(name) => PreparedUpdate::Remove(strng::new(name)),
             });
             Ok(())
         });
-        // Phase 2: take the write lock once and apply the converted batch, one
+        // For large batches (e.g. the full re-push on reconnect), drop
+        // no-op updates by diffing against current state under a read lock
+        let prepared = if batch.should_diff() {
+            let state = self.state.read().unwrap();
+            reduce_by_diff(&state, batch.updates)
+        } else {
+            batch.updates
+        };
+        // Take the write lock once and apply the reduced batch, one
         // clone + reindex per distinct service rather than once per endpoint.
         let mut state = self.state.write().unwrap();
         self.updater.apply_prepared(&mut state, prepared);
@@ -484,6 +496,58 @@ impl PreparedWorkload {
             endpoints,
         })
     }
+}
+
+/// Above these sizes a push is worth diffing against current state before
+/// applying (the read-lock comparison pass pays for itself by skipping unchanged
+/// resources); smaller steady-state deltas apply directly. `store_insert` cost is
+/// per-workload, so the primary gate is workload count.
+// TODO: Kinda arbitrary, tune these?
+const DIFF_MIN_WORKLOADS: usize = 1000;
+const DIFF_MIN_SERVICES: usize = 100;
+
+/// The converted resources of a push, accumulated during phase-1 conversion.
+/// Tracks the per-kind counts as it's built so the diff-vs-direct decision needs
+/// no extra pass over the batch.
+#[derive(Default)]
+struct PreparedBatch {
+    updates: Vec<PreparedUpdate>,
+    workloads: usize,
+    services: usize,
+}
+
+impl PreparedBatch {
+    fn push(&mut self, update: PreparedUpdate) {
+        match &update {
+            PreparedUpdate::Workload(_) => self.workloads += 1,
+            PreparedUpdate::Service(_) => self.services += 1,
+            PreparedUpdate::Remove(_) => {}
+        }
+        self.updates.push(update);
+    }
+
+    fn should_diff(&self) -> bool {
+        self.workloads >= DIFF_MIN_WORKLOADS || self.services >= DIFF_MIN_SERVICES
+    }
+}
+
+/// Drops updates that would be no-ops against `state`
+/// Removes are always kept.
+fn reduce_by_diff(state: &ProxyState, prepared: Vec<PreparedUpdate>) -> Vec<PreparedUpdate> {
+    prepared
+        .into_iter()
+        .filter(|update| match update {
+            PreparedUpdate::Workload(pw) => state
+                .workloads
+                .find_uid(&pw.workload.uid)
+                .is_none_or(|existing| *existing != *pw.workload),
+            PreparedUpdate::Service(svc) => state
+                .services
+                .get_by_namespaced_host(&svc.namespaced_hostname())
+                .is_none_or(|existing| !existing.config_eq(svc)),
+            PreparedUpdate::Remove(_) => true,
+        })
+        .collect()
 }
 
 /// Applies a single workload's service endpoints directly (one-shot). Used by the
@@ -836,5 +900,74 @@ mod tests {
         let remove = XdsUpdate::<XdsAddress>::Remove(workload(0, XdsStatus::Healthy).uid.into());
         apply(&updater, vec![remove]).unwrap();
         assert_eq!(endpoint_count(&state), 1);
+    }
+
+    // A batch large enough to trigger the diff path (> DIFF_MIN_WORKLOADS).
+    fn large_batch() -> Vec<XdsUpdate<XdsAddress>> {
+        let n = DIFF_MIN_WORKLOADS + 50;
+        let mut batch = vec![svc_update(service())];
+        batch.extend((0..n).map(|i| wl_update(workload(i, XdsStatus::Healthy))));
+        batch
+    }
+
+    fn reindexes(state: &Arc<RwLock<ProxyState>>) -> usize {
+        state.read().unwrap().services.endpoint_reindexes()
+    }
+
+    // Re-pushing the identical large batch (the reconnect case) is reduced to a
+    // no-op: no endpoints change and no service is reindexed.
+    #[test]
+    fn reconnect_repush_is_noop() {
+        let (updater, state) = updater_and_state();
+        apply(&updater, large_batch()).unwrap();
+        let eps = endpoint_count(&state);
+        let before = reindexes(&state);
+
+        apply(&updater, large_batch()).unwrap();
+
+        assert_eq!(endpoint_count(&state), eps);
+        assert_eq!(
+            reindexes(&state),
+            before,
+            "identical re-push must not reindex"
+        );
+    }
+
+    // In a large re-push where only one workload changed, only that change is
+    // applied: the unchanged service is skipped, so exactly one reindex occurs.
+    #[test]
+    fn diff_applies_only_changed() {
+        let (updater, state) = updater_and_state();
+        let n = DIFF_MIN_WORKLOADS + 50;
+        apply(&updater, large_batch()).unwrap();
+        assert_eq!(endpoint_count(&state), n);
+        let before = reindexes(&state);
+
+        // Same batch, but workload 0 is now unhealthy -> dropped from the service.
+        let mut batch = vec![svc_update(service())];
+        batch.push(wl_update(workload(0, XdsStatus::Unhealthy)));
+        batch.extend((1..n).map(|i| wl_update(workload(i, XdsStatus::Healthy))));
+        apply(&updater, batch).unwrap();
+
+        assert_eq!(endpoint_count(&state), n - 1);
+        assert_eq!(reindexes(&state), before + 1);
+    }
+
+    // Removes survive the diff (they are never dropped as "unchanged").
+    #[test]
+    fn diff_keeps_removes() {
+        let (updater, state) = updater_and_state();
+        let n = DIFF_MIN_WORKLOADS + 50;
+        apply(&updater, large_batch()).unwrap();
+        assert_eq!(endpoint_count(&state), n);
+
+        // A large, otherwise-unchanged re-push that also removes workload 0.
+        let mut batch = large_batch();
+        batch.push(XdsUpdate::Remove(
+            workload(0, XdsStatus::Healthy).uid.into(),
+        ));
+        apply(&updater, batch).unwrap();
+
+        assert_eq!(endpoint_count(&state), n - 1);
     }
 }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -534,6 +534,11 @@ impl PreparedBatch {
 /// Drops updates that would be no-ops against `state`
 /// Removes are always kept.
 fn reduce_by_diff(state: &ProxyState, prepared: Vec<PreparedUpdate>) -> Vec<PreparedUpdate> {
+    // Nothing to diff against on the initial push (empty state) — every resource
+    // is new, so skip the comparison pass and apply the batch as-is.
+    if state.workloads.is_empty() && state.services.is_empty() {
+        return prepared;
+    }
     prepared
         .into_iter()
         .filter(|update| match update {

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error as StdErr;
 use std::fmt;
 use std::fmt::Formatter;
@@ -103,6 +103,47 @@ pub struct ProxyStateUpdateMutator {
     cert_fetcher: Arc<dyn CertFetcher>,
 }
 
+/// Accumulates per-service endpoint changes during a single xDS push so they can
+/// be applied to each service with one clone + one reindex, instead of once per
+/// endpoint (which is O(E²) for a service with E endpoints — see
+/// [ServiceStore::apply_endpoints]).
+///
+/// A `(service, uid)` may legitimately appear in both `removals` and `upserts`:
+/// re-inserting a workload removes its old endpoints and adds its new ones in the
+/// same push. [ServiceStore::apply_endpoints] applies removals before upserts so
+/// the new endpoint wins — and, crucially, if the new endpoint is health-filtered
+/// out the stale one is still removed.
+#[derive(Default)]
+struct EndpointAccumulator {
+    upserts: HashMap<NamespacedHostname, HashMap<Strng, Endpoint>>,
+    removals: HashMap<NamespacedHostname, HashSet<Strng>>,
+}
+
+impl EndpointAccumulator {
+    fn upsert(&mut self, service: NamespacedHostname, uid: Strng, ep: Endpoint) {
+        self.upserts.entry(service).or_default().insert(uid, ep);
+    }
+
+    fn remove(&mut self, service: NamespacedHostname, uid: Strng) {
+        self.removals.entry(service).or_default().insert(uid);
+    }
+
+    /// Drains the accumulator into the store, touching each service once.
+    fn apply(self, services: &mut ServiceStore) {
+        let EndpointAccumulator {
+            mut upserts,
+            removals,
+        } = self;
+        for (service, removals) in removals {
+            let upserts = upserts.remove(&service).unwrap_or_default();
+            services.apply_endpoints(&service, upserts, removals);
+        }
+        for (service, upserts) in upserts {
+            services.apply_endpoints(&service, upserts, HashSet::new());
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ProxyStateUpdater {
     state: Arc<RwLock<ProxyState>>,
@@ -141,35 +182,54 @@ impl ProxyStateUpdateMutator {
         fields(uid=%w.uid),
     )]
     pub fn insert_workload(&self, state: &mut ProxyState, w: XdsWorkload) -> anyhow::Result<()> {
+        let mut acc = EndpointAccumulator::default();
+        self.insert_workload_into(state, w, &mut acc)?;
+        acc.apply(&mut state.services);
+        Ok(())
+    }
+
+    /// Inserts a workload into the workload store and accumulates its service
+    /// endpoint changes into `acc` (rather than applying them per-endpoint). The
+    /// caller drains `acc` once per push via [EndpointAccumulator::apply].
+    fn insert_workload_into(
+        &self,
+        state: &mut ProxyState,
+        w: XdsWorkload,
+        acc: &mut EndpointAccumulator,
+    ) -> anyhow::Result<()> {
         debug!("handling insert");
 
-        // Clone services, so we can pass full ownership of the rest of XdsWorkload to build our Workload
-        // object, which doesn't include Services.
-        // In theory, I think we could avoid this if Workload::try_from returning the services.
-        // let services = w.services.clone();
-        // Convert the workload.
+        // Convert the workload first, so a malformed update leaves the existing
+        // workload untouched.
         let (workload, services): (Workload, HashMap<String, PortList>) = w.try_into()?;
         let workload = Arc::new(workload);
 
         // First, remove the entry entirely to make sure things are cleaned up properly.
-        self.remove_workload_for_insert(state, &workload.uid);
+        self.remove_workload_for_insert(state, &workload.uid, acc);
 
         // Prefetch the cert for the workload.
         self.cert_fetcher.prefetch_cert(&workload);
 
         // Lock and upstate the stores.
         state.workloads.insert(workload.clone());
-        insert_service_endpoints(&workload, &services, &mut state.services)?;
+        accumulate_service_endpoints(&workload, &services, acc)?;
 
         Ok(())
     }
 
     pub fn remove(&self, state: &mut ProxyState, xds_name: &Strng) {
-        self.remove_internal(state, xds_name, false);
+        let mut acc = EndpointAccumulator::default();
+        self.remove_internal(state, xds_name, false, &mut acc);
+        acc.apply(&mut state.services);
     }
 
-    fn remove_workload_for_insert(&self, state: &mut ProxyState, xds_name: &Strng) {
-        self.remove_internal(state, xds_name, true);
+    fn remove_workload_for_insert(
+        &self,
+        state: &mut ProxyState,
+        xds_name: &Strng,
+        acc: &mut EndpointAccumulator,
+    ) {
+        self.remove_internal(state, xds_name, true, acc);
     }
 
     #[instrument(
@@ -178,11 +238,21 @@ impl ProxyStateUpdateMutator {
         skip_all,
         fields(name=%xds_name, for_workload_insert=%for_workload_insert),
     )]
-    fn remove_internal(&self, state: &mut ProxyState, xds_name: &Strng, for_workload_insert: bool) {
+    fn remove_internal(
+        &self,
+        state: &mut ProxyState,
+        xds_name: &Strng,
+        for_workload_insert: bool,
+        acc: &mut EndpointAccumulator,
+    ) {
         // remove workload by UID; if xds_name is a service then this will no-op
         if let Some(prev) = state.workloads.remove(&strng::new(xds_name)) {
-            // Also remove service endpoints for the workload.
-            state.services.remove_endpoint(&prev);
+            // Also remove this workload's endpoints from each of its services.
+            // Routed through the accumulator so a service touched many times in a
+            // push is reindexed once.
+            for svc in prev.services.iter() {
+                acc.remove(svc.clone(), prev.uid.clone());
+            }
 
             // This is a real removal (not a removal before insertion), and nothing else references the cert
             // Clear it out
@@ -224,8 +294,23 @@ impl ProxyStateUpdateMutator {
     }
 
     pub fn insert_address(&self, state: &mut ProxyState, a: XdsAddress) -> anyhow::Result<()> {
+        let mut acc = EndpointAccumulator::default();
+        self.insert_address_into(state, a, &mut acc)?;
+        acc.apply(&mut state.services);
+        Ok(())
+    }
+
+    fn insert_address_into(
+        &self,
+        state: &mut ProxyState,
+        a: XdsAddress,
+        acc: &mut EndpointAccumulator,
+    ) -> anyhow::Result<()> {
         match a.r#type {
-            Some(XdsType::Workload(w)) => self.insert_workload(state, w),
+            Some(XdsType::Workload(w)) => self.insert_workload_into(state, w, acc),
+            // Services are applied immediately (already a single clone + reindex,
+            // and they must be present before phase-2 endpoint application so the
+            // staged-endpoint flush runs first).
             Some(XdsType::Service(s)) => self.insert_service(state, s),
             _ => Err(anyhow::anyhow!("unknown address type")),
         }
@@ -294,17 +379,23 @@ impl Handler<XdsWorkload> for ProxyStateUpdater {
     ) -> Result<(), Vec<RejectedConfig>> {
         // use deepsize::DeepSizeOf;
         let mut state = self.state.write().unwrap();
-        let handle = |res: XdsUpdate<XdsWorkload>| {
+        let mut acc = EndpointAccumulator::default();
+        let result = handle_single_resource(updates, |res: XdsUpdate<XdsWorkload>| {
             match res {
-                XdsUpdate::Update(w) => self.updater.insert_workload(&mut state, w.resource)?,
+                XdsUpdate::Update(w) => self
+                    .updater
+                    .insert_workload_into(&mut state, w.resource, &mut acc)?,
                 XdsUpdate::Remove(name) => {
                     debug!("handling delete {}", name);
-                    self.updater.remove(&mut state, &strng::new(name))
+                    self.updater
+                        .remove_internal(&mut state, &strng::new(name), false, &mut acc)
                 }
             }
             Ok(())
-        };
-        handle_single_resource(updates, handle)
+        });
+        // Apply all accumulated endpoint changes, one clone + reindex per service.
+        acc.apply(&mut state.services);
+        result
     }
 }
 
@@ -314,37 +405,62 @@ impl Handler<XdsAddress> for ProxyStateUpdater {
         updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsAddress>>>,
     ) -> Result<(), Vec<RejectedConfig>> {
         let mut state = self.state.write().unwrap();
-        let handle = |res: XdsUpdate<XdsAddress>| {
+        let mut acc = EndpointAccumulator::default();
+        // Phase 1: apply workloads to the workload store and services to the
+        // service store immediately, accumulating each workload's endpoint
+        // changes (keyed by service) into `acc`.
+        let result = handle_single_resource(updates, |res: XdsUpdate<XdsAddress>| {
             match res {
-                XdsUpdate::Update(w) => self.updater.insert_address(&mut state, w.resource)?,
+                XdsUpdate::Update(w) => self
+                    .updater
+                    .insert_address_into(&mut state, w.resource, &mut acc)?,
                 XdsUpdate::Remove(name) => {
                     debug!("handling delete {}", name);
-                    self.updater.remove(&mut state, &strng::new(name))
+                    self.updater
+                        .remove_internal(&mut state, &strng::new(name), false, &mut acc)
                 }
             }
             Ok(())
-        };
-        handle_single_resource(updates, handle)
+        });
+        // Phase 2: apply the accumulated endpoint changes, one clone + reindex
+        // per distinct service rather than once per endpoint.
+        acc.apply(&mut state.services);
+        result
     }
 }
 
-fn insert_service_endpoints(
+fn accumulate_service_endpoints(
     workload: &Workload,
     services: &HashMap<String, PortList>,
-    services_state: &mut ServiceStore,
+    acc: &mut EndpointAccumulator,
 ) -> anyhow::Result<()> {
     for (namespaced_host, ports) in services {
         // Parse the namespaced hostname for the service.
         let namespaced_host = NamespacedHostname::from_str(namespaced_host)?;
-        services_state.insert_endpoint(
+        acc.upsert(
             namespaced_host,
+            workload.uid.clone(),
             Endpoint {
                 workload_uid: workload.uid.clone(),
                 port: ports.into(),
                 status: workload.status,
             },
-        )
+        );
     }
+    Ok(())
+}
+
+/// Applies a single workload's service endpoints directly (one-shot). Used by the
+/// file-based [LocalClient], which builds state fresh and isn't on the xDS push
+/// hot path.
+fn insert_service_endpoints(
+    workload: &Workload,
+    services: &HashMap<String, PortList>,
+    services_state: &mut ServiceStore,
+) -> anyhow::Result<()> {
+    let mut acc = EndpointAccumulator::default();
+    accumulate_service_endpoints(workload, services, &mut acc)?;
+    acc.apply(services_state);
     Ok(())
 }
 
@@ -487,5 +603,199 @@ impl LocalClient {
         }
         info!(%num_workloads, %num_policies, "local config initialized");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::workload::NamespacedHostname;
+    use crate::xds::istio::workload::{
+        NetworkAddress as XdsNetworkAddress, Port, WorkloadStatus as XdsStatus,
+    };
+    use bytes::Bytes;
+    use std::net::Ipv4Addr;
+
+    const NS: &str = "ns";
+    const HOST: &str = "svc1.ns.svc.cluster.local";
+
+    fn updater_and_state() -> (ProxyStateUpdater, Arc<RwLock<ProxyState>>) {
+        let state = Arc::new(RwLock::new(ProxyState::new(None)));
+        let updater = ProxyStateUpdater::new_no_fetch(state.clone());
+        (updater, state)
+    }
+
+    fn service() -> XdsService {
+        XdsService {
+            name: "svc1".to_string(),
+            namespace: NS.to_string(),
+            hostname: HOST.to_string(),
+            addresses: vec![XdsNetworkAddress {
+                network: "".to_string(),
+                address: Ipv4Addr::new(127, 0, 1, 1).octets().to_vec(),
+                length: None,
+            }],
+            ports: vec![Port {
+                service_port: 80,
+                target_port: 80,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn workload(i: usize, status: XdsStatus) -> XdsWorkload {
+        XdsWorkload {
+            uid: format!("cluster1//v1/Pod/{NS}/pod-{i}"),
+            addresses: vec![Bytes::copy_from_slice(&[
+                127,
+                0,
+                (i / 255) as u8,
+                (i % 255) as u8,
+            ])],
+            name: format!("pod-{i}"),
+            services: HashMap::from([(
+                format!("{NS}/{HOST}"),
+                PortList {
+                    ports: vec![Port {
+                        service_port: 80,
+                        target_port: 8080,
+                    }],
+                },
+            )]),
+            status: status as i32,
+            ..Default::default()
+        }
+    }
+
+    fn host() -> NamespacedHostname {
+        NamespacedHostname {
+            namespace: NS.into(),
+            hostname: HOST.into(),
+        }
+    }
+
+    fn wl_update(w: XdsWorkload) -> XdsUpdate<XdsAddress> {
+        XdsUpdate::Update(XdsResource {
+            name: w.uid.as_str().into(),
+            resource: XdsAddress {
+                r#type: Some(XdsType::Workload(w)),
+            },
+        })
+    }
+
+    fn svc_update(s: XdsService) -> XdsUpdate<XdsAddress> {
+        XdsUpdate::Update(XdsResource {
+            name: s.hostname.as_str().into(),
+            resource: XdsAddress {
+                r#type: Some(XdsType::Service(s)),
+            },
+        })
+    }
+
+    fn apply(updater: &ProxyStateUpdater, batch: Vec<XdsUpdate<XdsAddress>>) -> Result<(), usize> {
+        let handler = updater as &dyn Handler<XdsAddress>;
+        handler
+            .handle(Box::new(&mut batch.into_iter()))
+            .map_err(|rejects| rejects.len())
+    }
+
+    fn endpoint_count(state: &Arc<RwLock<ProxyState>>) -> usize {
+        state
+            .read()
+            .unwrap()
+            .services
+            .get_by_namespaced_host(&host())
+            .map(|s| s.endpoints.len())
+            .unwrap_or(0)
+    }
+
+    // All N workloads land on one service, applied in a single push, with the
+    // service in the middle of the batch. The service must end with N endpoints
+    // and must have been reindexed exactly once (not once per endpoint).
+    #[test]
+    fn batch_groups_endpoints_per_service() {
+        let (updater, state) = updater_and_state();
+        const N: usize = 50;
+
+        let mut batch: Vec<_> = (0..N / 2)
+            .map(|i| wl_update(workload(i, XdsStatus::Healthy)))
+            .collect();
+        batch.push(svc_update(service()));
+        batch.extend((N / 2..N).map(|i| wl_update(workload(i, XdsStatus::Healthy))));
+
+        apply(&updater, batch).unwrap();
+
+        assert_eq!(endpoint_count(&state), N);
+        assert_eq!(state.read().unwrap().services.num_staged_services(), 0);
+        // One clone + reindex for the single service, regardless of N endpoints.
+        assert_eq!(state.read().unwrap().services.endpoint_reindexes(), 1);
+    }
+
+    // Equivalent batch with the service first must produce the same result.
+    #[test]
+    fn batch_service_before_workloads() {
+        let (updater, state) = updater_and_state();
+        let mut batch = vec![svc_update(service())];
+        batch.extend((0..10).map(|i| wl_update(workload(i, XdsStatus::Healthy))));
+
+        apply(&updater, batch).unwrap();
+
+        assert_eq!(endpoint_count(&state), 10);
+        assert_eq!(state.read().unwrap().services.endpoint_reindexes(), 1);
+    }
+
+    // Unhealthy workloads in a batch are excluded from the service's endpoints.
+    #[test]
+    fn batch_filters_unhealthy() {
+        let (updater, state) = updater_and_state();
+        let batch = vec![
+            svc_update(service()),
+            wl_update(workload(0, XdsStatus::Healthy)),
+            wl_update(workload(1, XdsStatus::Unhealthy)),
+            wl_update(workload(2, XdsStatus::Healthy)),
+        ];
+
+        apply(&updater, batch).unwrap();
+
+        assert_eq!(endpoint_count(&state), 2);
+    }
+
+    // A malformed resource only rejects itself; the rest of the batch applies.
+    #[test]
+    fn batch_partial_failure() {
+        let (updater, state) = updater_and_state();
+        let bad = XdsUpdate::Update(XdsResource {
+            name: "bad".into(),
+            resource: XdsAddress { r#type: None },
+        });
+        let batch = vec![
+            svc_update(service()),
+            wl_update(workload(0, XdsStatus::Healthy)),
+            bad,
+            wl_update(workload(1, XdsStatus::Healthy)),
+        ];
+
+        assert_eq!(apply(&updater, batch), Err(1));
+        assert_eq!(endpoint_count(&state), 2);
+    }
+
+    // Removing a workload in a later push drops its endpoint from the service.
+    #[test]
+    fn remove_drops_endpoint() {
+        let (updater, state) = updater_and_state();
+        apply(
+            &updater,
+            vec![
+                svc_update(service()),
+                wl_update(workload(0, XdsStatus::Healthy)),
+                wl_update(workload(1, XdsStatus::Healthy)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(endpoint_count(&state), 2);
+
+        let remove = XdsUpdate::<XdsAddress>::Remove(workload(0, XdsStatus::Healthy).uid.into());
+        apply(&updater, vec![remove]).unwrap();
+        assert_eq!(endpoint_count(&state), 1);
     }
 }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -182,27 +182,49 @@ impl ProxyStateUpdateMutator {
         fields(uid=%w.uid),
     )]
     pub fn insert_workload(&self, state: &mut ProxyState, w: XdsWorkload) -> anyhow::Result<()> {
+        // Conversion happens here (off any caller-held lock); the store mutation is
+        // the only part that needs the lock.
+        let prepared = PreparedWorkload::try_from_xds(w)?;
         let mut acc = EndpointAccumulator::default();
-        self.insert_workload_into(state, w, &mut acc)?;
+        self.apply_prepared_workload(state, prepared, &mut acc);
         acc.apply(&mut state.services);
         Ok(())
     }
 
-    /// Inserts a workload into the workload store and accumulates its service
-    /// endpoint changes into `acc` (rather than applying them per-endpoint). The
-    /// caller drains `acc` once per push via [EndpointAccumulator::apply].
-    fn insert_workload_into(
+    /// Applies an already-converted batch of updates to the state under the
+    /// caller's write lock. All expensive proto→internal conversion has already
+    /// happened off-lock (see [PreparedUpdate]); this only mutates the stores.
+    /// Endpoint changes are accumulated and applied once per service at the end.
+    fn apply_prepared(&self, state: &mut ProxyState, prepared: Vec<PreparedUpdate>) {
+        let mut acc = EndpointAccumulator::default();
+        for update in prepared {
+            match update {
+                PreparedUpdate::Workload(w) => self.apply_prepared_workload(state, w, &mut acc),
+                // Services are applied in order (already a single clone + reindex,
+                // and must be present before phase-2 endpoint application).
+                PreparedUpdate::Service(s) => self.insert_service_prepared(state, *s),
+                PreparedUpdate::Remove(name) => {
+                    debug!("handling delete {}", name);
+                    self.remove_internal(state, &name, false, &mut acc);
+                }
+            }
+        }
+        acc.apply(&mut state.services);
+    }
+
+    /// Inserts a pre-converted workload into the workload store and accumulates
+    /// its service endpoint changes into `acc` (applied once per service later).
+    fn apply_prepared_workload(
         &self,
         state: &mut ProxyState,
-        w: XdsWorkload,
+        prepared: PreparedWorkload,
         acc: &mut EndpointAccumulator,
-    ) -> anyhow::Result<()> {
+    ) {
         debug!("handling insert");
-
-        // Convert the workload first, so a malformed update leaves the existing
-        // workload untouched.
-        let (workload, services): (Workload, HashMap<String, PortList>) = w.try_into()?;
-        let workload = Arc::new(workload);
+        let PreparedWorkload {
+            workload,
+            endpoints,
+        } = prepared;
 
         // First, remove the entry entirely to make sure things are cleaned up properly.
         self.remove_workload_for_insert(state, &workload.uid, acc);
@@ -210,11 +232,10 @@ impl ProxyStateUpdateMutator {
         // Prefetch the cert for the workload.
         self.cert_fetcher.prefetch_cert(&workload);
 
-        // Lock and upstate the stores.
         state.workloads.insert(workload.clone());
-        accumulate_service_endpoints(&workload, &services, acc)?;
-
-        Ok(())
+        for (service, endpoint) in endpoints {
+            acc.upsert(service, workload.uid.clone(), endpoint);
+        }
     }
 
     pub fn remove(&self, state: &mut ProxyState, xds_name: &Strng) {
@@ -294,26 +315,9 @@ impl ProxyStateUpdateMutator {
     }
 
     pub fn insert_address(&self, state: &mut ProxyState, a: XdsAddress) -> anyhow::Result<()> {
-        let mut acc = EndpointAccumulator::default();
-        self.insert_address_into(state, a, &mut acc)?;
-        acc.apply(&mut state.services);
+        let prepared = PreparedUpdate::try_from_address(a)?;
+        self.apply_prepared(state, vec![prepared]);
         Ok(())
-    }
-
-    fn insert_address_into(
-        &self,
-        state: &mut ProxyState,
-        a: XdsAddress,
-        acc: &mut EndpointAccumulator,
-    ) -> anyhow::Result<()> {
-        match a.r#type {
-            Some(XdsType::Workload(w)) => self.insert_workload_into(state, w, acc),
-            // Services are applied immediately (already a single clone + reindex,
-            // and they must be present before phase-2 endpoint application so the
-            // staged-endpoint flush runs first).
-            Some(XdsType::Service(s)) => self.insert_service(state, s),
-            _ => Err(anyhow::anyhow!("unknown address type")),
-        }
     }
 
     #[instrument(
@@ -327,9 +331,15 @@ impl ProxyStateUpdateMutator {
         state: &mut ProxyState,
         service: XdsService,
     ) -> anyhow::Result<()> {
-        debug!("handling insert");
-        let mut service = Service::try_from(&service)?;
+        let service = Service::try_from(&service)?;
+        self.insert_service_prepared(state, service);
+        Ok(())
+    }
 
+    /// Applies an already-converted [Service] to the store, migrating existing
+    /// endpoints into the new instance.
+    fn insert_service_prepared(&self, state: &mut ProxyState, mut service: Service) {
+        debug!("handling insert");
         // If the service already exists, add existing endpoints into the new service.
         if let Some(prev) = state
             .services
@@ -345,7 +355,6 @@ impl ProxyStateUpdateMutator {
         }
 
         state.services.insert(service);
-        Ok(())
     }
 
     pub fn insert_authorization(
@@ -377,24 +386,21 @@ impl Handler<XdsWorkload> for ProxyStateUpdater {
         &self,
         updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsWorkload>>>,
     ) -> Result<(), Vec<RejectedConfig>> {
-        // use deepsize::DeepSizeOf;
-        let mut state = self.state.write().unwrap();
-        let mut acc = EndpointAccumulator::default();
+        // Phase 1: convert every resource off-lock. A malformed resource only
+        // rejects itself and doesn't abort the batch.
+        let mut prepared = Vec::new();
         let result = handle_single_resource(updates, |res: XdsUpdate<XdsWorkload>| {
-            match res {
-                XdsUpdate::Update(w) => self
-                    .updater
-                    .insert_workload_into(&mut state, w.resource, &mut acc)?,
-                XdsUpdate::Remove(name) => {
-                    debug!("handling delete {}", name);
-                    self.updater
-                        .remove_internal(&mut state, &strng::new(name), false, &mut acc)
+            prepared.push(match res {
+                XdsUpdate::Update(w) => {
+                    PreparedUpdate::Workload(PreparedWorkload::try_from_xds(w.resource)?)
                 }
-            }
+                XdsUpdate::Remove(name) => PreparedUpdate::Remove(strng::new(name)),
+            });
             Ok(())
         });
-        // Apply all accumulated endpoint changes, one clone + reindex per service.
-        acc.apply(&mut state.services);
+        // Phase 2: take the write lock once and apply the converted batch.
+        let mut state = self.state.write().unwrap();
+        self.updater.apply_prepared(&mut state, prepared);
         result
     }
 }
@@ -404,62 +410,95 @@ impl Handler<XdsAddress> for ProxyStateUpdater {
         &self,
         updates: Box<&mut dyn Iterator<Item = XdsUpdate<XdsAddress>>>,
     ) -> Result<(), Vec<RejectedConfig>> {
-        let mut state = self.state.write().unwrap();
-        let mut acc = EndpointAccumulator::default();
-        // Phase 1: apply workloads to the workload store and services to the
-        // service store immediately, accumulating each workload's endpoint
-        // changes (keyed by service) into `acc`.
+        // Phase 1: convert every resource off-lock (the expensive proto→internal
+        // work). A malformed resource only rejects itself.
+        let mut prepared = Vec::new();
         let result = handle_single_resource(updates, |res: XdsUpdate<XdsAddress>| {
-            match res {
-                XdsUpdate::Update(w) => self
-                    .updater
-                    .insert_address_into(&mut state, w.resource, &mut acc)?,
-                XdsUpdate::Remove(name) => {
-                    debug!("handling delete {}", name);
-                    self.updater
-                        .remove_internal(&mut state, &strng::new(name), false, &mut acc)
-                }
-            }
+            prepared.push(match res {
+                XdsUpdate::Update(w) => PreparedUpdate::try_from_address(w.resource)?,
+                XdsUpdate::Remove(name) => PreparedUpdate::Remove(strng::new(name)),
+            });
             Ok(())
         });
-        // Phase 2: apply the accumulated endpoint changes, one clone + reindex
-        // per distinct service rather than once per endpoint.
-        acc.apply(&mut state.services);
+        // Phase 2: take the write lock once and apply the converted batch, one
+        // clone + reindex per distinct service rather than once per endpoint.
+        let mut state = self.state.write().unwrap();
+        self.updater.apply_prepared(&mut state, prepared);
         result
     }
 }
 
-fn accumulate_service_endpoints(
-    workload: &Workload,
-    services: &HashMap<String, PortList>,
-    acc: &mut EndpointAccumulator,
-) -> anyhow::Result<()> {
-    for (namespaced_host, ports) in services {
-        // Parse the namespaced hostname for the service.
-        let namespaced_host = NamespacedHostname::from_str(namespaced_host)?;
-        acc.upsert(
-            namespaced_host,
-            workload.uid.clone(),
-            Endpoint {
-                workload_uid: workload.uid.clone(),
-                port: ports.into(),
-                status: workload.status,
-            },
-        );
+/// A resource converted from its xDS proto form, ready to be applied under the
+/// write lock. Conversion (proto→internal, string interning, hostname parsing) is
+/// the expensive part and happens off-lock so it doesn't starve readers.
+enum PreparedUpdate {
+    Workload(PreparedWorkload),
+    // Boxed: Service is far larger than the other variants, and a push holds a
+    // Vec of these sized to the largest variant.
+    Service(Box<Service>),
+    Remove(Strng),
+}
+
+impl PreparedUpdate {
+    fn try_from_address(a: XdsAddress) -> anyhow::Result<Self> {
+        match a.r#type {
+            Some(XdsType::Workload(w)) => Ok(Self::Workload(PreparedWorkload::try_from_xds(w)?)),
+            Some(XdsType::Service(s)) => Ok(Self::Service(Box::new(Service::try_from(&s)?))),
+            _ => Err(anyhow::anyhow!("unknown address type")),
+        }
     }
-    Ok(())
+}
+
+/// A converted workload plus the per-service endpoints it contributes, computed
+/// off-lock.
+struct PreparedWorkload {
+    workload: Arc<Workload>,
+    endpoints: Vec<(NamespacedHostname, Endpoint)>,
+}
+
+impl PreparedWorkload {
+    fn try_from_xds(w: XdsWorkload) -> anyhow::Result<Self> {
+        let (workload, services): (Workload, HashMap<String, PortList>) = w.try_into()?;
+        Self::build(Arc::new(workload), &services)
+    }
+
+    fn build(
+        workload: Arc<Workload>,
+        services: &HashMap<String, PortList>,
+    ) -> anyhow::Result<Self> {
+        let mut endpoints = Vec::with_capacity(services.len());
+        for (namespaced_host, ports) in services {
+            // Parse the namespaced hostname for the service.
+            let namespaced_host = NamespacedHostname::from_str(namespaced_host)?;
+            endpoints.push((
+                namespaced_host,
+                Endpoint {
+                    workload_uid: workload.uid.clone(),
+                    port: ports.into(),
+                    status: workload.status,
+                },
+            ));
+        }
+        Ok(Self {
+            workload,
+            endpoints,
+        })
+    }
 }
 
 /// Applies a single workload's service endpoints directly (one-shot). Used by the
 /// file-based [LocalClient], which builds state fresh and isn't on the xDS push
 /// hot path.
 fn insert_service_endpoints(
-    workload: &Workload,
+    workload: &Arc<Workload>,
     services: &HashMap<String, PortList>,
     services_state: &mut ServiceStore,
 ) -> anyhow::Result<()> {
+    let prepared = PreparedWorkload::build(workload.clone(), services)?;
     let mut acc = EndpointAccumulator::default();
-    accumulate_service_endpoints(workload, services, &mut acc)?;
+    for (service, endpoint) in prepared.endpoints {
+        acc.upsert(service, workload.uid.clone(), endpoint);
+    }
     acc.apply(services_state);
     Ok(())
 }


### PR DESCRIPTION
Working on #1966

## TLDR
Diff full pushes against state to reduce them to a delta before taking the write lock. It saves a lot of time under write lock when a running ztunnel reconnects to istiod.

## Goals:
- improved handling of the large "full push" which is received when ztunnel reconnects
- keep small delta pushes fast

## Non-goals:
- Handling a true super large push which isn't mostly no-op updates like we receive when re-connecting to istiod

## Also considered:
ArcSwap|mem::Swap type of implementation. This would require doing a clone of potentially large state and applying the push off lock, then swapping it out for an O(1) operation under write lock. This would be a more optimal path for true very large diffs, but the basic approach would render small delta pushes intolerably slow I think. A form of swapping undertaken when the prepared + diff-reduced batch is still quite large would be a potential enhancement to follow up with, which I have not yet explored very thoroughly.

There are some immutable map type data structures we could consider to reduce the costs of this "clone to update" operation, however they seem to be more optimal for write at a cost of more expensive read. I suspect the additional cost paid on every read outweighs the more optimal write many-fold.

## High level implementation:
- Move preparation of the batched update off lock
- If the update is large, reduce it by diffing against present state
- Apply the prepared batch under write lock

## Result
I tested two different "real world" cluster shapes based on the information graciously provided by @es-ma-n. This was simulated in a small KinD cluster augmented by `pilot-load` to handle the many mock workloads and services that make the full push bite. The times shown in the table are the P100 latency observed by fortio driving all new connections through ztunnel across 6 reconnects (full push).

| cluster shape | baseline | this PR |
| --- | --- | --- |
| clusterA (max ~2,700-endpoint service) | 597 ms | 17 ms |
| clusterB (max ~1,600-endpoint service) | 509 ms | 13 ms |
