### PR TITLE
Add HBONE pool coordination benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ harness = false
 name = "basic"
 harness = false
 
+[[bench]]
+name = "pool"
+harness = false
+
 [dependencies]
 # Enabled with 'tls-boring'
 boring-rustls-provider = { git = "https://github.com/janrueth/boring-rustls-provider", optional = true } #

--- a/benches/pool.rs
+++ b/benches/pool.rs
@@ -1,0 +1,195 @@
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, SamplingMode, criterion_group, criterion_main};
+use futures_util::future;
+use tokio::runtime::Runtime;
+use ztunnel::proxy::pool::benchmarks::{ProductionPool, ProductionPoolFixture};
+
+#[cfg(target_os = "linux")]
+mod profiler;
+
+#[cfg(target_os = "linux")]
+use profiler::{Output, PProfProfiler};
+
+fn criterion_config() -> Criterion {
+    let criterion = Criterion::default();
+    #[cfg(target_os = "linux")]
+    {
+        criterion.with_profiler(PProfProfiler::new(100, Output::Protobuf))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        criterion
+    }
+}
+
+fn runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+async fn run_pool(pool: Arc<ProductionPool>, destinations: usize, callers_per_destination: usize) {
+    let tasks = (0..destinations)
+        .flat_map(|key| (0..callers_per_destination).map(move |_| key))
+        .map(|key| {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.checkout(key).await })
+        });
+    future::join_all(tasks)
+        .await
+        .into_iter()
+        .for_each(|result| result.unwrap());
+}
+
+async fn checkout_latencies(
+    fixture: &ProductionPoolFixture,
+    iterations: usize,
+    callers: usize,
+) -> Vec<Duration> {
+    let mut latencies = Vec::with_capacity(iterations * callers);
+    for _ in 0..iterations {
+        let pool = Arc::new(fixture.pool());
+        let tasks = (0..callers).map(|_| {
+            let pool = pool.clone();
+            tokio::spawn(async move {
+                let start = Instant::now();
+                pool.checkout(0).await;
+                start.elapsed()
+            })
+        });
+        latencies.extend(
+            future::join_all(tasks)
+                .await
+                .into_iter()
+                .map(Result::unwrap),
+        );
+    }
+    latencies
+}
+
+fn percentile(latencies: &mut [Duration], percentile: usize) -> Duration {
+    latencies.sort_unstable();
+    latencies[(latencies.len() - 1) * percentile / 100]
+}
+
+fn available_connection(c: &mut Criterion) {
+    let runtime = runtime();
+    let fixture = runtime.block_on(ProductionPoolFixture::new(1));
+    let pool = fixture.pool();
+    runtime.block_on(pool.checkout(0));
+
+    let mut group = c.benchmark_group("hbone_pool_available_with_idle");
+    group.measurement_time(Duration::from_secs(3));
+    group.bench_function("production", |bencher| {
+        bencher.to_async(&runtime).iter(|| async {
+            pool.checkout(black_box(0)).await;
+        });
+    });
+    group.finish();
+}
+
+fn same_destination_storm(c: &mut Criterion) {
+    let runtime = runtime();
+    let fixture = runtime.block_on(ProductionPoolFixture::new(1));
+    runtime.block_on(async {
+        let mut latencies = checkout_latencies(&fixture, 50, 32).await;
+        println!(
+            "hbone_pool_latency_probe callers=32 samples={} median_ns={} p99_ns={}",
+            latencies.len(),
+            percentile(&mut latencies, 50).as_nanos(),
+            percentile(&mut latencies, 99).as_nanos(),
+        );
+
+        let pool = Arc::new(fixture.pool());
+        run_pool(pool.clone(), 1, 100).await;
+        assert_eq!(pool.factory_calls(), 1);
+        println!(
+            "hbone_pool_single_flight_probe callers=100 factory_calls={} \
+             destination_wakeups={} unrelated_wakeups={}",
+            pool.factory_calls(),
+            pool.wakeups(),
+            pool.unrelated_wakeups(),
+        );
+    });
+
+    let mut group = c.benchmark_group("hbone_pool_same_destination_spawned");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(2));
+    group.sample_size(20);
+    group.sampling_mode(SamplingMode::Flat);
+    for callers in [1usize, 8, 32, 128, 512] {
+        group.bench_with_input(
+            BenchmarkId::new("production", callers),
+            &callers,
+            |bencher, &callers| {
+                bencher.to_async(&runtime).iter_batched(
+                    || Arc::new(fixture.pool()),
+                    |pool| async move {
+                        run_pool(pool.clone(), 1, callers).await;
+                        black_box(pool.factory_calls());
+                        black_box(pool.wakeups());
+                        pool
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn many_destinations(c: &mut Criterion) {
+    let runtime = runtime();
+    let fixture = runtime.block_on(ProductionPoolFixture::new(1_000));
+    runtime.block_on(async {
+        let pool = Arc::new(fixture.pool());
+        run_pool(pool.clone(), 100, 2).await;
+        println!(
+            "hbone_pool_wakeup_probe destinations=100 callers_per_destination=2 \
+             factory_calls={} destination_wakeups={} unrelated_wakeups={}",
+            pool.factory_calls(),
+            pool.wakeups(),
+            pool.unrelated_wakeups(),
+        );
+    });
+
+    let mut group = c.benchmark_group("hbone_pool_many_destinations_spawned");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(2));
+    group.sample_size(20);
+    group.sampling_mode(SamplingMode::Flat);
+    for destinations in [100usize, 1_000] {
+        group.bench_with_input(
+            BenchmarkId::new("production", destinations),
+            &destinations,
+            |bencher, &destinations| {
+                bencher.to_async(&runtime).iter_batched(
+                    || Arc::new(fixture.pool()),
+                    |pool| async move {
+                        run_pool(pool.clone(), destinations, 2).await;
+                        black_box(pool.factory_calls());
+                        black_box(pool.wakeups());
+                        pool
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets =
+        available_connection,
+        same_destination_storm,
+        many_destinations
+}
+criterion_main!(benches);

--- a/src/proxy/h2/client.rs
+++ b/src/proxy/h2/client.rs
@@ -153,6 +153,43 @@ impl H2ConnectClient {
     pub fn revoked_receiver(&self) -> Option<watch::Receiver<bool>> {
         self.revoked_rx.clone()
     }
+
+    #[cfg(feature = "testing")]
+    pub async fn benchmark_client(wl_key: WorkloadKey, max_allowed_streams: u16) -> Self {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        tokio::spawn(async move {
+            let Ok(mut server) = h2::server::handshake(server_io).await else {
+                return;
+            };
+
+            while let Some(request) = server.accept().await {
+                let Ok((_request, mut respond)) = request else {
+                    return;
+                };
+
+                let _ = respond.send_response(http::Response::new(()), true);
+            }
+        });
+
+        let (sender, connection) = h2::client::Builder::new()
+            .initial_max_send_streams(max_allowed_streams as usize)
+            .handshake::<_, Bytes>(client_io)
+            .await
+            .unwrap();
+
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+
+        Self {
+            sender,
+            max_allowed_streams,
+            stream_count: Arc::new(AtomicU16::new(0)),
+            wl_key,
+            revoked_rx: None,
+        }
+    }
 }
 
 pub async fn spawn_connection(

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -22,6 +22,8 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use std::sync::Arc;
+#[cfg(feature = "testing")]
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use tokio::sync::watch;
@@ -50,13 +52,15 @@ use tokio::io;
 #[derive(Clone)]
 pub struct WorkloadHBONEPool {
     state: Arc<PoolState>,
-    pool_watcher: watch::Receiver<bool>,
+    pool_watcher: watch::Receiver<u64>,
 }
 
 // PoolState is effectively the gnarly inner state stuff that needs thread/task sync, and should be wrapped in a Mutex.
 struct PoolState {
-    pool_notifier: watch::Sender<bool>, // This is already impl clone? rustc complains that it isn't, tho
-    timeout_tx: watch::Sender<bool>, // This is already impl clone? rustc complains that it isn't, tho
+    // The hash key identifies which destination caused the notification.
+    pool_notifier: watch::Sender<u64>,
+    timeout_tx: watch::Sender<bool>,
+    timeout_rx: watch::Receiver<bool>,
     // this is effectively just a convenience data type - a rwlocked hashmap with keying and LRU drops
     // and has no actual hyper/http/connection logic.
     connected_pool: Arc<pingora_pool::ConnectionPool<H2ConnectClient>>,
@@ -66,7 +70,11 @@ struct PoolState {
     // This is merely a counter to track the overall number of conns this pool spawns
     // to ensure we get unique poolkeys-per-new-conn, it is not a limit
     pool_global_conn_count: AtomicI32,
-    spawner: ConnSpawner,
+    factory: Arc<dyn ConnectionFactory>,
+    #[cfg(feature = "testing")]
+    synchronization_wakeups: AtomicU64,
+    #[cfg(feature = "testing")]
+    unrelated_wakeups: AtomicU64,
 }
 
 struct ConnSpawner {
@@ -78,8 +86,14 @@ struct ConnSpawner {
     metrics: Arc<crate::proxy::Metrics>,
 }
 
+#[async_trait::async_trait]
+trait ConnectionFactory: Send + Sync {
+    async fn new_pool_conn(&self, key: WorkloadKey) -> Result<H2ConnectClient, Error>;
+}
+
 // Does nothing but spawn new conns when asked
-impl ConnSpawner {
+#[async_trait::async_trait]
+impl ConnectionFactory for ConnSpawner {
     async fn new_pool_conn(&self, key: WorkloadKey) -> Result<H2ConnectClient, Error> {
         debug!("spawning new pool conn for {}", key);
 
@@ -151,7 +165,7 @@ impl PoolState {
             return;
         }
         let (evict, pickup) = self.connected_pool.put(&pool_key, conn);
-        let rx = self.spawner.timeout_rx.clone();
+        let rx = self.timeout_rx.clone();
         let pool_ref = self.connected_pool.clone();
         let pool_key_ref = pool_key.clone();
         let release_timeout = self.pool_unused_release_timeout;
@@ -168,7 +182,7 @@ impl PoolState {
             }
             .in_current_span(),
         );
-        let _ = self.pool_notifier.send(true);
+        let _ = self.pool_notifier.send(pool_key.key);
     }
 
     // Since we are using a hash key to do lookup on the inner pingora pool, do a get guard
@@ -244,7 +258,7 @@ impl PoolState {
             Ok(_guard) => {
                 // BEGIN take inner writelock
                 debug!("nothing else is creating a conn and we won the lock, make one");
-                let client = self.spawner.new_pool_conn(workload_key.clone()).await?;
+                let client = self.factory.new_pool_conn(workload_key.clone()).await?;
 
                 debug!(
                     "checking in new conn for {} with pk {:?}",
@@ -325,7 +339,7 @@ impl PoolState {
                 }
                 None => {
                     debug!("new connection needed for {}", workload_key);
-                    break self.spawner.new_pool_conn(workload_key.clone()).await?;
+                    break self.factory.new_pool_conn(workload_key.clone()).await?;
                 }
             };
         };
@@ -359,33 +373,37 @@ impl WorkloadHBONEPool {
         crl_manager: Option<Arc<crate::tls::crl::CrlManager>>,
         metrics: Arc<crate::proxy::Metrics>,
     ) -> WorkloadHBONEPool {
+        let (pool_notifier, pool_watcher) = watch::channel(0u64);
         let (timeout_tx, timeout_rx) = watch::channel(false);
-        let (timeout_send, timeout_recv) = watch::channel(false);
         let pool_duration = cfg.pool_unused_release_timeout;
 
-        let spawner = ConnSpawner {
+        let factory = Arc::new(ConnSpawner {
             cfg,
             socket_factory,
             local_workload,
-            timeout_rx: timeout_recv.clone(),
+            timeout_rx: timeout_rx.clone(),
             crl_manager,
             metrics,
-        };
+        });
 
         Self {
             state: Arc::new(PoolState {
-                pool_notifier: timeout_tx,
-                timeout_tx: timeout_send,
-                // timeout_rx: timeout_recv,
-                // the number here is simply the number of unique src/dest keys
+                pool_notifier,
+                timeout_tx,
+                timeout_rx,
+                // The number here is simply the number of unique src/dest keys
                 // the pool is expected to track before the inner hashmap resizes.
                 connected_pool: Arc::new(pingora_pool::ConnectionPool::new(500)),
                 established_conn_writelock: flurry::HashMap::new(),
                 pool_unused_release_timeout: pool_duration,
                 pool_global_conn_count: AtomicI32::new(0),
-                spawner,
+                factory,
+                #[cfg(feature = "testing")]
+                synchronization_wakeups: AtomicU64::new(0),
+                #[cfg(feature = "testing")]
+                unrelated_wakeups: AtomicU64::new(0),
             }),
-            pool_watcher: timeout_rx,
+            pool_watcher,
         }
     }
 
@@ -498,6 +516,17 @@ impl WorkloadHBONEPool {
                 loop {
                     match self.pool_watcher.changed().await {
                         Ok(_) => {
+                            #[cfg(feature = "testing")]
+                            {
+                                let notified_key = *self.pool_watcher.borrow();
+                                self.state
+                                    .synchronization_wakeups
+                                    .fetch_add(1, Ordering::Relaxed);
+                                if notified_key != hash_key {
+                                    self.state.unrelated_wakeups.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+
                             trace!(
                                 "notified a new conn was enpooled, checking for hash {:?}",
                                 hash_key
@@ -532,6 +561,129 @@ impl WorkloadHBONEPool {
     }
 }
 
+#[cfg(feature = "testing")]
+pub mod benchmarks {
+    use super::{ConnectionFactory, PoolState, WorkloadHBONEPool};
+    use crate::proxy::h2::client::{H2ConnectClient, WorkloadKey};
+    use std::collections::HashMap;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicI32, AtomicU64, AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tokio::sync::watch;
+
+    struct BenchmarkFactory {
+        clients: Arc<HashMap<WorkloadKey, H2ConnectClient>>,
+        factory_calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl ConnectionFactory for BenchmarkFactory {
+        async fn new_pool_conn(&self, key: WorkloadKey) -> Result<H2ConnectClient, super::Error> {
+            self.factory_calls.fetch_add(1, Ordering::Relaxed);
+
+            // Allow competing checkout tasks to reach the coordination path.
+            tokio::task::yield_now().await;
+
+            self.clients
+                .get(&key)
+                .cloned()
+                .ok_or_else(|| std::io::Error::other("missing benchmark connection").into())
+        }
+    }
+
+    pub struct ProductionPoolFixture {
+        clients: Arc<HashMap<WorkloadKey, H2ConnectClient>>,
+        keys: Arc<Vec<WorkloadKey>>,
+    }
+
+    impl ProductionPoolFixture {
+        pub async fn new(destinations: usize) -> Self {
+            let keys = (0..destinations)
+                .map(|index| WorkloadKey {
+                    src_id: crate::identity::Identity::default(),
+                    dst_id: vec![crate::identity::Identity::default()],
+                    dst: SocketAddr::new(
+                        IpAddr::V4(Ipv4Addr::LOCALHOST),
+                        10_000 + u16::try_from(index).unwrap(),
+                    ),
+                    src: IpAddr::V4(Ipv4Addr::LOCALHOST),
+                })
+                .collect::<Vec<_>>();
+
+            let mut clients = HashMap::with_capacity(keys.len());
+            for key in &keys {
+                clients.insert(
+                    key.clone(),
+                    H2ConnectClient::benchmark_client(key.clone(), u16::MAX).await,
+                );
+            }
+
+            Self {
+                clients: Arc::new(clients),
+                keys: Arc::new(keys),
+            }
+        }
+
+        pub fn pool(&self) -> ProductionPool {
+            let factory = Arc::new(BenchmarkFactory {
+                clients: self.clients.clone(),
+                factory_calls: AtomicUsize::new(0),
+            });
+
+            let (pool_notifier, pool_watcher) = watch::channel(0u64);
+            let (timeout_tx, timeout_rx) = watch::channel(false);
+
+            ProductionPool {
+                pool: WorkloadHBONEPool {
+                    state: Arc::new(PoolState {
+                        pool_notifier,
+                        timeout_tx,
+                        timeout_rx,
+                        connected_pool: Arc::new(pingora_pool::ConnectionPool::new(500)),
+                        established_conn_writelock: flurry::HashMap::new(),
+                        pool_unused_release_timeout: Duration::from_secs(60),
+                        pool_global_conn_count: AtomicI32::new(0),
+                        factory: factory.clone(),
+                        synchronization_wakeups: AtomicU64::new(0),
+                        unrelated_wakeups: AtomicU64::new(0),
+                    }),
+                    pool_watcher,
+                },
+                keys: self.keys.clone(),
+                factory,
+            }
+        }
+    }
+
+    pub struct ProductionPool {
+        pool: WorkloadHBONEPool,
+        keys: Arc<Vec<WorkloadKey>>,
+        factory: Arc<BenchmarkFactory>,
+    }
+
+    impl ProductionPool {
+        pub async fn checkout(&self, key: usize) {
+            let mut pool = self.pool.clone();
+            pool.connect(&self.keys[key]).await.unwrap();
+        }
+
+        pub fn factory_calls(&self) -> usize {
+            self.factory.factory_calls.load(Ordering::Relaxed)
+        }
+
+        pub fn wakeups(&self) -> u64 {
+            self.pool
+                .state
+                .synchronization_wakeups
+                .load(Ordering::Relaxed)
+        }
+
+        pub fn unrelated_wakeups(&self) -> u64 {
+            self.pool.state.unrelated_wakeups.load(Ordering::Relaxed)
+        }
+    }
+}
 #[cfg(test)]
 mod test {
     use std::convert::Infallible;


### PR DESCRIPTION
Adds benchmarks for HBONE connection-pool coordination.

The benchmarks measures the pool implementation using an in-memory HTTP/2 connection fixture. 

1. checkout of an available pooled connection;
2. concurrent checkout requests for one destination;
3. concurrent checkout requests across many destination keys;
4. single-flight connection creation;
5. shared pool notifications that wake tasks waiting for unrelated destinations.

Run with:

cargo bench --bench pool --no-run
cargo bench --bench pool -- hbone_pool_same_destination_spawned
cargo bench --bench pool -- hbone_pool_many_destinations_spawned


hbone_pool_latency_probe callers=32 samples=1600 median_ns=42625 p99_ns=100500
hbone_pool_single_flight_probe callers=100 factory_calls=1 destination_wakeups=0 unrelated_wakeups=0
hbone_pool_wakeup_probe destinations=100 callers_per_destination=2 factory_calls=100 destination_wakeups=4 unrelated_wakeups=4

many-destination result records unrelated_wakeups > 0, demonstrating that the pool-wide notification can wake a task even when the newly available connection belongs to a different destination key. The exact number of wake-ups is scheduler-dependent.
