### PR TITLE
Use R2 credential region for uploads

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,9 +56,11 @@ fi
 
 R2_DEST="${DEST/gs:\/\//s3:\/\/}"
 ENDPOINT=$(echo "${CF_CREDENTIALS}" | jq -r '.endpoint')
+R2_REGION=$(echo "${CF_CREDENTIALS}" | jq -r '.region')
 AWS_ACCESS_KEY_ID=$(echo "${CF_CREDENTIALS}" | jq -r '.access_key') \
     AWS_SECRET_ACCESS_KEY=$(echo "${CF_CREDENTIALS}" | jq -r '.secret_key') \
     AWS_SESSION_TOKEN=$(echo "${CF_CREDENTIALS}" | jq -r '.session_token') \
+    AWS_REGION="${R2_REGION}" \
     aws s3 cp "${WD}/../out/rust/release/ztunnel" \
     "${R2_DEST}/${RELEASE_NAME}" \
     --endpoint-url "${ENDPOINT}"


### PR DESCRIPTION
The release script passed the Cloudflare R2 endpoint to `aws s3 cp` but inherited the workload region (`us-west-2`). R2 requires the region stored in the credential secret (`auto`).

Read `.region` from `CF_CREDENTIALS` and scope `AWS_REGION` to the R2 upload invocation.

we do a similar thing here: https://github.com/istio/proxy/blob/98e840f31e7a7079bd4f74bc95cd3d72fe91ebe8/scripts/release-binary.sh#L183-L183