### PR TITLE
Add MESH_CIPHER_SUITES env var for runtime TLS13 cipher suite configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -202,6 +202,15 @@ impl serde::Serialize for MetadataVector {
 
 #[derive(serde::Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct MeshTlsConfig {
+    pub crypto_provider: String,
+    pub tls12_enabled: bool,
+    pub compliance_policy: String,
+    pub cipher_suites: Vec<String>,
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Config {
     /// If true, the HBONE proxy will be used.
     pub proxy: bool,
@@ -337,6 +346,8 @@ pub struct Config {
     // path to CRL file; if set, enables CRL checking
     pub crl_path: Option<PathBuf>,
     pub enable_enhanced_baggage: bool,
+
+    pub mesh_tls: MeshTlsConfig,
 }
 
 #[derive(serde::Serialize, Clone, Copy, Debug)]
@@ -953,6 +964,13 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
             .filter(|s| !s.is_empty())
             .map(PathBuf::from),
         enable_enhanced_baggage: parse_default(ENABLE_ENHANCED_BAGGAGE, true)?,
+
+        mesh_tls: MeshTlsConfig {
+            crypto_provider: crate::tls::CRYPTO_PROVIDER.to_string(),
+            tls12_enabled: *crate::TLS12_ENABLED,
+            compliance_policy: crate::COMPLIANCE_POLICY.clone(),
+            cipher_suites: crate::tls::MESH_CIPHER_SUITES.clone(),
+        },
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,11 @@ pub mod xds;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;
 
+pub(crate) static COMPLIANCE_POLICY: Lazy<String> =
+    Lazy::new(|| env::var("COMPLIANCE_POLICY").unwrap_or_default());
+
 #[allow(dead_code)]
-static PQC_ENABLED: Lazy<bool> =
-    Lazy::new(|| env::var("COMPLIANCE_POLICY").unwrap_or_default() == "pqc");
+static PQC_ENABLED: Lazy<bool> = Lazy::new(|| COMPLIANCE_POLICY.as_str() == "pqc");
 
 #[allow(dead_code)]
 static TLS12_ENABLED: Lazy<bool> =

--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -107,6 +107,8 @@ macro_rules! impl_parse_cipher_suites {
                 tracing::warn!("all configured cipher suites were unrecognized ({names:?}), falling back to defaults");
                 None
             } else {
+                let applied: Vec<_> = suites.iter().map(|s| s.suite()).collect();
+                tracing::info!("MESH_CIPHER_SUITES: configured cipher suites: {applied:?}");
                 Some(suites)
             }
         }
@@ -400,6 +402,168 @@ pub mod tests {
         // Without ossl350 cfg, PQC cannot be enabled (would panic in provider())
         if *crate::PQC_ENABLED {
             panic!("PQC_ENABLED=true without ossl350 cfg - provider() will panic");
+        }
+    }
+
+    fn s(v: &str) -> String {
+        v.to_string()
+    }
+
+    fn suite_names(suites: &[rustls::SupportedCipherSuite]) -> Vec<rustls::CipherSuite> {
+        suites.iter().map(|s| s.suite()).collect()
+    }
+
+    #[cfg(any(feature = "tls-aws-lc", feature = "tls-ring", feature = "tls-openssl"))]
+    mod parse_cipher_suites_tests {
+        use super::*;
+        use rustls::CipherSuite;
+
+        fn parse(names: &[String]) -> Option<Vec<rustls::SupportedCipherSuite>> {
+            #[cfg(feature = "tls-aws-lc")]
+            return crate::tls::lib::parse_cipher_suites_aws_lc(names);
+            #[cfg(feature = "tls-ring")]
+            return crate::tls::lib::parse_cipher_suites_ring(names);
+            #[cfg(feature = "tls-openssl")]
+            return crate::tls::lib::parse_cipher_suites_openssl(names);
+        }
+
+        #[test]
+        fn empty_input_returns_none() {
+            assert!(parse(&[]).is_none());
+        }
+
+        #[test]
+        fn single_tls13_suite() {
+            let result = parse(&[s("TLS_AES_256_GCM_SHA384")]).unwrap();
+            assert_eq!(suite_names(&result), vec![CipherSuite::TLS13_AES_256_GCM_SHA384]);
+        }
+
+        #[test]
+        fn single_tls12_suite() {
+            let result = parse(&[s("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")]).unwrap();
+            assert_eq!(
+                suite_names(&result),
+                vec![CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384]
+            );
+        }
+
+        #[test]
+        fn multiple_valid_suites() {
+            let input = vec![
+                s("TLS_AES_256_GCM_SHA384"),
+                s("TLS_AES_128_GCM_SHA256"),
+                s("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+            ];
+            let result = parse(&input).unwrap();
+            assert_eq!(
+                suite_names(&result),
+                vec![
+                    CipherSuite::TLS13_AES_256_GCM_SHA384,
+                    CipherSuite::TLS13_AES_128_GCM_SHA256,
+                    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                ]
+            );
+        }
+
+        #[test]
+        fn all_unknown_returns_none() {
+            let input = vec![s("BOGUS_CIPHER"), s("ANOTHER_FAKE")];
+            assert!(parse(&input).is_none());
+        }
+
+        #[test]
+        fn mix_of_valid_and_unknown_keeps_valid() {
+            let input = vec![
+                s("TLS_AES_128_GCM_SHA256"),
+                s("BOGUS_CIPHER"),
+                s("TLS_CHACHA20_POLY1305_SHA256"),
+            ];
+            let result = parse(&input).unwrap();
+            assert_eq!(
+                suite_names(&result),
+                vec![
+                    CipherSuite::TLS13_AES_128_GCM_SHA256,
+                    CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+                ]
+            );
+        }
+
+        #[test]
+        fn all_nine_supported_suites() {
+            let input = vec![
+                s("TLS_AES_256_GCM_SHA384"),
+                s("TLS_AES_128_GCM_SHA256"),
+                s("TLS_CHACHA20_POLY1305_SHA256"),
+                s("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"),
+                s("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"),
+                s("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),
+                s("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+                s("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"),
+                s("TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"),
+            ];
+            let result = parse(&input).unwrap();
+            assert_eq!(result.len(), 9);
+        }
+
+        #[test]
+        fn preserves_input_order() {
+            let input = vec![
+                s("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+                s("TLS_AES_256_GCM_SHA384"),
+            ];
+            let result = parse(&input).unwrap();
+            assert_eq!(
+                suite_names(&result),
+                vec![
+                    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                    CipherSuite::TLS13_AES_256_GCM_SHA384,
+                ]
+            );
+        }
+    }
+
+    mod mesh_cipher_suites_env_parsing {
+        fn parse_env_value(val: &str) -> Vec<String> {
+            val.split(',')
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .collect()
+        }
+
+        #[test]
+        fn comma_separated() {
+            assert_eq!(
+                parse_env_value("TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256"),
+                vec!["TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256"]
+            );
+        }
+
+        #[test]
+        fn whitespace_trimmed() {
+            assert_eq!(
+                parse_env_value("  TLS_AES_256_GCM_SHA384 , TLS_AES_128_GCM_SHA256  "),
+                vec!["TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256"]
+            );
+        }
+
+        #[test]
+        fn empty_entries_filtered() {
+            assert_eq!(
+                parse_env_value("TLS_AES_256_GCM_SHA384,,, ,TLS_AES_128_GCM_SHA256"),
+                vec!["TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256"]
+            );
+        }
+
+        #[test]
+        fn empty_string_produces_empty_vec() {
+            let result: Vec<String> = parse_env_value("");
+            assert!(result.is_empty());
+        }
+
+        #[test]
+        fn only_commas_produces_empty_vec() {
+            let result: Vec<String> = parse_env_value(",,,");
+            assert!(result.is_empty());
         }
     }
 }

--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -19,6 +19,8 @@ use crate::PQC_ENABLED;
 use crate::TLS12_ENABLED;
 use crate::identity::{self, Identity};
 
+use once_cell::sync::Lazy;
+use std::env;
 use std::fmt::Debug;
 
 use std::sync::Arc;
@@ -28,6 +30,18 @@ use rustls::crypto::CryptoProvider;
 
 use rustls::ClientConfig;
 use rustls::ServerConfig;
+
+static MESH_CIPHER_SUITES: Lazy<Vec<String>> = Lazy::new(|| {
+    env::var("MESH_CIPHER_SUITES")
+        .ok()
+        .map(|s| {
+            s.split(',')
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+});
 
 #[async_trait::async_trait]
 pub trait ControlPlaneClientCertProvider: Send + Sync {
@@ -66,28 +80,71 @@ pub static CRYPTO_PROVIDER: &str = "tls-openssl";
 // One exception is CSR generation which doesn't currently have a plugin mechanism (https://github.com/rustls/rcgen/issues/228);
 // In that case, and any future ones, it is critical to guard the code with appropriate `cfg` guards.
 
+#[allow(unused_macros)]
+macro_rules! impl_parse_cipher_suites {
+    ($fn_name:ident, $provider_mod:path) => {
+        fn $fn_name(names: &[String]) -> Option<Vec<rustls::SupportedCipherSuite>> {
+            if names.is_empty() {
+                return None;
+            }
+            use $provider_mod as cs;
+            let mut suites = Vec::new();
+            for name in names {
+                match name.as_str() {
+                    "TLS_AES_256_GCM_SHA384" => suites.push(cs::TLS13_AES_256_GCM_SHA384),
+                    "TLS_AES_128_GCM_SHA256" => suites.push(cs::TLS13_AES_128_GCM_SHA256),
+                    "TLS_CHACHA20_POLY1305_SHA256" => suites.push(cs::TLS13_CHACHA20_POLY1305_SHA256),
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" => suites.push(cs::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384),
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" => suites.push(cs::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" => suites.push(cs::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384),
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" => suites.push(cs::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256),
+                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256" => suites.push(cs::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256),
+                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256" => suites.push(cs::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256),
+                    unknown => tracing::warn!("unknown cipher suite '{unknown}', ignoring"),
+                }
+            }
+            if suites.is_empty() {
+                tracing::warn!("all configured cipher suites were unrecognized ({names:?}), falling back to defaults");
+                None
+            } else {
+                Some(suites)
+            }
+        }
+    };
+}
+
 #[cfg(feature = "tls-boring")]
 pub(super) fn provider() -> Arc<CryptoProvider> {
     // Due to 'fips-only' feature on the boring provider, this will use only AES_256_GCM_SHA384
     // and AES_128_GCM_SHA256
+    if !MESH_CIPHER_SUITES.is_empty() {
+        tracing::warn!("MESH_CIPHER_SUITES ignored: BoringSSL FIPS uses fixed cipher suites");
+    }
     Arc::new(boring_rustls_provider::provider())
 }
 
 #[cfg(feature = "tls-ring")]
+impl_parse_cipher_suites!(parse_cipher_suites_ring, rustls::crypto::ring::cipher_suite);
+
+#[cfg(feature = "tls-ring")]
 pub(super) fn provider() -> Arc<CryptoProvider> {
-    let mut cipher_suites = vec![
-        rustls::crypto::ring::cipher_suite::TLS13_AES_256_GCM_SHA384,
-        rustls::crypto::ring::cipher_suite::TLS13_AES_128_GCM_SHA256,
-    ];
-    if *TLS12_ENABLED {
-        // Add TLS 1.2 FIPS-compatible cipher suites
-        cipher_suites.extend([
-            rustls::crypto::ring::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-            rustls::crypto::ring::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            rustls::crypto::ring::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            rustls::crypto::ring::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        ]);
-    }
+    let cipher_suites = if let Some(suites) = parse_cipher_suites_ring(&MESH_CIPHER_SUITES) {
+        suites
+    } else {
+        let mut suites = vec![
+            rustls::crypto::ring::cipher_suite::TLS13_AES_256_GCM_SHA384,
+            rustls::crypto::ring::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        ];
+        if *TLS12_ENABLED {
+            suites.extend([
+                rustls::crypto::ring::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                rustls::crypto::ring::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                rustls::crypto::ring::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                rustls::crypto::ring::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            ]);
+        }
+        suites
+    };
     Arc::new(CryptoProvider {
         cipher_suites,
         ..rustls::crypto::ring::default_provider()
@@ -95,20 +152,28 @@ pub(super) fn provider() -> Arc<CryptoProvider> {
 }
 
 #[cfg(feature = "tls-aws-lc")]
+impl_parse_cipher_suites!(parse_cipher_suites_aws_lc, rustls::crypto::aws_lc_rs::cipher_suite);
+
+#[cfg(feature = "tls-aws-lc")]
 pub(super) fn provider() -> Arc<CryptoProvider> {
-    let mut cipher_suites = vec![
-        rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
-        rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
-    ];
-    if *TLS12_ENABLED {
-        // Add TLS 1.2 FIPS-compatible cipher suites
-        cipher_suites.extend([
-            rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-            rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        ]);
-    }
+    let cipher_suites = if let Some(suites) = parse_cipher_suites_aws_lc(&MESH_CIPHER_SUITES) {
+        suites
+    } else {
+        let mut suites = vec![
+            rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
+            rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        ];
+        if *TLS12_ENABLED {
+            suites.extend([
+                rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            ]);
+        }
+        suites
+    };
+
     let mut provider = CryptoProvider {
         cipher_suites,
         ..rustls::crypto::aws_lc_rs::default_provider()
@@ -122,24 +187,29 @@ pub(super) fn provider() -> Arc<CryptoProvider> {
 }
 
 #[cfg(feature = "tls-openssl")]
+impl_parse_cipher_suites!(parse_cipher_suites_openssl, rustls_openssl::cipher_suite);
+
+#[cfg(feature = "tls-openssl")]
 pub(super) fn provider() -> Arc<CryptoProvider> {
-    let mut cipher_suites = vec![
-        rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
-        rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
-    ];
-    if *TLS12_ENABLED {
-        // Add TLS 1.2 FIPS-compatible cipher suites
-        cipher_suites.extend([
-            rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-            rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        ]);
-    }
+    let cipher_suites = if let Some(suites) = parse_cipher_suites_openssl(&MESH_CIPHER_SUITES) {
+        suites
+    } else {
+        let mut suites = vec![
+            rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
+            rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        ];
+        if *TLS12_ENABLED {
+            suites.extend([
+                rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            ]);
+        }
+        suites
+    };
 
     let kx_groups: Vec<&'static dyn rustls::crypto::SupportedKxGroup> = if *PQC_ENABLED {
-        // To use PQC with OpenSSL provider the binary needs to be
-        // both compiled and used with OpenSSL >= 3.5.0.
         #[cfg(ossl350)]
         {
             if openssl::version::number() >= 0x30500000 {

--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -94,12 +94,6 @@ macro_rules! impl_parse_cipher_suites {
                     "TLS_AES_256_GCM_SHA384" => suites.push(cs::TLS13_AES_256_GCM_SHA384),
                     "TLS_AES_128_GCM_SHA256" => suites.push(cs::TLS13_AES_128_GCM_SHA256),
                     "TLS_CHACHA20_POLY1305_SHA256" => suites.push(cs::TLS13_CHACHA20_POLY1305_SHA256),
-                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" => suites.push(cs::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384),
-                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" => suites.push(cs::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
-                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" => suites.push(cs::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384),
-                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" => suites.push(cs::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256),
-                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256" => suites.push(cs::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256),
-                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256" => suites.push(cs::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256),
                     unknown => tracing::warn!("unknown cipher suite '{unknown}', ignoring"),
                 }
             }
@@ -439,12 +433,8 @@ pub mod tests {
         }
 
         #[test]
-        fn single_tls12_suite() {
-            let result = parse(&[s("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")]).unwrap();
-            assert_eq!(
-                suite_names(&result),
-                vec![CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384]
-            );
+        fn tls12_suite_rejected_as_unknown() {
+            assert!(parse(&[s("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")]).is_none());
         }
 
         #[test]
@@ -452,7 +442,7 @@ pub mod tests {
             let input = vec![
                 s("TLS_AES_256_GCM_SHA384"),
                 s("TLS_AES_128_GCM_SHA256"),
-                s("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+                s("TLS_CHACHA20_POLY1305_SHA256"),
             ];
             let result = parse(&input).unwrap();
             assert_eq!(
@@ -460,7 +450,7 @@ pub mod tests {
                 vec![
                     CipherSuite::TLS13_AES_256_GCM_SHA384,
                     CipherSuite::TLS13_AES_128_GCM_SHA256,
-                    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                    CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
                 ]
             );
         }
@@ -489,33 +479,27 @@ pub mod tests {
         }
 
         #[test]
-        fn all_nine_supported_suites() {
+        fn all_three_supported_suites() {
             let input = vec![
                 s("TLS_AES_256_GCM_SHA384"),
                 s("TLS_AES_128_GCM_SHA256"),
                 s("TLS_CHACHA20_POLY1305_SHA256"),
-                s("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"),
-                s("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"),
-                s("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),
-                s("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
-                s("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"),
-                s("TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"),
             ];
             let result = parse(&input).unwrap();
-            assert_eq!(result.len(), 9);
+            assert_eq!(result.len(), 3);
         }
 
         #[test]
         fn preserves_input_order() {
             let input = vec![
-                s("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+                s("TLS_CHACHA20_POLY1305_SHA256"),
                 s("TLS_AES_256_GCM_SHA384"),
             ];
             let result = parse(&input).unwrap();
             assert_eq!(
                 suite_names(&result),
                 vec![
-                    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                    CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
                     CipherSuite::TLS13_AES_256_GCM_SHA384,
                 ]
             );

--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -31,7 +31,7 @@ use rustls::crypto::CryptoProvider;
 use rustls::ClientConfig;
 use rustls::ServerConfig;
 
-static MESH_CIPHER_SUITES: Lazy<Vec<String>> = Lazy::new(|| {
+pub static MESH_CIPHER_SUITES: Lazy<Vec<String>> = Lazy::new(|| {
     env::var("MESH_CIPHER_SUITES")
         .ok()
         .map(|s| {


### PR DESCRIPTION
Alternative implementation of https://docs.google.com/document/d/1mlxeZZAZnUxfEehiLSIvnuzDrj041-Ugn9zpffW6YTY.
Deprecates: https://github.com/istio/ztunnel/pull/1861, https://github.com/istio/istio/pull/60023.
Main objectives of implementing alternative implementation:
1) Envoy proxy does not have TLS13 ciphersuites configurable via xDS. When using default boringssl crypto provider they are not configurable at all, when using openssl provider they can be configured via openssl system config but still not via xDS. That means that implementing TLS13 configuration via xDS in ztunnel does not really close any feature parity gap.
2) no need to implement draining mechanism, as application of new ciphersuites requires rolling out new ztunnel.
3) this implementation is less complex and does not require change on Istio side, only in sail-operator, see example here: https://github.com/openshift-service-mesh/sail-operator/pull/910
4) we already use this (but openssl only) in our downstream fork so we know this works fine, see: https://github.com/openshift-service-mesh/ztunnel/pull/32.

What to consider:
1) when both TLS12_ENABLED=true and MESH_CIPHER_SUITES are set, the MESH_CIPHER_SUITES wins.
