### PR TITLE
[release-1.29] Add test coverage for `apply_endpoints`

### DIFF
--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -713,4 +713,113 @@ mod tests {
     fn ip(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
         IpAddr::V4(Ipv4Addr::new(a, b, c, d))
     }
+
+    fn nshost(name: &str, ns: &str) -> NamespacedHostname {
+        NamespacedHostname {
+            namespace: ns.into(),
+            hostname: format!("{name}.{ns}.svc.cluster.local").into(),
+        }
+    }
+
+    fn endpoint(uid: &str, status: HealthStatus) -> Endpoint {
+        Endpoint {
+            workload_uid: uid.into(),
+            port: HashMap::new(),
+            status,
+        }
+    }
+
+    // Endpoints arriving before their service are staged, not reindexed, until the
+    // service materializes; on flush the unhealthy one is filtered out.
+    #[test]
+    fn apply_endpoints_stages_and_filters_on_flush() {
+        let mut store = ServiceStore::default();
+        let host = nshost("svc", "ns");
+
+        let mut upserts = HashMap::new();
+        upserts.insert(
+            "ep-healthy".into(),
+            endpoint("ep-healthy", HealthStatus::Healthy),
+        );
+        upserts.insert(
+            "ep-unhealthy".into(),
+            endpoint("ep-unhealthy", HealthStatus::Unhealthy),
+        );
+        store.apply_endpoints(&host, upserts, HashSet::new());
+
+        // Staged, not applied: no service exists yet, so nothing is reindexed.
+        assert_eq!(store.num_staged_services(), 1);
+        assert_eq!(store.endpoint_reindexes(), 0);
+        assert!(store.get_by_namespaced_host(&host).is_none());
+
+        // Once the service arrives, staged endpoints are flushed and the unhealthy
+        // one is filtered out.
+        store.insert(make_service("svc", "ns", vec![ip(10, 0, 0, 1)], vec![]));
+        assert_eq!(store.num_staged_services(), 0);
+        let svc = store.get_by_namespaced_host(&host).unwrap();
+        assert_eq!(svc.endpoints.len(), 1);
+        assert!(svc.endpoints.contains(&"ep-healthy".into()));
+        assert!(!svc.endpoints.contains(&"ep-unhealthy".into()));
+    }
+
+    // Removals against staged (not-yet-received) services: pruning an entry keeps
+    // the service key staged, emptying the staged map drops the key, and a removal
+    // with nothing staged is a no-op (no panic, no empty entry created).
+    #[test]
+    fn apply_endpoints_staged_removals() {
+        let mut store = ServiceStore::default();
+        let host = nshost("svc", "ns");
+
+        let mut upserts = HashMap::new();
+        upserts.insert("ep1".into(), endpoint("ep1", HealthStatus::Healthy));
+        upserts.insert("ep2".into(), endpoint("ep2", HealthStatus::Healthy));
+        store.apply_endpoints(&host, upserts, HashSet::new());
+        assert_eq!(store.num_staged_services(), 1);
+
+        // Remove one of two staged endpoints: the service key remains staged.
+        store.apply_endpoints(&host, HashMap::new(), HashSet::from(["ep1".into()]));
+        assert_eq!(store.num_staged_services(), 1);
+
+        // Removing the last staged endpoint drops the staged service entirely.
+        store.apply_endpoints(&host, HashMap::new(), HashSet::from(["ep2".into()]));
+        assert_eq!(store.num_staged_services(), 0);
+
+        // Removing again with nothing staged is a no-op: no empty entry created.
+        store.apply_endpoints(&host, HashMap::new(), HashSet::from(["missing".into()]));
+        assert_eq!(store.num_staged_services(), 0);
+        assert_eq!(store.endpoint_reindexes(), 0);
+    }
+
+    // A workload re-insertion puts the same uid in both removals and upserts in
+    // one batch. Removals are applied before upserts, so when the new endpoint
+    // is health-filtered out the stale one is still dropped.
+    #[test]
+    fn apply_endpoints_present_removal_before_filtered_upsert() {
+        let mut store = ServiceStore::default();
+        let host = nshost("svc", "ns");
+
+        // Service present, with a healthy endpoint already applied.
+        store.insert(make_service("svc", "ns", vec![ip(10, 0, 0, 1)], vec![]));
+        let mut upserts = HashMap::new();
+        upserts.insert("ep1".into(), endpoint("ep1", HealthStatus::Healthy));
+        store.apply_endpoints(&host, upserts, HashSet::new());
+        assert_eq!(store.endpoint_reindexes(), 1);
+        assert!(
+            store
+                .get_by_namespaced_host(&host)
+                .unwrap()
+                .endpoints
+                .contains(&"ep1".into())
+        );
+
+        // Re-insertion of the same uid, now unhealthy: the removal drops the stale
+        // endpoint and the unhealthy upsert is filtered out, so ep1 disappears.
+        let mut upserts = HashMap::new();
+        upserts.insert("ep1".into(), endpoint("ep1", HealthStatus::Unhealthy));
+        store.apply_endpoints(&host, upserts, HashSet::from(["ep1".into()]));
+        assert_eq!(store.endpoint_reindexes(), 2);
+        let svc = store.get_by_namespaced_host(&host).unwrap();
+        assert_eq!(svc.endpoints.len(), 0);
+        assert!(!svc.endpoints.contains(&"ep1".into()));
+    }
 }

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -821,4 +821,36 @@ mod tests {
         assert_eq!(svc.endpoints.len(), 0);
         assert!(!svc.endpoints.contains(&"ep1".into()));
     }
