### PR TITLE
Working on Memory Management

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,11 @@
 [build]
 target-dir = "out/rust"
+
+[target.'cfg(target_os = "linux")']
+rustflags = ["-C", "force-frame-pointers"]
+
 [env]
 BORING_BSSL_FIPS_PATH = { value = "vendor/boringssl-fips/linux_x86_64", force = true, relative = true }
 BORING_BSSL_FIPS_INCLUDE_PATH = { value = "vendor/boringssl-fips/include/", force = true, relative = true }
+CFLAGS = "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+CXXFLAGS = "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.90"
 autobenches = false # benches must be explicitly declared
 
 [features]
-default = ["tls-aws-lc"]
+default = ["tls-aws-lc", "jemalloc"]
 jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
 tls-boring = ["dep:boring", "dep:boring-sys", "boring-rustls-provider/fips-only"]
 tls-ring = ["dep:ring", "rustls/ring", "tokio-rustls/ring", "hyper-rustls/ring", "dep:rcgen"]

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -2,11 +2,11 @@ include common/Makefile.common.mk
 
 FEATURES ?=
 ifeq ($(TLS_MODE), boring)
-	FEATURES:=--no-default-features -F tls-boring
+	FEATURES:=--no-default-features -F tls-boring -F jemalloc
 else ifeq ($(TLS_MODE), aws-lc)
-	FEATURES:=--no-default-features -F tls-aws-lc
+	FEATURES:=--no-default-features -F tls-aws-lc -F jemalloc
 else ifeq ($(TLS_MODE), openssl)
-	FEATURES:=--no-default-features -F tls-openssl
+	FEATURES:=--no-default-features -F tls-openssl -F jemalloc
 endif
 
 test:
@@ -30,12 +30,14 @@ build:
 inpodserver:
 	cargo build --example inpodserver
 
-# Test that all important features build
+# Test that all important features build.
+# Each TLS mode is checked with jemalloc (the combination release builds ship)
+# and one without it to keep the non-jemalloc cfg paths compiling.
 check-features:
-	cargo check --no-default-features -F tls-boring
+	cargo check --no-default-features -F tls-boring -F jemalloc
+	cargo check --no-default-features -F tls-aws-lc -F jemalloc
+	cargo check --no-default-features -F tls-openssl -F jemalloc
 	cargo check --no-default-features -F tls-aws-lc
-	cargo check --no-default-features -F tls-openssl
-	cargo check -F jemalloc
 	(cd fuzz; RUSTFLAGS="--cfg fuzzing" cargo check)
 
 # target in common/Makefile.common.mk doesn't handle our third party vendored files; only check golang and rust codes

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -12,6 +12,14 @@ endif
 test:
 	RUST_BACKTRACE=1 cargo test --benches --tests --bins $(FEATURES)
 
+# The throughput bench needs netns privileges, which BUILD_WITH_CONTAINER=1 (default)
+# already provides via Makefile.overrides.mk (--privileged + /var/run/netns mount).
+#   make bench BENCH_ARGS="-F jemalloc -- --save-baseline master"
+#   make bench BENCH_ARGS="-F jemalloc --bench basic -- --baseline master"
+BENCH_ARGS ?=
+bench:
+	RUST_BACKTRACE=1 cargo bench $(FEATURES) $(BENCH_ARGS)
+
 coverage:
 	FEATURES=$(FEATURES) ./scripts/test-with-coverage.sh 
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -400,6 +400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +640,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flurry"
@@ -1335,6 +1354,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jemalloc_pprof"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d44c349cfe2654897fadcb9de4f0bfbf48288ec344f700b2bd59f152dd209"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1539,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mappings"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bab1e61a4b76757edb59cd81fcaa7f3ba9018d43b527d9abfad877b4c6c60f2"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1697,12 +1747,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -1718,6 +1791,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1796,6 +1890,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1929,6 +2029,20 @@ dependencies = [
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pprof_util"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea0cc524de808a6d98d192a3d99fe95617031ad4a52ec0a0f987ef4432e8fe1"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "flate2",
+ "num",
+ "paste",
+ "prost",
 ]
 
 [[package]]
