### PR TITLE
Bump the all-dependencies group with 2 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e30e509674ef0ec91e21a7735766db37d163d46151b6a361d8b83dd79116bd"
+checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -4873,7 +4879,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "backoff",
- "base64 0.22.1",
+ "base64 0.23.0",
  "boring",
  "boring-rustls-provider",
  "boring-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ openssl-sys = { version = "0.9", optional = true }
 anyhow = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"
-base64 = "0.22"
+base64 = "0.23"
 byteorder = "1.5"
 bytes = { version = "1.11", features = ["serde"] }
 chrono = "0.4"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -248,6 +248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,7 +4095,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "backoff",
- "base64 0.22.1",
+ "base64 0.23.1",
  "byteorder",
  "bytes",
  "chrono",


### PR DESCRIPTION
replaces #2020 with the fuzz lockfile regenerated so check-clean-repo passes