### PR TITLE
Sync workload.proto with istio master

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -77,6 +77,7 @@ pub fn xds(c: &mut Criterion) {
                                     ports: vec![Port {
                                         service_port: 80,
                                         target_port: 1234,
+                                        app_protocol: 0,
                                     }],
                                 },
                             )]),
@@ -144,6 +145,7 @@ fn build_load_balancer(
         ports: vec![Port {
             service_port: 80,
             target_port: 0,
+            app_protocol: 0,
         }],
         load_balancing,
         ..Default::default()
@@ -169,6 +171,7 @@ fn build_load_balancer(
                             ports: vec![Port {
                                 service_port: 80,
                                 target_port: 1234,
+                                app_protocol: 0,
                             }],
                         },
                     )]),
@@ -303,6 +306,7 @@ fn one_service(hostname: &str, addr: [u8; 4]) -> XdsService {
         ports: vec![Port {
             service_port: 80,
             target_port: 0,
+            app_protocol: 0,
         }],
         ..Default::default()
     }
@@ -318,6 +322,7 @@ fn build_workloads(n: usize, svc_for: impl Fn(usize) -> Option<String>) -> Vec<X
                         ports: vec![Port {
                             service_port: 80,
                             target_port: 1234,
+                            app_protocol: 0,
                         }],
                     },
                 )]),

--- a/proto/workload.proto
+++ b/proto/workload.proto
@@ -94,6 +94,11 @@ message Service {
   // when there is not a match in the namespace of the client.
   bool canonical = 11;
 
+  // ingress_use_waypoint indicates that ingress gateways should send traffic destined
+  // for this service through the service's waypoint proxy.
+  // This is controlled by the istio.io/ingress-use-waypoint label on the Service or its namespace.
+  bool ingress_use_waypoint = 12;
+
   // weighted_waypoints, when non-empty, describes a weighted set of waypoints for this
   // service, and the client dataplane selects one waypoint per connection proportional to
   // each entry's weight. This is used to shift a configurable share of a service's
@@ -104,7 +109,6 @@ message Service {
   // set, `waypoint` remains populated with the primary waypoint so that dataplanes which do
   // not understand this field continue to send all traffic to the primary.
   repeated WeightedWaypoint weighted_waypoints = 13;
-
   // Visibility controls which clients can resolve and send traffic to a service.
   enum Visibility {
     // Visible to every client the control plane serves. This is the default,
@@ -339,6 +343,17 @@ message Port {
   uint32 service_port = 1;
   // Port the service forwards to (backend).
   uint32 target_port = 2;
+  // Application level protocol
+  AppProtocol app_protocol = 3;
+}
+
+enum AppProtocol {
+  UNKNOWN = 0;
+  HTTP11 = 1;
+  HTTP2 = 2;
+  GRPC = 3;
+  TCP = 4;
+  TLS = 5;
 }
 
 // TunnelProtocol indicates the tunneling protocol for requests.
@@ -348,6 +363,9 @@ enum TunnelProtocol {
   // HBONE means requests should be tunneled over HTTP.
   // This does not dictate HTTP/1.1 vs HTTP/2; ALPN should be used for that purpose.
   HBONE = 1;
+  // The workload supports the legacy "istio" mTLS (without HBONE tunnel).
+  // Note: ztunnel does not support sending legacy Istio mTLS.
+  LEGACY_ISTIO_MTLS = 2;
   // Future options may include things like QUIC/HTTP3, etc.
 }
 
@@ -396,7 +414,8 @@ message WeightedWaypoint {
   GatewayAddress destination = 1;
   // Relative weight for selecting this waypoint. The realized share of connections
   // sent to this waypoint is weight / (sum of weights in the set). A weight of 0
-  // means the waypoint is described but receives no traffic.
+  // means the waypoint is described (and may be validated/reported) but receives no
+  // traffic.
   uint32 weight = 2;
 }
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -747,6 +747,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             )]),
@@ -772,6 +773,7 @@ mod tests {
             ports: vec![XdsPort {
                 service_port: 80,
                 target_port: 80,
+                app_protocol: 0,
             }],
             subject_alt_names: vec!["SAN1".to_string(), "SAN2".to_string()],
             waypoint: None,
@@ -785,6 +787,7 @@ mod tests {
             extensions: Default::default(),
             canonical: true,
             visibility: 0,
+            ingress_use_waypoint: false,
         };
 
         let auth = XdsAuthorization {

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -1946,6 +1946,7 @@ mod tests {
             ports: vec![XdsPort {
                 service_port: 80,
                 target_port: 80,
+                app_protocol: 0,
             }],
             ..Default::default()
         }
@@ -2006,6 +2007,7 @@ mod tests {
                             ports: vec![XdsPort {
                                 service_port: 80,
                                 target_port: 80,
+                                app_protocol: 0,
                             }],
                         },
                     );

--- a/src/proxy/outbound.rs
+++ b/src/proxy/outbound.rs
@@ -1012,6 +1012,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                     ..Default::default()
                 }),
