### PR TITLE
add source and destination clusters to access logs

### DIFF
--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -621,6 +621,7 @@ impl ConnectionResultBuilder {
             src.workload = self.src.1.as_deref().map(to_value),
             src.namespace = self.tl.source_workload_namespace.to_value(),
             src.identity = self.tl.source_principal.as_ref().filter(|_| mtls).map(to_value_owned),
+            src.cluster = self.tl.source_cluster.to_value(),
 
             dst.addr = %self.dst.0,
             dst.hbone_addr = self.hbone_target.as_ref().map(display),
@@ -628,6 +629,7 @@ impl ConnectionResultBuilder {
             dst.workload = self.dst.1.as_deref().map(to_value),
             dst.namespace = self.tl.destination_workload_namespace.to_value(),
             dst.identity = self.tl.destination_principal.as_ref().filter(|_| mtls).map(to_value_owned),
+            dst.cluster = self.tl.destination_cluster.to_value(),
 
             direction = if self.tl.reporter == Reporter::source {
                 "outbound"
@@ -753,6 +755,7 @@ impl ConnectionResult {
             src.workload = self.src.1.as_deref().map(to_value),
             src.namespace = tl.source_workload_namespace.to_value(),
             src.identity = tl.source_principal.as_ref().filter(|_| mtls).map(to_value_owned),
+            src.cluster = tl.source_cluster.to_value(),
 
             dst.addr = %self.dst.0,
             dst.hbone_addr = self.hbone_target.as_ref().map(display),
@@ -760,6 +763,7 @@ impl ConnectionResult {
             dst.workload = self.dst.1.as_deref().map(to_value),
             dst.namespace = tl.destination_workload_namespace.to_value(),
             dst.identity = tl.destination_principal.as_ref().filter(|_| mtls).map(to_value_owned),
+            dst.cluster = tl.destination_cluster.to_value(),
 
             direction = if tl.reporter == Reporter::source {
                 "outbound"


### PR DESCRIPTION
ztunnel already exports source_cluster / destination_cluster as labels on the istio_tcp_* metrics, but the access log omits them. In multi-cluster / multi-network meshes this is a real gap as you can't tell from an access log whether a connection stayed in-cluster or crossed a cluster boundary without correlating back to aggregate metrics. This change closes that gap and brings the log in line with the metric label set. The values are already computed and held on CommonTrafficLabels, so this only formats two existing fields into the log line.