### PR TITLE
more reasonable default pprof frequency (100hz) + configure frequency…

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -161,7 +161,8 @@ async fn handle_dashboard(_req: Request<Incoming>) -> Response<Full<Bytes>> {
     let apis = &[
         (
             "debug/pprof/profile",
-            "build profile using the pprof profiler (if supported)",
+            "capture a CPU profile (if supported); \
+             params: seconds (1-300, default 10), frequency in Hz (1-1000, default 100)",
         ),
         (
             "debug/pprof/heap",
@@ -244,14 +245,47 @@ async fn dump_certs(cert_manager: &SecretManager) -> Vec<CertsDump> {
 }
 
 #[cfg(target_os = "linux")]
-async fn handle_pprof(_req: Request<Incoming>) -> anyhow::Result<Response<Full<Bytes>>> {
+async fn handle_pprof(req: Request<Incoming>) -> anyhow::Result<Response<Full<Bytes>>> {
+    let qp: HashMap<String, String> = req
+        .uri()
+        .query()
+        .map(|v| {
+            url::form_urlencoded::parse(v.as_bytes())
+                .into_owned()
+                .collect()
+        })
+        .unwrap_or_default();
+    let seconds = match qp.get("seconds").map(|s| s.parse::<u64>()) {
+        None => 10,
+        Some(Ok(s)) if (1..=300).contains(&s) => s,
+        Some(_) => {
+            return Ok(plaintext_response(
+                hyper::StatusCode::BAD_REQUEST,
+                "invalid seconds value; expected 1-300\n".into(),
+            ));
+        }
+    };
+    // Default matches Go's CPU profiler. Higher rates severely under-report on a
+    // multi-core-busy process: SIGPROF is non-queuing, so expirations coalesce, and
+    // pprof-rs's handler serializes all threads through one lock and drops samples
+    // that arrive while it is held.
+    let frequency = match qp.get("frequency").map(|s| s.parse::<i32>()) {
+        None => 100,
+        Some(Ok(f)) if (1..=1000).contains(&f) => f,
+        Some(_) => {
+            return Ok(plaintext_response(
+                hyper::StatusCode::BAD_REQUEST,
+                "invalid frequency value; expected 1-1000\n".into(),
+            ));
+        }
+    };
+
     use pprof::protos::Message;
     let guard = pprof::ProfilerGuardBuilder::default()
-        .frequency(1000)
-        // .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .frequency(frequency)
         .build()?;
 
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    tokio::time::sleep(Duration::from_secs(seconds)).await;
     let report = guard.report().build()?;
     let profile = report.pprof()?;
 


### PR DESCRIPTION
- more reasonable default pprof frequency (100hz)
- configure frequency by query param

Started this work after seeing a ztunnel profile which seemed to have a lot of missing data. Turns out the pprof-rs crate has a global write lock which is accessed by try. When a handler fails to grab the mutex, it silently drops that data rather than forming a queue behind the mutex.

100hz is the value used by golang and the value used in the pprof-rs multi-thread example.

Testing results:

| frequency (Hz) | captured CPU (s) | actual CPU (s) | capture ratio |
| --- | --- | --- | --- |
| 10 | 26.60 | 29.01 | 91.7% |
| 50 | 26.90 | 29.30 | 91.8% |
| 100 | 26.72 | 29.31 | 91.2% |
| 200 | 26.84 | 29.43 | 91.2% |
| 300 | 25.00 | 29.46 | 84.9% |
| 400 | 21.62 | 29.49 | 73.3% |
| 500 | 19.23 | 29.43 | 65.3% |
| 600 | 17.27 | 29.61 | 58.3% |
| 700 | 15.98 | 29.47 | 54.2% |
| 800 | 15.23 | 29.45 | 51.7% |
| 900 | 14.69 | 29.00 | 50.7% |
| 1000 | 13.90 | 29.13 | 47.7% |