@@ -1025,6 +1026,7 @@ mod tests {
                             ports: vec![Port {
                                 service_port: 80,
                                 target_port: 8080,
+                                app_protocol: 0,
                             }],
                         },
                     )]),
@@ -1054,6 +1056,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                     ..Default::default()
                 }),
@@ -1079,6 +1082,7 @@ mod tests {
                             ports: vec![Port {
                                 service_port: 80,
                                 target_port: 8080,
+                                app_protocol: 0,
                             }],
                         },
                     )]),
@@ -1114,6 +1118,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                     ..Default::default()
                 }),
@@ -1127,6 +1132,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 15009,
                         target_port: 15009,
+                        app_protocol: 0,
                     }],
                     ..Default::default()
                 }),
@@ -1151,6 +1157,7 @@ mod tests {
                             ports: vec![Port {
                                 service_port: 80,
                                 target_port: 8080,
+                                app_protocol: 0,
                             }],
                         },
                     )]),
@@ -1166,6 +1173,7 @@ mod tests {
                             ports: vec![Port {
                                 service_port: 15009,
                                 target_port: 15008,
+                                app_protocol: 0,
                             }],
                         },
                     )]),
@@ -1195,6 +1203,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                     waypoint: Some(xds::istio::workload::GatewayAddress {
                         destination: Some(
@@ -1219,6 +1228,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 15008,
                         target_port: 15008,
+                        app_protocol: 0,
                     }],
                     ..Default::default()
                 }),
@@ -1244,6 +1254,7 @@ mod tests {
                             ports: vec![Port {
                                 service_port: 15008,
                                 target_port: 15008,
+                                app_protocol: 0,
                             }],
                         },
                     )]),
@@ -1280,6 +1291,7 @@ mod tests {
             ports: vec![Port {
                 service_port: 80,
                 target_port: 8080,
+                app_protocol: 0,
             }],
             // Prefer routing to workloads on the same network, but when nothing is healthy locally
             // allow failing over to remote networks.
@@ -1318,6 +1330,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             )]),
@@ -1334,6 +1347,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             )]),
@@ -1351,6 +1365,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             )]),
@@ -1594,6 +1609,7 @@ mod tests {
                 ports: vec![Port {
                     service_port: 80,
                     target_port: 8080,
+                    app_protocol: 0,
                 }],
                 waypoint: Some(xds::istio::workload::GatewayAddress {
                     destination: Some(xds::istio::workload::gateway_address::Destination::Address(
@@ -1631,6 +1647,7 @@ mod tests {
                 ports: vec![Port {
                     service_port: 80,
                     target_port: 8080,
+                    app_protocol: 0,
                 }],
                 ..Default::default()
             }),
@@ -1657,10 +1674,12 @@ mod tests {
                         Port {
                             service_port: 80,
                             target_port: 0, // named port
+                            app_protocol: 0,
                         },
                         Port {
                             service_port: 8080,
                             target_port: 0, // named port
+                            app_protocol: 0,
                         },
                     ],
                     ..Default::default()
@@ -1674,6 +1693,7 @@ mod tests {
                             ports: vec![Port {
                                 service_port: 80,
                                 target_port: 1234,
+                                app_protocol: 0,
                             }],
                         },
                     )]),
@@ -1689,6 +1709,7 @@ mod tests {
                             ports: vec![Port {
                                 service_port: 8080,
                                 target_port: 9999,
+                                app_protocol: 0,
                             }],
                         },
                     )]),