+
+    // A healthy re-upsert of an already-present uid (same uid in both the removal and the upsert) must
+    // leave the new endpoint in place.
+    #[test]
+    fn apply_endpoints_present_removal_applied_before_upsert() {
+        let mut store = ServiceStore::default();
+        let host = nshost("svc", "ns");
+
+        // Service present, with the original endpoint (port 80 -> 8080).
+        store.insert(make_service("svc", "ns", vec![ip(10, 0, 0, 1)], vec![]));
+        let mut old = endpoint("ep1", HealthStatus::Healthy);
+        old.port = HashMap::from([(80, 8080)]);
+        store.apply_endpoints(&host, HashMap::from([("ep1".into(), old)]), HashSet::new());
+
+        // Same uid removed and re-upserted (healthy) in one batch, now port 90 -> 9090.
+        let mut new = endpoint("ep1", HealthStatus::Healthy);
+        new.port = HashMap::from([(90, 9090)]);
+        store.apply_endpoints(
+            &host,
+            HashMap::from([("ep1".into(), new)]),
+            HashSet::from(["ep1".into()]),
+        );
+
+        // The new endpoint survives (not deleted by its own removal) and reflects
+        // the upsert, not the stale port mapping.
+        let svc = store.get_by_namespaced_host(&host).unwrap();
+        assert_eq!(svc.endpoints.len(), 1);
+        assert_eq!(
+            svc.endpoints.get(&"ep1".into()).unwrap().port,
+            HashMap::from([(90, 9090)])
+        );
+    }
 }

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -681,3 +681,36 @@ impl<'a> ServiceMatch<'a> {
             .into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ipnet::IpNet;
+    use std::net::Ipv4Addr;
+
+    fn make_service(name: &str, ns: &str, vips: Vec<IpAddr>, _cidrs: Vec<IpNet>) -> Service {
+        Service {
+            name: name.into(),
+            namespace: ns.into(),
+            hostname: format!("{name}.{ns}.svc.cluster.local").into(),
+            vips: vips
+                .into_iter()
+                .map(|ip| NetworkAddress {
+                    address: ip,
+                    network: crate::strng::EMPTY,
+                })
+                .collect(),
+            ports: HashMap::new(),
+            endpoints: EndpointSet::from_list([]),
+            subject_alt_names: vec![],
+            waypoint: None,
+            load_balancer: None,
+            ip_families: None,
+            canonical: false,
+        }
+    }
+
+    fn ip(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+}

--- a/src/state/service.rs
+++ b/src/state/service.rs
@@ -790,11 +790,10 @@ mod tests {
         assert_eq!(store.endpoint_reindexes(), 0);
     }
 
-    // A workload re-insertion puts the same uid in both removals and upserts in
-    // one batch. Removals are applied before upserts, so when the new endpoint
-    // is health-filtered out the stale one is still dropped.
+    // A workload going unhealthy on re-insertion (same uid in both the removal and
+    // the upsert) must still evict its previously-healthy endpoint.
     #[test]
-    fn apply_endpoints_present_removal_before_filtered_upsert() {
+    fn apply_endpoints_present_unhealthy_reinsert_evicts() {
         let mut store = ServiceStore::default();
         let host = nshost("svc", "ns");
 


### PR DESCRIPTION
Manual cherry-pick of #2002 to release-1.29. Fixes #2008.

The automated cherry-pick failed to apply: release-1.29 already has the `apply_endpoints` API (backported via #2003) but not the `mod tests` scaffolding the new tests attach to, so the patch had nothing to merge into. So I manually added the test scaffold (`mod tests`, `make_service`, `ip`).