@@ -2588,6 +2702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,6 +2920,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -3882,6 +4033,7 @@ dependencies = [
  "hyper-util",
  "ipnet",
  "itertools 0.14.0",
+ "jemalloc_pprof",
  "keyed_priority_queue",
  "libc",
  "log",
@@ -3914,6 +4066,7 @@ dependencies = [
  "split-iter",
  "textnonce",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tls-listener",
  "tokio",
  "tokio-rustls",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -400,15 +400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,16 +631,6 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "flurry"
@@ -1354,23 +1335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jemalloc_pprof"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d44c349cfe2654897fadcb9de4f0bfbf48288ec344f700b2bd59f152dd209"
-dependencies = [
- "anyhow",
- "libc",
- "mappings",
- "once_cell",
- "pprof_util",
- "tempfile",
- "tikv-jemalloc-ctl",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,19 +1503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mappings"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bab1e61a4b76757edb59cd81fcaa7f3ba9018d43b527d9abfad877b4c6c60f2"
-dependencies = [
- "anyhow",
- "libc",
- "once_cell",
- "pprof_util",
- "tracing",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,7 +1548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -1747,35 +1697,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
  "num-traits",
 ]
 
@@ -1791,27 +1718,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -1890,12 +1796,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -2029,20 +1929,6 @@ dependencies = [
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "pprof_util"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea0cc524de808a6d98d192a3d99fe95617031ad4a52ec0a0f987ef4432e8fe1"
-dependencies = [
- "anyhow",
- "backtrace",
- "flate2",
- "num",
- "paste",
- "prost",
 ]
 
 [[package]]
@@ -2702,12 +2588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
-
-[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,37 +2800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tikv-jemalloc-ctl"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
-dependencies = [
- "libc",
- "paste",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -4033,7 +3882,6 @@ dependencies = [
  "hyper-util",
  "ipnet",
  "itertools 0.14.0",
- "jemalloc_pprof",
  "keyed_priority_queue",
  "libc",
  "log",
@@ -4066,7 +3914,6 @@ dependencies = [
  "split-iter",
  "textnonce",
  "thiserror 2.0.18",
- "tikv-jemallocator",
  "tls-listener",
  "tokio",
  "tokio-rustls",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,10 @@ anyhow = "1.0"
 
 [dependencies.ztunnel]
 path = ".."
+# No default features: jemalloc's unprefixed malloc/free conflicts with the
+# sanitizers cargo-fuzz/OSS-Fuzz build with (ASan heap interceptors).
+default-features = false
+features = ["tls-aws-lc"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,11 +31,11 @@ if [[ "$TLS_MODE" == "boring" ]]; then
     # TODO(https://github.com/istio/ztunnel/issues/357) clean up this hack
     sed -i 's/x86_64/arm64/g' .cargo/config.toml
   fi
-  cargo build --release --no-default-features -F tls-boring
+  cargo build --release --no-default-features -F tls-boring -F jemalloc
 elif [[ "$TLS_MODE" == "aws-lc" ]]; then
-  cargo build --release --no-default-features -F tls-aws-lc
+  cargo build --release --no-default-features -F tls-aws-lc -F jemalloc
 elif [[ "$TLS_MODE" == "openssl" ]]; then
-  cargo build --release --no-default-features -F tls-openssl
+  cargo build --release --no-default-features -F tls-openssl -F jemalloc
 else
   cargo build --release
 fi

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -128,6 +128,8 @@ impl Service {
                 "/debug/pprof/profile" => handle_pprof(req).await,
                 #[cfg(target_os = "linux")]
                 "/debug/pprof/heap" => handle_jemalloc_pprof_heapgen(req).await,
+                #[cfg(target_os = "linux")]
+                "/debug/pprof/heap/profiling" => handle_jemalloc_prof_toggle(req).await,
                 "/quitquitquit" => Ok(handle_server_shutdown(
                     state.shutdown_trigger.clone(),
                     req,
@@ -164,6 +166,10 @@ async fn handle_dashboard(_req: Request<Incoming>) -> Response<Full<Bytes>> {
         (
             "debug/pprof/heap",
             "collect heap profiling data (if supported, requires jmalloc)",
+        ),
+        (
+            "debug/pprof/heap/profiling",
+            "query or toggle heap profiling with ?activate=true|false (requires jmalloc)",
         ),
         ("quitquitquit", "shut down the server"),
         ("config_dump", "dump the current Ztunnel configuration"),
@@ -410,14 +416,17 @@ async fn handle_jemalloc_pprof_heapgen(
     let Some(prof_ctrl) = jemalloc_pprof::PROF_CTL.as_ref() else {
         return Ok(Response::builder()
             .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-            .body("jemalloc profiling is not enabled".into())
+            .body("heap profiling is not enabled".into())
             .expect("builder with known status code should not fail"));
     };
     let mut prof_ctl = prof_ctrl.lock().await;
     if !prof_ctl.activated() {
         return Ok(Response::builder()
             .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-            .body("jemalloc not enabled".into())
+            .body(
+                "heap profiling not active; activate with /debug/pprof/heap/profiling?activate=true"
+                    .into(),
+            )
             .expect("builder with known status code should not fail"));
     }
     let pprof = prof_ctl.dump_pprof()?;
@@ -429,6 +438,55 @@ async fn handle_jemalloc_pprof_heapgen(
 
 #[cfg(not(feature = "jemalloc"))]
 async fn handle_jemalloc_pprof_heapgen(
+    _req: Request<Incoming>,
+) -> anyhow::Result<Response<Full<Bytes>>> {
+    Ok(Response::builder()
+        .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
+        .body("jemalloc not enabled".into())
+        .expect("builder with known status code should not fail"))
+}
+
+#[cfg(all(feature = "jemalloc", target_os = "linux"))]
+async fn handle_jemalloc_prof_toggle(
+    req: Request<Incoming>,
+) -> anyhow::Result<Response<Full<Bytes>>> {
+    let Some(prof_ctrl) = jemalloc_pprof::PROF_CTL.as_ref() else {
+        return Ok(Response::builder()
+            .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
+            .body("jemalloc profiling is not enabled".into())
+            .expect("builder with known status code should not fail"));
+    };
+    let qp: HashMap<String, String> = req
+        .uri()
+        .query()
+        .map(|v| {
+            url::form_urlencoded::parse(v.as_bytes())
+                .into_owned()
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut prof_ctl = prof_ctrl.lock().await;
+    // Dumps from /debug/pprof/heap only include allocations sampled while
+    // profiling is active; allocations made before activation are not visible.
+    match qp.get("activate").map(String::as_str) {
+        Some("true") => prof_ctl.activate()?,
+        Some("false") => prof_ctl.deactivate()?,
+        Some(v) => {
+            return Ok(plaintext_response(
+                hyper::StatusCode::BAD_REQUEST,
+                format!("invalid activate value {v:?}; expected true or false\n"),
+            ));
+        }
+        None => {}
+    }
+    Ok(plaintext_response(
+        hyper::StatusCode::OK,
+        format!("heap profiling active: {}\n", prof_ctl.activated()),
+    ))
+}
+
+#[cfg(not(feature = "jemalloc"))]
+async fn handle_jemalloc_prof_toggle(
     _req: Request<Incoming>,
 ) -> anyhow::Result<Response<Full<Bytes>>> {
     Ok(Response::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "malloc_conf")]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19,thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
 
 // We use this on Unix systems to increase the number of open file descriptors
 // if possible. This is useful for high-load scenarios where the default limit

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "malloc_conf")]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19,thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
+pub static malloc_conf: &[u8] = b"thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
 
 // We use this on Unix systems to increase the number of open file descriptors
 // if possible. This is useful for high-load scenarios where the default limit

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "malloc_conf")]
-pub static malloc_conf: &[u8] = b"thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19,thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
 
 // We use this on Unix systems to increase the number of open file descriptors
 // if possible. This is useful for high-load scenarios where the default limit


### PR DESCRIPTION
Inspired and influence by https://github.com/agentgateway/agentgateway/pull/1696

glibc exhibits a behavior where memory which ztunnel has freed is not returned. This causes the working set to grow in a way which is often mistaken for a memory leak. From a system perspective, freed memory which isn't given back is leaky, but it's not indicative of ztunnel retaining stale references. jemalloc has better behaviors in this regard.


| arm | idle | peak* | after idle |
| --- | --- | --- | --- |
| master (glibc) | ~2 | 33–37 | **34.6–35.1 (frees ~0)** |
| patched (jemalloc no profiling)| ~3.6 | 24–27 | **8.8–9.8** |
| patched (jemalloc profiling enabled, not active) | ~3.8 | 24–27 | **9.0–10.1** |

*peak is working set size measured during fortio 100 concurrency no keep alive benchmarking session

Additionally, glibc complicates the collection of heap profiles. Today, this requires a custom build of ztunnel. You cannot profile any normal build published by the Istio project. Switching to jemalloc would allow us to have heap profiling capability compiled in and enabled on our default builds.

Performance is mostly on par. Slightly worse on c1 but better under higher churn c100 benchmarks.

| arm | c1 max | c10 max | c100 max | c100 no-keepalive |
| --- | --- | --- | --- | --- |
| master (glibc) | 9574 | 40830 | 59487 | 11085 |
| patched (jemalloc profiling enabled, not active) | 9477 | 40996 | 59741 | 11436 |

**note** This round of benchmarking was done on my consumer-grade, not server-grade, hardware.