@@ -1718,6 +1739,7 @@ mod tests {
                 ports: vec![Port {
                     service_port: 80,
                     target_port: 80,
+                    app_protocol: 0,
                 }],
                 ..Default::default()
             }),
@@ -1732,6 +1754,7 @@ mod tests {
                         ports: vec![Port {
                             service_port: 80,
                             target_port: 80,
+                            app_protocol: 0,
                         }],
                     },
                 )]),
@@ -1858,6 +1881,7 @@ mod tests {
                 ports: vec![Port {
                     service_port: 80,
                     target_port: 80,
+                    app_protocol: 0,
                 }],
                 ..Default::default()
             };
@@ -1941,6 +1965,7 @@ mod tests {
                 ports: vec![Port {
                     service_port: 80,
                     target_port: 80,
+                    app_protocol: 0,
                 }],
                 ..Default::default()
             }),
@@ -1989,6 +2014,7 @@ mod tests {
                 ports: vec![Port {
                     service_port: 80,
                     target_port: 80,
+                    app_protocol: 0,
                 }],
                 ..Default::default()
             }),

--- a/src/state/workload.rs
+++ b/src/state/workload.rs
@@ -63,11 +63,16 @@ pub enum InboundProtocol {
     HBONE,
 }
 
-impl From<xds::istio::workload::TunnelProtocol> for InboundProtocol {
-    fn from(value: xds::istio::workload::TunnelProtocol) -> Self {
+impl TryFrom<xds::istio::workload::TunnelProtocol> for InboundProtocol {
+    type Error = WorkloadError;
+
+    fn try_from(value: xds::istio::workload::TunnelProtocol) -> Result<Self, Self::Error> {
         match value {
-            xds::istio::workload::TunnelProtocol::Hbone => InboundProtocol::HBONE,
-            xds::istio::workload::TunnelProtocol::None => InboundProtocol::TCP,
+            xds::istio::workload::TunnelProtocol::Hbone => Ok(InboundProtocol::HBONE),
+            xds::istio::workload::TunnelProtocol::None => Ok(InboundProtocol::TCP),
+            xds::istio::workload::TunnelProtocol::LegacyIstioMtls => Err(WorkloadError::EnumParse(
+                "unsupported tunnel protocol: legacy istio mtls".to_string(),
+            )),
         }
     }
 }
@@ -360,6 +365,7 @@ impl From<HashMap<u16, u16>> for PortList {
                 .map(|(k, v)| Port {
                     service_port: *k as u32,
                     target_port: *v as u32,
+                    app_protocol: 0,
                 })
                 .collect(),
         }
@@ -465,9 +471,9 @@ impl TryFrom<XdsWorkload> for (Workload, HashMap<String, PortList>) {
             waypoint: wp,
             network_gateway: network_gw,
 
-            protocol: InboundProtocol::from(xds::istio::workload::TunnelProtocol::try_from(
+            protocol: InboundProtocol::try_from(xds::istio::workload::TunnelProtocol::try_from(
                 resource.tunnel_protocol,
-            )?),
+            )?)?,
             network_mode: NetworkMode::from(xds::istio::workload::NetworkMode::try_from(
                 resource.network_mode,
             )?),
@@ -1057,6 +1063,7 @@ mod tests {
                 ports: vec![XdsPort {
                     service_port: 80,
                     target_port: 8080,
+                    app_protocol: 0,
                 }],
             },
         )]);
