### PR TITLE
Accept the trust domains the mesh tells us to

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ const INPOD_UDS: &str = "INPOD_UDS";
 const INPOD_PORT_REUSE: &str = "INPOD_PORT_REUSE";
 const CLUSTER_ID: &str = "CLUSTER_ID";
 const CLUSTER_DOMAIN: &str = "CLUSTER_DOMAIN";
+const TRUST_DOMAINS: &str = "TRUST_DOMAINS";
 const LOCAL_XDS_PATH: &str = "LOCAL_XDS_PATH";
 const LOCAL_XDS: &str = "LOCAL_XDS";
 const XDS_ON_DEMAND: &str = "XDS_ON_DEMAND";
@@ -241,6 +242,8 @@ pub struct Config {
     pub illegal_ports: HashSet<u16>,
     /// The network of the node this ztunnel is running on.
     pub network: Strng,
+    /// Trust domains accepted on inbound connections in addition to our own.
+    pub trust_domains: Arc<Vec<Strng>>,
     /// The name of the node this ztunnel is running as.
     pub local_node: Option<String>,
     /// The proxy mode of ztunnel, Shared or Dedicated, default to Shared.
@@ -851,6 +854,14 @@ pub fn construct_config(pc: ProxyConfig) -> Result<Config, Error> {
         illegal_ports,
 
         network: parse(NETWORK)?.unwrap_or_default(),
+        trust_domains: Arc::new(
+            parse::<String>(TRUST_DOMAINS)?
+                .iter()
+                .flat_map(|domains| domains.split(','))
+                .map(|domain| domain.trim().into())
+                .filter(|domain: &Strng| !domain.is_empty())
+                .collect(),
+        ),
         local_node: parse(NODE_NAME)?,
         proxy_mode,
         proxy_workload_information,

--- a/src/proxy/inbound.rs
+++ b/src/proxy/inbound.rs
@@ -91,6 +91,7 @@ impl Inbound {
         let acceptor = InboundCertProvider {
             local_workload: self.pi.local_workload_information.clone(),
             crl_manager: self.pi.crl_manager.clone(),
+            trust_domains: self.pi.cfg.trust_domains.clone(),
         };
 
         // Safety: we set nodelay directly in tls_server, so it is safe to convert to a normal listener.
@@ -761,6 +762,7 @@ impl InboundFlagError {
 struct InboundCertProvider {
     local_workload: Arc<LocalWorkloadInformation>,
     crl_manager: Option<Arc<tls::crl::CrlManager>>,
+    trust_domains: Arc<Vec<Strng>>,
 }
 
 #[async_trait::async_trait]
@@ -771,7 +773,10 @@ impl crate::tls::ServerCertProvider for InboundCertProvider {
             "fetching cert"
         );
         let cert = self.local_workload.fetch_certificate().await?;
-        Ok(Arc::new(cert.server_config(self.crl_manager.clone())?))
+        Ok(Arc::new(cert.server_config(
+            &self.trust_domains,
+            self.crl_manager.clone(),
+        )?))
     }
 }
 

--- a/src/tls/certificate.rs
+++ b/src/tls/certificate.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::identity::Identity;
+use crate::strng::Strng;
 use crate::tls::{Error, IdentityVerifier, OutboundConnector};
 use base64::engine::general_purpose::STANDARD;
 use bytes::Bytes;
@@ -315,11 +316,23 @@ impl WorkloadCertificate {
 
     pub fn server_config(
         &self,
+        trust_domains: &[Strng],
         crl_manager: Option<Arc<crate::tls::crl::CrlManager>>,
     ) -> Result<ServerConfig, Error> {
-        let td = self.cert.identity().map(|i| match i {
-            Identity::Spiffe { trust_domain, .. } => trust_domain,
-        });
+        // Accept the trust domain our own certificate is in, plus any the mesh tells us about.
+        let trust_domains = match self.cert.identity() {
+            Some(Identity::Spiffe { trust_domain, .. }) => {
+                let mut accepted = vec![trust_domain];
+                for td in trust_domains {
+                    if !accepted.contains(td) {
+                        accepted.push(td.clone());
+                    }
+                }
+                accepted
+            }
+            // Without an identity of our own there is nothing to compare a peer against.
+            None => Vec::new(),
+        };
 
         // build the base client cert verifier with optional CRL support
         let mut builder = WebPkiClientVerifier::builder_with_provider(
@@ -341,7 +354,7 @@ impl WorkloadCertificate {
         let raw_client_cert_verifier = builder.build()?;
 
         let client_cert_verifier =
-            crate::tls::workload::TrustDomainVerifier::new(raw_client_cert_verifier, td);
+            crate::tls::workload::TrustDomainVerifier::new(raw_client_cert_verifier, trust_domains);
         let mut sc = ServerConfig::builder_with_provider(crate::tls::lib::provider())
             .with_protocol_versions(tls::tls_versions())
             .expect("server config must be valid")
@@ -447,6 +460,7 @@ fn der_to_pem(der: &[u8], label: &str) -> String {
 #[cfg(test)]
 mod test {
     use crate::identity::Identity;
+    use crate::strng::Strng;
     use crate::test_helpers::helpers;
     use crate::tls::mock::{
         TEST_ROOT, TEST_ROOT_KEY, TEST_ROOT2, TEST_ROOT2_KEY, TestIdentity, crl_pem_revoking_cert,
@@ -498,7 +512,7 @@ mod test {
             WorkloadCertificate::new(key.as_bytes(), cert.as_bytes(), vec![&joined]).unwrap();
 
         // Do a simple handshake between them; we should be able to accept the trusted root
-        let server = cert1.server_config(None).unwrap();
+        let server = cert1.server_config(&[], None).unwrap();
         let tls = TlsAcceptor::from(Arc::new(server));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -572,7 +586,7 @@ mod test {
         );
 
         // Create TLS server to listen for incoming connections
-        let server_tls = TlsAcceptor::from(Arc::new(server_wl.server_config(None).unwrap()));
+        let server_tls = TlsAcceptor::from(Arc::new(server_wl.server_config(&[], None).unwrap()));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::task::spawn(async move {
@@ -648,7 +662,7 @@ mod test {
             .unwrap(),
         );
 
-        let server_tls = TlsAcceptor::from(Arc::new(server_wl.server_config(None).unwrap()));
+        let server_tls = TlsAcceptor::from(Arc::new(server_wl.server_config(&[], None).unwrap()));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::task::spawn(async move {
@@ -665,5 +679,56 @@ mod test {
             .await
             .expect_err("connection should fail: intermediate cert is revoked");
         assert!(io_error_is_cert_revoked(&err));
+    }
+
+    #[tokio::test]
+    async fn configured_trust_domains() {
+        helpers::initialize_telemetry();
+        let server_id = Identity::from_str("spiffe://td/ns/n/sa/a").unwrap();
+        let client_id = Identity::from_str("spiffe://other-td/ns/n/sa/b").unwrap();
+
+        let certs = |id: &Identity| {
+            let (key, cert) = crate::tls::mock::generate_test_certs_with_root(
+                &TestIdentity::Identity(id.clone()),
+                SystemTime::now(),
+                SystemTime::now() + Duration::from_secs(60),
+                None,
+                TEST_ROOT_KEY,
+            );
+            WorkloadCertificate::new(key.as_bytes(), cert.as_bytes(), vec![TEST_ROOT]).unwrap()
+        };
+        let server_cert = certs(&server_id);
+        let client_cert = certs(&client_id);
+
+        // A client from another trust domain is rejected unless we are told to accept it.
+        for (trust_domains, want_ok) in [
+            (vec![], false),
+            (vec![Strng::from("unrelated-td")], false),
+            (vec![Strng::from("other-td")], true),
+        ] {
+            let server = server_cert.server_config(&trust_domains, None).unwrap();
+            let tls = TlsAcceptor::from(Arc::new(server));
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::task::spawn(async move {
+                let (stream, _) = listener.accept().await.unwrap();
+                if let Ok(mut tls) = tls.accept(stream).await {
+                    let _ = tls.write(b"serv").await;
+                }
+            });
+
+            let stream = TcpStream::connect(addr).await.unwrap();
+            let client = client_cert
+                .outbound_connector(vec![server_id.clone()], None)
+                .unwrap();
+            let got_ok = match client.connect(stream).await {
+                Ok(mut tls) => {
+                    let mut buf = [0u8; 4];
+                    tls.write(b"hi").await.is_ok() && tls.read_exact(&mut buf).await.is_ok()
+                }
+                Err(_) => false,
+            };
+            assert_eq!(got_ok, want_ok, "trust domains {trust_domains:?}");
+        }
     }
 }

--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -18,6 +18,7 @@ use super::Error;
 use crate::PQC_ENABLED;
 use crate::TLS12_ENABLED;
 use crate::identity::{self, Identity};
+use crate::strng::Strng;
 
 use std::fmt::Debug;
 
@@ -202,10 +203,10 @@ pub enum TlsError {
     SanError(Vec<Identity>, Vec<Identity>),
     #[error(
         "identity verification error: peer did not present the expected trustdomain ({}), got {}",
-        .0,
+        display_list(.0),
         display_list(.1)
     )]
-    SanTrustDomainError(String, Vec<Identity>),
+    SanTrustDomainError(Vec<Strng>, Vec<Identity>),
     #[error("ssl error: {0}")]
     SslError(#[from] Error),
 }

--- a/src/tls/revocation.rs
+++ b/src/tls/revocation.rs
@@ -1051,7 +1051,7 @@ mod tests {
         let (mut crl_file, crl_mgr) = crl_manager_empty();
 
         let server_tls = TlsAcceptor::from(Arc::new(
-            server_wl.server_config(Some(crl_mgr.clone())).unwrap(),
+            server_wl.server_config(&[], Some(crl_mgr.clone())).unwrap(),
         ));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1215,7 +1215,7 @@ mod tests {
         let (mut crl_file, crl_mgr) = crl_manager_empty();
 
         let server_tls = TlsAcceptor::from(Arc::new(
-            server_wl.server_config(Some(crl_mgr.clone())).unwrap(),
+            server_wl.server_config(&[], Some(crl_mgr.clone())).unwrap(),
         ));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/src/tls/workload.rs
+++ b/src/tls/workload.rs
@@ -54,20 +54,23 @@ impl<F: ServerCertProvider> InboundAcceptor<F> {
 #[derive(Debug)]
 pub(super) struct TrustDomainVerifier {
     base: Arc<dyn ClientCertVerifier>,
-    trust_domain: Option<Strng>,
+    trust_domains: Vec<Strng>,
 }
 
 impl TrustDomainVerifier {
-    pub fn new(base: Arc<dyn ClientCertVerifier>, trust_domain: Option<Strng>) -> Arc<Self> {
-        Arc::new(Self { base, trust_domain })
+    pub fn new(base: Arc<dyn ClientCertVerifier>, trust_domains: Vec<Strng>) -> Arc<Self> {
+        Arc::new(Self {
+            base,
+            trust_domains,
+        })
     }
 
     fn verify_trust_domain(&self, client_cert: &CertificateDer<'_>) -> Result<(), rustls::Error> {
         use x509_parser::prelude::*;
-        let Some(want_trust_domain) = &self.trust_domain else {
+        if self.trust_domains.is_empty() {
             // No need to verify
             return Ok(());
-        };
+        }
         let (_, c) = X509Certificate::from_der(client_cert).map_err(|_e| {
             rustls::Error::InvalidCertificate(rustls::CertificateError::BadEncoding)
         })?;
@@ -77,17 +80,17 @@ impl TrustDomainVerifier {
             )
         })?;
         trace!(
-            "verifying client identities {ids:?} against trust domain {:?}",
-            want_trust_domain
+            "verifying client identities {ids:?} against trust domains {:?}",
+            self.trust_domains
         );
         ids.iter()
             .find(|id| match id {
-                Identity::Spiffe { trust_domain, .. } => trust_domain == want_trust_domain,
+                Identity::Spiffe { trust_domain, .. } => self.trust_domains.contains(trust_domain),
             })
             .ok_or_else(|| {
                 rustls::Error::InvalidCertificate(rustls::CertificateError::Other(
                     rustls::OtherError(Arc::new(TlsError::SanTrustDomainError(
-                        want_trust_domain.to_string(),
+                        self.trust_domains.clone(),
                         ids.clone(),
                     ))),
                 ))


### PR DESCRIPTION
ztunnel accepts an inbound connection only from the trust domain its own
certificate is in. The mesh has two settings that say a peer in another trust
domain should be accepted, and both are ignored:

- `meshConfig.trustDomainAliases`
- `meshConfig.caCertificates[].trustDomains`

`TrustDomainsForValidation` in istio/istio builds the accepted set from the mesh
trust domain, its aliases and every configured CA certificate's trust domains,
and sidecars, waypoints and gateways all validate against it. ztunnel has no
equivalent, so a workload that worked with a sidecar starts failing when its
namespace is moved to ambient:

```
src.addr=10.20.0.20:50980 dst.addr=10.20.0.10:15008 direction="inbound"
error="tls handshake error: Custom { kind: InvalidData, error: InvalidCertificate(
  Other(OtherError(SanTrustDomainError("domain2.local",
  [Spiffe { trust_domain: "domain1.local", namespace: "sample", service_account: "curl" }]
))))}"
```

This is the blocker for ambient across clusters that use different trust domains
but chain to a shared root — see istio/istio#61608 (continues #58427).

### What this does

Reads `TRUST_DOMAINS` (comma separated) and accepts those alongside the trust
domain our own certificate is in. With none configured the accepted set is just
ours, exactly as before, and the behaviour is unchanged. Where we cannot
determine our own trust domain the trust domain is still not verified at all,
also as before.

`TrustDomainVerifier` goes from `Option<Strng>` to a list; an empty list keeps
the existing "nothing to check" path.

`TRUST_DOMAINS` is set by the ztunnel chart in
**istio/istio#61610**, which renders `trustDomainAliases` and
`caCertificates[].trustDomains` onto the DaemonSet. That PR is inert without this
one and this one is inert without it, so they can merge in either order.

### Note on `Arc<Vec<Strng>>`

The accepted set is held behind an `Arc`. `InboundCertProvider` is cloned per
connection and is measured by `assertions::size_between_ref(1000, 1650, ..)` in
`Inbound::run`; carrying the `Vec` inline pushed that future to 1664 and tripped
the assertion. An `Arc` keeps it in range and avoids copying the list per
connection, which seemed better than raising the bound.

### Testing

`configured_trust_domains` in `src/tls/certificate.rs` does a real handshake
between two workloads in different trust domains and checks all three cases:

| `TRUST_DOMAINS` | result |
| --- | --- |
| empty | rejected |
| an unrelated trust domain | rejected |
| the client's trust domain | accepted |

Full suite green in the build container: 254 lib + 20 `direct` + 30 `namespaced`,
0 failures.

Verified end to end on two kind clusters (Kubernetes 1.36.1) with separate trust
domains (`domain1.local` / `domain2.local`) chaining to one shared root, over an
ambient east-west gateway:

| destination accepts the caller via | dest path | result |
| --- | --- | --- |
| `trustDomainAliases` | L4 | HTTP 200 |
| `trustDomainAliases` | waypoint | HTTP 200 |
| `caCertificates[].trustDomains` | L4 | HTTP 200 |
| `caCertificates[].trustDomains` | waypoint | HTTP 200 |

A control run with both clusters on a single shared trust domain and neither
setting configured also passes, with `TRUST_DOMAINS` absent from the DaemonSet —
the existing single-trust-domain path is untouched.