@@ -1152,6 +1159,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 80,
+                        app_protocol: 0,
                     }],
                     subject_alt_names: vec![],
                     waypoint: None,
@@ -1161,6 +1169,7 @@ mod tests {
                     extensions: Default::default(),
                     canonical: true,
                     visibility: 0,
+                    ingress_use_waypoint: false,
                 },
             )
             .unwrap();
@@ -1191,6 +1200,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 80,
+                        app_protocol: 0,
                     }],
                     subject_alt_names: vec![],
                     waypoint: None,
@@ -1200,6 +1210,7 @@ mod tests {
                     extensions: Default::default(),
                     canonical: true,
                     visibility: 0,
+                    ingress_use_waypoint: false,
                 },
             )
             .unwrap();
@@ -1255,6 +1266,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 80,
+                        app_protocol: 0,
                     }],
                     subject_alt_names: vec![],
                     waypoint: None,
@@ -1264,6 +1276,7 @@ mod tests {
                     extensions: Default::default(),
                     canonical: true,
                     visibility: 0,
+                    ingress_use_waypoint: false,
                 },
             )
             .unwrap();
@@ -1518,6 +1531,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             ),
@@ -1527,6 +1541,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             ),
@@ -1576,6 +1591,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 80,
+                        app_protocol: 0,
                     }],
                     subject_alt_names: vec![],
                     waypoint: None,
@@ -1585,6 +1601,7 @@ mod tests {
                     extensions: Default::default(),
                     canonical: true,
                     visibility: 0,
+                    ingress_use_waypoint: false,
                 },
             )
             .unwrap();
@@ -1603,6 +1620,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 80,
+                        app_protocol: 0,
                     }],
                     subject_alt_names: vec![],
                     waypoint: None,
@@ -1616,6 +1634,7 @@ mod tests {
                     extensions: Default::default(),
                     canonical: true,
                     visibility: 0,
+                    ingress_use_waypoint: false,
                 },
             )
             .unwrap();
@@ -1658,6 +1677,7 @@ mod tests {
             ports: vec![XdsPort {
                 service_port: 80,
                 target_port: 80,
+                app_protocol: 0,
             }],
             subject_alt_names: vec![],
             waypoint: None,
@@ -1671,6 +1691,7 @@ mod tests {
             extensions: Default::default(),
             canonical: true,
             visibility: 0,
+            ingress_use_waypoint: false,
         };
         updater
             .insert_service(
@@ -1687,6 +1708,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 80,
+                        app_protocol: 0,
                     }],
                     subject_alt_names: vec![],
                     waypoint: None,
@@ -1696,6 +1718,7 @@ mod tests {
                     extensions: Default::default(),
                     canonical: true,
                     visibility: 0,
+                    ingress_use_waypoint: false,
                 },
             )
             .unwrap();
@@ -1710,6 +1733,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             ),
@@ -1719,6 +1743,7 @@ mod tests {
                     ports: vec![XdsPort {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             ),
@@ -1813,6 +1838,7 @@ mod tests {
                 ports: vec![XdsPort {
                     service_port: 80,
                     target_port: 8080,
+                    app_protocol: 0,
                 }],
             },
         )]);

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -677,6 +677,7 @@ mod tests {
             ports: vec![Port {
                 service_port: 80,
                 target_port: 80,
+                app_protocol: 0,
             }],
             ..Default::default()
         }
@@ -698,6 +699,7 @@ mod tests {
                     ports: vec![Port {
                         service_port: 80,
                         target_port: 8080,
+                        app_protocol: 0,
                     }],
                 },
             )]),


### PR DESCRIPTION
Side effects:
- InboundProtocol now derives from TunnelProtocol via TryFrom so the unsupported LEGACY_ISTIO_MTLS is rejected rather than silently mapped.
- app_protocol / ingress_use_waypoint added to affected struct literals.